### PR TITLE
Add Send constraint to CompressionCodec

### DIFF
--- a/chd-rs/src/compression/mod.rs
+++ b/chd-rs/src/compression/mod.rs
@@ -28,7 +28,7 @@ pub mod codecs {
 
 // unstable(trait_alias)
 /// Marker trait for a codec that can be used to decompress a compressed hunk.
-pub trait CompressionCodec: CodecImplementation + CompressionCodecType {}
+pub trait CompressionCodec: CodecImplementation + CompressionCodecType + Send {}
 
 /// Trait for a codec that implements a known CHD codec type.
 pub trait CompressionCodecType {


### PR DESCRIPTION
I've been replacing my own libchdr Rust bindings with this crate (thanks for this project btw!), but I ran into a problem where I couldn't send a `ChdFile` across threads. This occurs as `dyn CompressionCodec` doesn't satisfy `Send` automatically.
I think it would be reasonable to require `Send` from any codec implementations, so I think placing this constraint here should be fine.