### PR TITLE
Some zstd optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
  "ruzstd",
  "take_mut",
  "text_io",
- "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -1176,15 +1176,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
-
-[[package]]
-name = "zstd"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
-dependencies = [
- "zstd-safe",
-]
 
 [[package]]
 name = "zstd-safe"

--- a/chd-rs/Cargo.toml
+++ b/chd-rs/Cargo.toml
@@ -31,7 +31,7 @@ want_raw_data_sector = []
 max_perf = ["fast_zlib", "fast_lzma", "fast_zstd"]
 fast_zlib = ["std", "flate2/zlib-ng"]
 fast_lzma = ["std"]
-fast_zstd = ["std", "zstd"]
+fast_zstd = ["std", "zstd-safe"]
 
 [dependencies]
 byteorder = "1"
@@ -49,7 +49,7 @@ claxon = "0.4"
 bitreader = "0.3.6"
 ruzstd = "0.5"
 
-zstd = { version = "0.13.0", optional = true }
+zstd-safe = { version = "7.0.0", optional = true }
 # lending-iterator
 lending-iterator = { version = "0.1", optional = true }
 nougat = { version = "0.2", optional = true }

--- a/chd-rs/benches/bench.rs
+++ b/chd-rs/benches/bench.rs
@@ -1,7 +1,5 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
-use chd::read::HunkBufReader;
 use chd::Chd;
-use std::env::args;
 use std::fs::File;
 use std::io::BufReader;
 
@@ -18,13 +16,14 @@ fn read_hunks_unbuf_bench(bench: &mut Bencher) {
         // for hunk_num in 13478..hunk_count {
         let mut cmp_buf = Vec::new();
         let mut bytes = 0;
+        let now = std::time::Instant::now();
         for hunk_num in 0..hunk_count {
             let mut hunk = chd.hunk(hunk_num).expect("could not acquire hunk");
             bytes += hunk
                 .read_hunk_in(&mut cmp_buf, &mut hunk_buf)
                 .expect(format!("could not read_hunk {}", hunk_num).as_str());
         }
-        println!("total: {}", bytes);
+        println!("total: {}, {:?}", bytes, now.elapsed());
     });
 }
 

--- a/chd-rs/src/compression/zstd.rs
+++ b/chd-rs/src/compression/zstd.rs
@@ -29,7 +29,7 @@ pub struct ZstdCodec {
 /// when decompressed.
 #[cfg(feature = "fast_zstd")]
 pub struct ZstdCodec {
-    zstd_context: zstd::zstd_safe::DCtx<'static>
+    zstd_context: zstd_safe::DCtx<'static>
 }
 
 #[cfg(not(feature = "fast_zstd"))]
@@ -71,7 +71,7 @@ impl CodecImplementation for ZstdCodec {
         Self: Sized,
     {
         Ok(Self {
-            zstd_context: zstd::zstd_safe::DCtx::try_create().ok_or(crate::Error::CodecError)?
+            zstd_context: zstd_safe::DCtx::try_create().ok_or(crate::Error::CodecError)?
         })
     }
 

--- a/chd-rs/src/lib.rs
+++ b/chd-rs/src/lib.rs
@@ -220,12 +220,12 @@ mod tests {
 
     #[test]
     fn read_parent_test() {
-        let mut p = BufReader::new(File::open(".testimages/TombRaider.chd").expect(""));
+        let p = BufReader::new(File::open(".testimages/TombRaider.chd").expect(""));
         let pchd = Chd::open(p, None).expect("parent");
 
-        let mut f = BufReader::new(File::open(".testimages/TombRaiderR1.chd").expect(""));
+        let f = BufReader::new(File::open(".testimages/TombRaiderR1.chd").expect(""));
 
-        let chd = Chd::open(f, Some(Box::new(pchd))).expect("child");
+        let _chd = Chd::open(f, Some(Box::new(pchd))).expect("child");
     }
 
     #[test]

--- a/rchdman/src/main.rs
+++ b/rchdman/src/main.rs
@@ -172,6 +172,8 @@ fn info(input: &PathBuf, verbose: bool) -> anyhow::Result<()> {
             CodecType::LzmaV5 => "LZMA",
             CodecType::AVHuffV5 => "A/V Huffman",
             CodecType::HuffV5 => "Huffman",
+            CodecType::ZstdV5 => "Zstandard",
+            CodecType::ZstdCdV5 => "CD Zstandard",
         }
     }
 
@@ -190,6 +192,8 @@ fn info(input: &PathBuf, verbose: bool) -> anyhow::Result<()> {
                 CodecType::LzmaV5 => "lzma (LZMA)",
                 CodecType::AVHuffV5 => "avhu (A/V Huffman)",
                 CodecType::HuffV5 => "huff (Huffman)",
+                CodecType::ZstdV5 => "zstd (Zstandard)",
+                CodecType::ZstdCdV5 => "cdzs (CD Zstandard)",
             }
         }
 


### PR DESCRIPTION
I looked at the code because I wanted to check why `Chd` wasn't `Send` anymore, saw some potential for optimizations and figured "might as well." 🙂

Saves a copy for both fast_zstd and non-fast_zstd, also saves an allocation for fast_zstd (`zstd::stream::read::Decoder::new()` called `BufReader::with_capacity()`).
Seems to be ~3% faster for non-fast_zstd and ~10% faster for fast_zstd when I test it with a Silent Hill CHD on my machine.

I also added a couple of fixes to warnings and stuff, feel free to cherry-pick what you wanna keep.
I'll submit another PR for re-adding `Send`.