### PR TITLE
Re-add Send to CompressionCodec constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
  "nougat",
  "num-derive",
  "num-traits",
- "ruzstd",
+ "ruzstd 0.6.0",
  "take_mut",
  "text_io",
  "zstd-safe",
@@ -191,7 +191,7 @@ dependencies = [
  "lzma-rs-perf-exp",
  "num-derive",
  "num-traits",
- "ruzstd",
+ "ruzstd 0.5.0",
  "take_mut",
  "text_io",
 ]
@@ -825,6 +825,17 @@ name = "ruzstd"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
+dependencies = [
+ "byteorder",
+ "derive_more",
+ "twox-hash",
+]
+
+[[package]]
+name = "ruzstd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
  "derive_more",

--- a/chd-rs/Cargo.toml
+++ b/chd-rs/Cargo.toml
@@ -47,7 +47,7 @@ flate2 = { version = "1", default-features = false, features = ["rust_backend"] 
 lzma-rs = { package = "lzma-rs-perf-exp", version = "0.2", features = ["raw_decoder"] }
 claxon = "0.4"
 bitreader = "0.3.6"
-ruzstd = "0.5"
+ruzstd = "0.6"
 
 zstd-safe = { version = "7.0.0", optional = true }
 # lending-iterator

--- a/chd-rs/src/compression/mod.rs
+++ b/chd-rs/src/compression/mod.rs
@@ -28,7 +28,7 @@ pub mod codecs {
 
 // unstable(trait_alias)
 /// Marker trait for a codec that can be used to decompress a compressed hunk.
-pub trait CompressionCodec: CodecImplementation + CompressionCodecType {}
+pub trait CompressionCodec: CodecImplementation + CompressionCodecType + Send {}
 
 /// Trait for a codec that implements a known CHD codec type.
 pub trait CompressionCodecType {


### PR DESCRIPTION
The `Send + Sync` constraints got removed when zstd support was added, probably because the[ FrameDecoder in ruzstd 0.5.0 was !Send + !Sync](https://docs.rs/ruzstd/0.5.0/ruzstd/frame_decoder/struct.FrameDecoder.html#impl-Send-for-FrameDecoder).

I created an issue over there (https://github.com/KillingSpark/zstd-rs/issues/56) and this was changed in 0.6.0, it's now both Send + Sync.

However, `zstd_safe::DCtx` [is explicitly `!Sync`](https://docs.rs/zstd-safe/7.0.0/src/zstd_safe/lib.rs.html#1220) (though I'm not 100% sure why), so re-adding Sync wouldn't work with the `fast_zstd` feature currently.

I don't personally need it, but if you *do* want to also re-add `Sync`, you could remove the `zstd_context` member on `ZstdCodec` again and recreate the context on each `decompress()` call, I haven't noticed much difference in performance there.