### PR TITLE
build: Fix compilation errors with chd_core_file

### DIFF
--- a/chd-rs-capi/src/chdcorefile.rs
+++ b/chd-rs-capi/src/chdcorefile.rs
@@ -63,6 +63,6 @@ mod tests {
 
 impl Drop for CoreFile {
     fn drop(&mut self) {
-        unsafe { core_fclose(self.0) }
+        unsafe { core_fclose(self.file) }
     }
 }

--- a/chd-rs-capi/src/lib.rs
+++ b/chd-rs-capi/src/lib.rs
@@ -394,7 +394,7 @@ pub unsafe extern "C" fn chd_core_file(chd: *mut chd_file) -> *mut chdcorefile_s
 
     let pointer = match file_ref.downcast_ref::<crate::chdcorefile::CoreFile>() {
         None => std::ptr::null_mut(),
-        Some(file) => file.0,
+        Some(file) => file.file,
     };
     std::mem::forget(file);
     pointer
@@ -431,7 +431,7 @@ pub unsafe extern "C" fn chd_open_file(
         Some(ffi_takeown_chd(parent))
     };
 
-    let core_file = Box::new(crate::chdcorefile::CoreFile(file)) as Box<dyn SeekRead>;
+    let core_file = Box::new(crate::chdcorefile::CoreFile { file: file }) as Box<dyn SeekRead>;
     let chd = match Chd::open(core_file, parent) {
         Ok(chd) => chd,
         Err(e) => return e,


### PR DESCRIPTION
Building with `chd_core_file` hit these errors on the latest stable and nightly Rust:

```rust
error[E0423]: expected function, tuple struct or tuple variant, found struct `crate::chdcorefile::CoreFile`
   --> chd-rs-capi/src/lib.rs:434:30
    |
434 |       let core_file = Box::new(crate::chdcorefile::CoreFile(file)) as Box<dyn SeekRead>;
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `crate::chdcorefile::CoreFile { file: val }`
    |
   ::: chd-rs-capi/src/chdcorefile.rs:7:1
    |
7   | / pub struct CoreFile {
8   | |     pub(crate) file: *mut core_file,
9   | | }
    | |_- `crate::chdcorefile::CoreFile` defined here

error[E0609]: no field `0` on type `&mut CoreFile`
  --> chd-rs-capi/src/chdcorefile.rs:66:35
   |
66 |         unsafe { core_fclose(self.0) }
   |                                   ^ unknown field
   |
   = note: available field is: `file`

error[E0609]: no field `0` on type `&CoreFile`
   --> chd-rs-capi/src/lib.rs:397:28
    |
397 |         Some(file) => file.0,
    |                            ^ unknown field
    |
    = note: available field is: `file`

Some errors have detailed explanations: E0423, E0609.
For more information about an error, try `rustc --explain E0423`.
error: could not compile `chd-capi` (lib) due to 3 previous errors
```

These fixes look OK? Though I am not Rust-proficient. I did build chd-rs with chd_core_file with these changes and verified that it works in a downstream application.