### PR TITLE
zstd: fix incorrect usage of ruzstd FrameDecoder

### DIFF
--- a/chd-rs/src/compression/zstd.rs
+++ b/chd-rs/src/compression/zstd.rs
@@ -48,10 +48,6 @@ impl CodecImplementation for ZstdCodec {
         mut input: &[u8],
         output: &mut [u8],
     ) -> crate::Result<DecompressResult> {
-        self.decoder
-            .reset(&mut input)
-            .map_err(|_| Error::DecompressionError)?;
-
         let bytes_out = self
             .decoder
             .decode_all(&mut input, output)


### PR DESCRIPTION
`FrameDecoder::decode_all()` calls `FrameDecoder::reset()` internally, so explicitly calling `reset()` before `decode_all()` causes decompression errors due to trying to read the frame header twice.

For me, chd-rs is unable to decompress hunks from CHD CD-ROM images that use `cdzs` compression (CD zstd) without this change, unless the `fast_zstd` feature is enabled (which bypasses this code path).