### PR TITLE
Danifunker chdman parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Build + test on all three desktop platforms. The default (read-only) build uses only
-  # crates.io deps; the `write`/`write-zstd` encode features depend on the sibling bit-exact
-  # codec crates via path deps (`../../<crate>`), so we clone them next to this checkout first.
+  # Build + test on all three desktop platforms. All deps (including the `write`/`write-zstd`
+  # encode features' bit-exact sibling codec crates) resolve from crates.io — no local checkout.
   test:
     strategy:
       fail-fast: false
@@ -24,29 +23,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
-      # The write feature's optional deps are local path deps on the sibling crates. Cargo reads
-      # every dependency manifest during resolution (even optional ones behind disabled features),
-      # so they must exist on disk for *any* build. They live one level above the repo root
-      # (`../../<crate>` from chd-rs/chd-rs == <parent-of-workspace>/<crate>), so clone them into
-      # the parent of the checkout, pinned to the tags this repo was developed against.
-      # (When the codec crates stabilise on crates.io, switch these to version deps and drop this.)
-      - name: Clone sibling codec crates
-        shell: bash
-        run: |
-          cd "${GITHUB_WORKSPACE}/.."
-          git clone --depth 1 --branch v0.2301.0 https://github.com/danifunker/lzma-sdk-rs.git
-          git clone --depth 1 --branch v0.143.0  https://github.com/danifunker/libflac-rs.git
-          git clone --depth 1 --branch v0.131.0  https://github.com/danifunker/zlib-bitexact-rs.git
-          git clone --depth 1 --branch v0.155.0  https://github.com/danifunker/libzstd-bitexact-rs.git
-
       # Read-only (default) build — the core product, no encode code. Scoped to the `chd` package
       # (the workspace also has rchdman + a C-backed capi crate that CI doesn't cover).
       - run: cargo build -p chd
 
-      # Encode side: build + run the unit tests (codec round-trips, hd/dvd/copy, codec module,
-      # doctests). The `chdman_compat` byte-identity tests need a real chdman binary and are gated
-      # behind `chdman_compat_tests` (not enabled here). The `read_*` tests need large CHD fixtures
-      # that aren't in the repo (.testimages/ is gitignored), so skip them.
+      # Encode side: build + run the unit tests (codec round-trips, hd/cd/dvd/copy, parent/diff,
+      # verify, codec module, doctests). The `chdman_compat` byte-identity tests need a real chdman
+      # binary and are gated behind `chdman_compat_tests` (not enabled here). The `read_*` tests
+      # need large CHD fixtures that aren't in the repo (.testimages/ is gitignored), so skip them.
       - run: cargo test -p chd --features write-zstd -- --skip tests::read
 
   # Formatting gate. (clippy is intentionally not `-D warnings` yet — the legacy read-side code
@@ -58,14 +42,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      # `cargo fmt -p chd` runs `cargo metadata`, which resolves the workspace — including the
-      # write feature's sibling path deps — so they must be present even for a formatting check.
-      - name: Clone sibling codec crates
-        shell: bash
-        run: |
-          cd "${GITHUB_WORKSPACE}/.."
-          git clone --depth 1 --branch v0.2301.0 https://github.com/danifunker/lzma-sdk-rs.git
-          git clone --depth 1 --branch v0.143.0  https://github.com/danifunker/libflac-rs.git
-          git clone --depth 1 --branch v0.131.0  https://github.com/danifunker/zlib-bitexact-rs.git
-          git clone --depth 1 --branch v0.155.0  https://github.com/danifunker/libzstd-bitexact-rs.git
       - run: cargo fmt -p chd --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+# Runs on every branch and pull request.
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Build + test on all three desktop platforms. The default (read-only) build uses only
+  # crates.io deps; the `write`/`write-zstd` encode features depend on the sibling bit-exact
+  # codec crates via path deps (`../../<crate>`), so we clone them next to this checkout first.
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      # The write feature's optional deps are local path deps on the sibling crates. Cargo reads
+      # every dependency manifest during resolution (even optional ones behind disabled features),
+      # so they must exist on disk for *any* build. They live one level above the repo root
+      # (`../../<crate>` from chd-rs/chd-rs == <parent-of-workspace>/<crate>), so clone them into
+      # the parent of the checkout, pinned to the tags this repo was developed against.
+      # (When the codec crates stabilise on crates.io, switch these to version deps and drop this.)
+      - name: Clone sibling codec crates
+        shell: bash
+        run: |
+          cd "${GITHUB_WORKSPACE}/.."
+          git clone --depth 1 --branch v0.2301.0 https://github.com/danifunker/lzma-sdk-rs.git
+          git clone --depth 1 --branch v0.143.0  https://github.com/danifunker/libflac-rs.git
+          git clone --depth 1 --branch v0.131.0  https://github.com/danifunker/zlib-bitexact-rs.git
+          git clone --depth 1 --branch v0.155.0  https://github.com/danifunker/libzstd-bitexact-rs.git
+
+      # Read-only (default) build — the core product, no encode code. Scoped to the `chd` package
+      # (the workspace also has rchdman + a C-backed capi crate that CI doesn't cover).
+      - run: cargo build -p chd
+
+      # Encode side: build + run the unit tests (codec round-trips, hd/dvd/copy, codec module,
+      # doctests). The `chdman_compat` byte-identity tests need a real chdman binary and are gated
+      # behind `chdman_compat_tests` (not enabled here). The `read_*` tests need large CHD fixtures
+      # that aren't in the repo (.testimages/ is gitignored), so skip them.
+      - run: cargo test -p chd --features write-zstd -- --skip tests::read
+
+  # Formatting gate. (clippy is intentionally not `-D warnings` yet — the legacy read-side code
+  # carries pre-existing lints; a dedicated cleanup pass can tighten this later.)
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt -p chd --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      # `cargo fmt -p chd` runs `cargo metadata`, which resolves the workspace — including the
+      # write feature's sibling path deps — so they must be present even for a formatting check.
+      - name: Clone sibling codec crates
+        shell: bash
+        run: |
+          cd "${GITHUB_WORKSPACE}/.."
+          git clone --depth 1 --branch v0.2301.0 https://github.com/danifunker/lzma-sdk-rs.git
+          git clone --depth 1 --branch v0.143.0  https://github.com/danifunker/libflac-rs.git
+          git clone --depth 1 --branch v0.131.0  https://github.com/danifunker/zlib-bitexact-rs.git
+          git clone --depth 1 --branch v0.155.0  https://github.com/danifunker/libzstd-bitexact-rs.git
       - run: cargo fmt -p chd --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,8 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 [[package]]
 name = "libflac-rs"
 version = "0.143.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2c99ea31135c0fbe89c4250975be550ef0d6d8c30eeb63468476f6526f1d726"
 dependencies = [
  "cc",
 ]
@@ -555,6 +557,8 @@ dependencies = [
 [[package]]
 name = "libzstd-bitexact-rs"
 version = "0.155.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdbf9f739e6df84ee3f90704d7f447819e355b090b4dc845e521e3e9f1f7259"
 
 [[package]]
 name = "linux-raw-sys"
@@ -581,6 +585,8 @@ dependencies = [
 [[package]]
 name = "lzma-sdk-rs"
 version = "0.2301.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc9569e7ea9498c0314a5733935f246f324b615a1145ced6665b98d9d7de673"
 dependencies = [
  "cc",
 ]
@@ -1124,6 +1130,8 @@ dependencies = [
 [[package]]
 name = "zlib-bitexact-rs"
 version = "0.131.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f4515d95508101b7c7b14f1807d5e7bb2b2a1debb75b2f9d3d95fb376e3f42"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.100",
 ]
 
@@ -129,13 +129,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -183,12 +184,17 @@ dependencies = [
  "crc",
  "flate2",
  "lending-iterator",
+ "libflac-rs",
+ "libzstd-bitexact-rs",
  "lzma-rs-perf-exp",
+ "lzma-sdk-rs",
  "nougat",
  "num-derive",
  "num-traits",
  "ruzstd",
+ "sha1",
  "text_io",
+ "zlib-bitexact-rs",
  "zstd-safe",
 ]
 
@@ -372,6 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flate2"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +517,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libflac-rs"
+version = "0.143.0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +553,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "libzstd-bitexact-rs"
+version = "0.155.0"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +576,13 @@ checksum = "38435c1305548bb408c98242841c3cf161246323e72a3e4433787f3c05bf18ee"
 dependencies = [
  "byteorder",
  "crc",
+]
+
+[[package]]
+name = "lzma-sdk-rs"
+version = "0.2301.0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -863,6 +893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1119,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "zlib-bitexact-rs"
+version = "0.131.0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/PARITY_PLAN.md
+++ b/PARITY_PLAN.md
@@ -1,0 +1,374 @@
+# chd-rs → libchdman-rs Feature Parity Plan
+
+Status: **DRAFT — one decision remaining: the bit-for-bit codec path (see [§11](#11-bit-for-bit-feasibility))**
+Last updated: 2026-06-09
+
+**Decisions locked 2026-06-09:** D1 = **bit-for-bit identical to chdman**; D3 = module/function-level
+parity (keep generic `Chd<F>`); D4 = full `hd`+`cd`+`dvd`+`copy` parity in one push. D2 (encoder
+strategy) is reframed by the bit-for-bit choice — see [§11](#11-bit-for-bit-feasibility).
+
+## 1. Goal
+
+Bring this crate (`chd-rs`, a **pure-Rust, read-only** CHD implementation) up to
+feature parity with `../libchdman-rs` (a wrapper around MAME's C++ `chd.cpp` with
+full `chdman` create/extract parity), **without copying GPL code** and keeping the
+result **BSD-3-Clause**.
+
+Where practical, mirror libchdman-rs's **Rust names** (modules, functions, option
+structs) so downstream code can move between the two crates with minimal churn.
+
+### What "parity" means here
+
+| Capability | chd-rs today | libchdman-rs | Target |
+| --- | --- | --- | --- |
+| Read / decompress (V1–V5) | ✅ | ✅ | keep |
+| Create HD (`createhd`/`createraw`) | ❌ | ✅ | **add** |
+| Create CD (`createcd`) | ❌ | ✅ | **add** |
+| Create DVD (`createdvd`) | ❌ | ✅ | **add** |
+| `copy` (recompress) | ❌ | ✅ | **add** |
+| Extract HD/CD/DVD | partial (`extractraw`) | ✅ | **add** |
+| Metadata write/delete | ❌ | ✅ | **add** |
+| Parent/diff CHDs (write) | read-only | ✅ | **add** |
+| Runtime block writes (`HdImage`) | ❌ | ✅ | **add** |
+| GD-ROM / Laserdisc / AV create | ❌ | deferred | **out of scope** |
+
+## 2. Licensing position (important — premise correction)
+
+The working assumption was "don't copy from MAME because it's GPL-3." The audit shows
+the relevant MAME files are **NOT GPL** — the entire CHD core is **BSD-3-Clause**
+(`// license:BSD-3-Clause copyright-holders:Aaron Giles` headers). Verified files in
+`../mame/src/lib/util/`:
+
+| File | License |
+| --- | --- |
+| `chd.cpp` / `chd.h` | BSD-3-Clause (Aaron Giles) |
+| `chdcodec.cpp` / `chdcodec.h` | BSD-3-Clause (Aaron Giles) |
+| `cdrom.cpp` / `cdrom.h` | BSD-3-Clause (Aaron Giles, R. Belmont) |
+| `huffman.cpp` / `huffman.h` | BSD-3-Clause (Aaron Giles) |
+| `hashing.cpp` / `hashing.h` | BSD-3-Clause (Aaron Giles, Vas Crabb) |
+| `flac.cpp` / `avhuff.cpp` | BSD-3-Clause (Aaron Giles) |
+| `../mame/src/tools/chdman.cpp` | BSD-3-Clause (Aaron Giles) |
+
+**Implication:** We may legally *reference these algorithms as documentation and even
+port them closely*, provided we preserve the BSD-3-Clause notice and Aaron Giles'
+copyright in our headers. BSD-3 → BSD-3 is fully compatible. (MAME *as a whole project*
+is GPL-2.0+, but that license attaches to the emulator/driver code we are not touching.)
+
+**Policy adopted by this plan:**
+- Reference only the BSD-3-Clause util files above. Do **not** read or port anything
+  outside `src/lib/util/` + `src/tools/chdman.cpp`.
+- Stay pure-Rust by *re-deriving* algorithms in idiomatic Rust (chd-rs's existing
+  house style), not transliterating C++. Where a file is a close functional port
+  (e.g. ECC tables, `guess_chs`), add an SPDX/attribution comment:
+  `// Algorithm ported from MAME src/lib/util/<file> (BSD-3-Clause, © Aaron Giles).`
+- Keep the existing `LICENSE.md` (BSD-3, © 2022 Ronny Chan); add a `NOTICE`/THIRD-PARTY
+  section crediting MAME's CHD authors for the referenced algorithms.
+
+## 3. Gap analysis
+
+chd-rs is cleanly layered (`header`, `map`, `metadata`, `compression/*`, `chdfile`,
+`read`) but **every path is decode-only**:
+
+- **Codecs are all decode-only.** `CodecImplementation` (`chd-rs/src/compression/mod.rs:43`)
+  has `decompress()` and no `compress()`. All 11 codecs implement decode only.
+- **No map *writing*.** `map.rs` parses V5 compressed maps + legacy maps; there is no
+  encoder (the inverse of `compress_v5_map`).
+- **No header writing**, no metadata writing, no SHA-1 *generation* (only parent SHA-1
+  *validation* at `chdfile.rs:54`).
+- **`Chd<F>` requires `F: Read + Seek`** — read-only trait bounds throughout.
+
+### Reusable assets already in-tree (big head start)
+
+- **CD ECC tables already present**: `chd-rs/src/compression/ecc.rs` has `ECC_LOW`,
+  `ECC_HIGH`, `ECC_P_OFF`, `ECC_Q_OFF` and the verify path. CD MODE1 ECC/EDC
+  *generation* is the same tables run "forwards" — low risk.
+- **Huffman decoder** + gated `huff_write` field scaffolding (`huffman.rs`) — the
+  static-Huffman *encoder* (needed for V5 map + `huff` codec) can sit alongside it.
+- **Deflate encode is free**: `flate2` (already a dep) does raw-deflate *encoding*, not
+  just decoding.
+- Full, correct parsers for every header/map/metadata structure → exact byte layouts to
+  invert for writing.
+
+### Codec encoder availability (the central risk — see also §8)
+
+| CHD codec | Decode dep (today) | Encode path | Risk |
+| --- | --- | --- | --- |
+| `none` | trivial | trivial | none |
+| `zlib`/Deflate | flate2 | **flate2 encodes** (raw deflate) | low |
+| `huff` | in-tree decoder | port MAME static Huffman encoder (BSD-3) | low–med |
+| `lzma` | `lzma-rs-perf-exp` (decoder fork) | needs **raw** LZMA encode (lc3/lp0/pb2, no end-marker) | **med–high** |
+| `zstd` / `cdzs` | `ruzstd` 0.8 (decoder) | `ruzstd` encoder support is immature; may need C `zstd` behind a feature | **med** |
+| `flac` / `cdfl` | `claxon` (decode-only) | **no pure-Rust FLAC encoder in deps** → `flacenc` crate or custom raw-FLAC | **high** |
+| `cdlz`/`cdzl` | in-tree | wrap base encoders + ECC/subcode split | med |
+| `avhuff` | in-tree | defer (AV out of scope) | n/a |
+
+## 4. Architecture / approach
+
+> **Encode-layer design is specified in [`docs/encode-integration.md`](docs/encode-integration.md)** —
+> how `lzma-sdk-rs` / `libflac-rs` / `libzstd-bitexact-rs` + in-tree `zlib`/`huff` plug into the
+> existing codec layer (the `CodecEncode` trait, per-codec mapping, CD ECC reuse, cargo wiring).
+
+Additive, non-breaking. Keep `Chd<F: Read + Seek>` for reading; add a parallel
+**write layer** and a libchdman-rs-shaped **facade**.
+
+1. **Encoder trait.** Extend the codec layer with an opt-in encode capability, e.g.
+   ```rust
+   pub trait CompressionCodecEncode {
+       fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize>; // Err if expands
+   }
+   ```
+   Implement per codec, gated initially behind a `write` feature so read-only consumers
+   pay nothing.
+2. **Writer core (`chd-rs/src/write/`).** A `ChdWriter<W: Write + Seek>` that owns:
+   header serialization, the hunk-write pipeline (try configured codecs → pick smallest,
+   else self/parent/uncompressed), V5 compressed-map encoding, metadata linked-list
+   writing, and SHA-1 accumulation (raw + overall, matching MAME's ordering so
+   `verify` passes against chdman output).
+3. **Compressor driver.** Pure-Rust equivalent of MAME's `chd_file_compressor`:
+   pull hunks from a source, compress, dedup self/parent hunks, emit map. Single-threaded
+   first; optional `rayon` parallelism later.
+4. **Format facade modules** mirroring libchdman-rs names: `hd`, `cd`, `dvd`, `copy`,
+   plus `codec` (FourCC constants + `parse_codec_spec`/`codec_name`/`codec_exists`).
+5. **rchdman** gains `createhd`/`createcd`/`createdvd`/`copy`/`addmeta`/`delmeta`
+   subcommands.
+
+## 5. API parity mapping
+
+Module/function/option **names match libchdman-rs**. The one unavoidable divergence is
+the `Chd` *type itself*: libchdman-rs's `Chd::open(path, writeable, parent)` is an owned
+FFI handle, whereas chd-rs's `Chd<F>` is generic over a borrowed reader. **Recommended
+(Decision D3):** keep chd-rs's generic `Chd<F>` for reads, and match parity at the
+module/free-function level, which is where the porting value is.
+
+| libchdman-rs | chd-rs target |
+| --- | --- |
+| `hd::create_from_path` / `create_from_reader` | same names, `write/hd.rs` |
+| `hd::extract_to_path` / `extract_to_writer` | same |
+| `hd::{HdCreateOptions, HdGeometry, compute_chs, format_gddd, read_geometry}` | same |
+| `hd::HdImage` (+ `open_with_diff`, `reopen_diff`, `read_sector`/`write_sector`) | same |
+| `cd::{create_from_cue, create_from_iso, list_tracks, extract_to_cue/iso/gdi}` | same |
+| `cd::{CdCreateOptions, TrackInfo, TrackType, SubcodeType, CdCookedReader}` | same |
+| `dvd::{create_from_iso, create_from_reader, extract_to_iso, DvdCreateOptions}` | same |
+| `copy::{copy, CopyOptions}` | same |
+| `codec::{parse_codec_spec, codec_name, codec_exists, CHD_CODEC_*}` | same |
+| `CompressionProgress { bytes_done, bytes_total, ratio }` | same |
+| `Chd::open(path, writeable, parent)` | **diverges** — see D3 |
+
+## 6. Milestones
+
+Each milestone is independently shippable, gated behind the `write` feature, and lands
+with tests that round-trip through the existing decoder **and** verify against chdman
+where available (D1).
+
+- **M0 — Foundations.** `write` feature; `CompressionCodecEncode` trait; SHA-1
+  generation (`sha1` dep) matching MAME's raw+overall ordering; round-trip test harness;
+  `NOTICE` attribution. Ref: `chd.cpp` `compute_overall_sha1`, `metadata_hash`.
+- **M1 — V5 writer core + `none`/`zlib`.** Header V5 write, `compress_v5_map`
+  (RLE+Huffman) encoder, uncompressed/self-hunk dedup, write an uncompressed and a
+  zlib-only CHD that chdman reads. Ref: `chd.cpp:2071` `compress_v5_map`.
+- **M2 — Codec encoders.** `huff` (port `huffman.cpp` encoder), `lzma` (raw),
+  `zstd`. Each: compress→our-decoder→chdman round-trip. (FLAC tracked separately, D2.)
+- **M3 — `hd` module + `codec` module.** `compute_chs` (port `guess_chs`,
+  `chdman.cpp:1115`), GDDD/IDNT metadata, create/extract, `parse_codec_spec`.
+- **M4 — Metadata write/delete + `copy`.** Metadata linked-list writer; `copy` clones
+  metadata + recompresses. Ref: `chd.cpp` `write_metadata`/`delete_metadata`.
+- **M5 — `dvd` module.** Flat 2048 sectors + empty `DVD ` record (note the 1-NUL-byte
+  quirk libchdman-rs documents). Defaults `[lzma,zlib,huff,flac]` (needs M2/FLAC).
+- **M6 — `cd` module.** CUE/GDI/ISO/Nero TOC parser (pure Rust), CD codec *encoders*
+  (sector+subcode split, ECC/EDC synthesis via `ecc.rs` tables run forward), CHT2
+  metadata, `list_tracks`, extract to cue/iso/gdi. Ref: `cdrom.cpp` `ecc_generate:1400`.
+- **M7 — Parent/diff + `HdImage` runtime writes.** Uncompressed diff children against a
+  compressed parent; block-device `read_sector`/`write_sector`.
+- **M8 — rchdman subcommands + docs.** `create*`/`copy`/`addmeta`/`delmeta`; port
+  libchdman-rs's `docs/format-modules.md` + `docs/chdman-mapping.md`; README rewrite.
+
+## 7. Testing strategy
+
+- **Round-trip (always):** create → read back with chd-rs's own decoder → assert logical
+  bytes + `raw_sha1` match the source.
+- **chdman cross-check (D1):** dev-local feature `chdman_compat_tests` that shells out to
+  a real `chdman` (and/or uses `../mame` build) to (a) `chdman verify` our output and
+  (b) confirm `info` SHA-1s match. Mirrors libchdman-rs's gating so CI needs no chdman.
+- **Fixtures:** reuse libchdman-rs's checked-in ISO/BIN/CUE fixtures (BSD-3) under
+  `chd-rs/tests/`.
+- **Fidelity expectation:** we target **logical + SHA-1 parity and chdman-readability**,
+  *not* byte-identical files (see D1 / §8).
+
+## 8. Pitfalls
+
+1. **Byte-for-byte parity is effectively unattainable in pure Rust.** libchdman-rs is
+   byte-exact only because it *is* MAME's compressors. Different deflate/LZMA/FLAC encoder
+   implementations emit different (valid) bitstreams, and MAME's per-hunk codec-selection
+   order would have to be matched exactly. Realistic target: files that **decompress to
+   identical content (matching `sha1`/`raw_sha1`) and pass `chdman verify`**. Set this
+   expectation up front (Decision D1).
+2. **FLAC encoding is the hardest gap.** `claxon` is decode-only; CHD FLAC uses a specific
+   raw framing (no seektable, block size tied to hunk frames, fixed STREAMINFO). Options:
+   `flacenc` crate (pure Rust, permissive) wrapped to emit raw frames, or a custom
+   minimal encoder. Until solved, the **DVD default `[lzma,zlib,huff,flac]` and CD `cdfl`
+   can't be produced** — M5/M6 partially blocked (Decision D2).
+3. **LZMA must be *raw*.** CHD uses raw LZMA (props lc=3/lp=0/pb=2, no end marker, dict
+   size derived from hunk size). The decoder dep is a fork; its *encoder* path (if any)
+   must produce that exact framing or chdman won't decode it.
+4. **zstd encoder maturity.** Pure-Rust zstd encoding (`ruzstd`) is young; ratios/ível may
+   be poor or incomplete. May need to gate a C-backed `zstd` encoder behind a feature,
+   which dents the "no C toolchain" promise for that codec only (Decision D2).
+5. **SHA-1 ordering must match MAME exactly** or `verify`/`info` SHA-1s won't line up.
+   The overall SHA-1 folds in metadata in a defined order with the `CHD_MDFLAGS_CHECKSUM`
+   filter; get this wrong and round-trips pass but cross-checks fail. Port carefully from
+   `chd.cpp`.
+6. **V5 compressed-map encoder is intricate** (RLE + self/parent compaction +
+   Huffman-coded lengths + `lengthbits`/`selfbits`/`parentbits` + CRC-16). Mirror
+   `compress_v5_map` (`chd.cpp:2071`) closely; easy to get subtly wrong.
+7. **CUE/GDI/Nero parsing** is reimplemented from scratch (libchdman-rs delegated to
+   MAME's `parse_toc`). Edge cases: pregap/postgap, INDEX 00/01, multi-FILE cues, split
+   bins, GDI high-density area. Scope risk for M6.
+8. **`Chd` API shape clash.** Existing generic `Chd<F>` vs libchdman-rs's owned handle —
+   100% drop-in source compatibility at the `Chd` level isn't possible without a breaking
+   change to the existing read API (Decision D3).
+9. **Self/parent hunk dedup correctness.** The writer must reproduce CHD's self-ref and
+   parent-ref hunk types and CRC bookkeeping, or produce larger-but-valid files. Start
+   conservative (no dedup), add dedup once verify is green.
+10. **chd-rs MSRV / `no_std` posture.** Adding `sha1`, possibly `flacenc`/`rayon` must
+    respect the existing MSRV (1.59 advertised) and `std`/`no_std` feature split. Keep all
+    write code behind `write` + `std`.
+
+## 9. Open Decisions
+
+These gate the plan and are being asked now.
+
+- **D1 — Fidelity target.** Byte-for-byte vs logical+SHA-1+chdman-readable.
+  *Recommendation: logical + SHA-1 + `chdman verify` clean.*
+- **D2 — Encoder purity.** Strict pure-Rust (accept FLAC/zstd gaps/effort) vs allow
+  optional C-backed encoders behind features vs limit initial codec scope to
+  `none/zlib/lzma/huff` and defer FLAC/zstd encode.
+- **D3 — API shape.** Module/function-level parity (keep generic `Chd<F>`) vs introduce a
+  separate owned writeable handle mirroring libchdman-rs's `Chd` exactly.
+- **D4 — Format scope/priority.** Full `hd`+`cd`+`dvd`+`copy` parity, or HD-first
+  (smallest path to a usable writer for the MiSTer/rusty-backup use case) with CD/DVD
+  later.
+
+## 11. Bit-for-bit feasibility
+
+D1 was chosen as **byte-for-byte identical to chdman**. This is the demanding option and
+it reshapes everything, so the analysis is recorded here.
+
+### Why bit-for-bit forces specific encoders
+
+A CHD's exact bytes are determined hunk-by-hunk by two things:
+1. **Each codec's exact compressed bitstream**, and
+2. **Which codec "wins" each hunk** — MAME tries every configured codec and keeps the
+   smallest output. A **1-byte** difference in any codec flips the winner for that hunk,
+   which changes the map, the self/parent dedup, and cascades into a *completely*
+   different file.
+
+So *bit-for-bit ⟺ every codec encoder emits byte-identical output to the exact C library
+MAME links, at the exact version and settings.* Verified MAME settings:
+
+| Codec | MAME library | Settings (`chdcodec.cpp` / `flac.cpp`) | Bit-exact in pure Rust today? | Prerequisite |
+| --- | --- | --- | --- | --- |
+| `none` | memcpy | — | ✅ yes | — |
+| `huff` | MAME static Huffman (`huffman.cpp`, BSD-3) | fully specified in-repo | ✅ yes (faithful port) | in-scope, small |
+| `zlib` | **stock zlib** (confirmed; *not* zlib-ng) | `deflateInit2(L9, -MAX_WBITS, memLevel 8, default strategy)` | ⚠️ *maybe* via `zlib-rs` (aims for byte-identical-to-zlib) | validate `zlib-rs` output |
+| `lzma` | LZMA SDK (7-zip) `LzmaEnc` | `level=8`, dict normalized from hunk size, BT4 | ❌ no Rust port is bit-exact | **bit-exact `LzmaEnc.c` port** |
+| `zstd` | libzstd | `ZSTD_maxCLevel()` = 22 | ❌ no; output also drifts across zstd versions | **bit-exact libzstd encoder** |
+| `flac` | libFLAC | `level=8`, subset off, fixed blocksize, verify/md5 off | ❌ no (`flacenc` ≠ libFLAC bytes) | **bit-exact libFLAC encoder** |
+
+`none` + `huff` are free / faithful ports. `zlib` is one validated dependency away
+(maybe). **`lzma`, `zstd`, `flac` each require reproducing a specific C library's bitstream
+byte-for-byte — there is no pure-Rust implementation that does this for any of the three.**
+They also pin output to the *exact* library versions MAME 0.288 bundles (zstd especially is
+version-sensitive).
+
+### The three-way tension
+
+`pure Rust` + `bit-for-bit` + `no C` **cannot all hold** for lzma/zstd/flac with what exists
+today. Pick the reconciling path:
+
+- **Path A — bit-for-bit via shared C codec libs.** Write the CHD orchestration (header,
+  map, metadata, SHA-1, compressor driver, dedup) in Rust, but link the *same* C encoders
+  MAME uses (zlib, LZMA SDK, libFLAC, libzstd) at matching versions/settings. The only
+  realistic route to true bit-for-bit. Drops "pure-Rust codecs" but avoids MAME's C++ core.
+- **Path B — bit-exact pure-Rust encoder crates first.** Build `lzma-sdk`-exact,
+  `libFLAC`-exact, and `libzstd`-exact encoders in Rust as standalone projects, then the
+  writer. Satisfies pure-Rust + bit-for-bit. Research-grade, multi-month per codec, and
+  brittle against upstream version drift.
+- **Path C — drop bit-for-bit; pure-Rust + `chdman verify` parity.** Any correct encoders;
+  validate by SHA-1 + `chdman verify`. Achievable now, keeps chd-rs's identity, but files
+  are not byte-identical (this was the D1 option *not* chosen).
+- **Path D — incremental (recommended first move).** Start now on the writer core +
+  `none`/`huff`/`zlib`, which *are* bit-exact-feasible, and prove the entire pipeline
+  (header, map encoder, metadata, SHA-1, dedup) byte-identical on uncompressed / huff / zlib
+  CHDs. Schedule `lzma`/`zstd`/`flac` as separate encoder subprojects, choosing Path A vs B
+  **per codec** when reached. Unblocks immediate progress without first solving the hardest
+  codecs.
+
+**Recommendation:** Path D to start, with Path A as the default for the three hard codecs
+unless a strict no-C mandate forces Path B. Answer to "do I need to start other projects
+first?": **for `none`/`zlib`/`huff`, no — start now; for `lzma`/`zstd`/`flac`, yes — each
+is a separate bit-exact encoder project (Path A links the C lib; Path B reimplements it).**
+
+### Encoder sourcing — C upstreams, versions, licenses (all permissive)
+
+To be bit-for-bit, we must match the **exact** library versions MAME 0.288 bundles
+(verified from `../mame/3rdparty/`). Good news: **none are GPL-only** — every one is
+public-domain, zlib, or BSD-3, so we may link *or* port and relicense the port BSD-3.
+
+| Codec | Upstream C project | Version in MAME | License | Existing Rust crate | Recommended route |
+| --- | --- | --- | --- | --- | --- |
+| `zlib` | zlib (madler) | **1.3.1** | zlib license | `zlib-rs` (byte-identical port; **already used** via flate2) | **Port (done) — validate byte-identity to 1.3.1** |
+| `huff` | MAME `huffman.cpp` | (in MAME) | BSD-3 | in-tree decoder | **Port encoder** (small) |
+| `lzma` | LZMA SDK (Igor Pavlov / 7-zip) | **23.01** | **public domain** | none bit-exact (`xz2`/`lzma-sys` wrap *liblzma*, different bytes) | **Port `LzmaEnc.c` + `LzFind.c`** (PD → BSD-3; self-contained, deterministic) |
+| `zstd` | libzstd (Meta) | **1.5.5** | BSD-3 (dual GPLv2) | `zstd-sys`/`zstd-safe` (**already optional dep**) | **Link, pinned to 1.5.5** (porting impractical) |
+| `flac` | libFLAC (Xiph.Org) | **1.4.3** | BSD-3 (lib only; tools are GPL/LGPL — not used) | `libflac-sys`/`flac-sys` | **Link 1.4.3 first; optional port later** |
+
+Notes:
+- **zlib is essentially solved**: chd-rs already decodes via `zlib-rs`, which is an
+  explicit byte-compatible reimplementation of zlib. We only need to confirm its *deflate*
+  output equals zlib 1.3.1 at `(level 9, -MAX_WBITS, memLevel 8, default strategy)`.
+- **LZMA is the flagship port**: the 7-zip SDK encoder is public domain and self-contained
+  (`LzmaEnc.c` + `LzFind.c` match finder), so a faithful Rust port can be bit-exact and is
+  legally unencumbered. *Do not* use `liblzma`/`xz` — different encoder, different bytes.
+- **zstd should be linked, not ported**: libzstd at level 22 uses an enormous, version-
+  sensitive optimal parser; a bit-exact pure-Rust port is not realistic. The `zstd` crate
+  already exists and is BSD-3. Pin it to a build that reports `1.5.5`.
+- **FLAC**: link libFLAC 1.4.3 (BSD-3) to get bit-for-bit quickly; a Rust port of
+  `stream_encoder.c` (LPC/apodization/Rice search must match exactly) is feasible later if
+  a fully-pure-Rust build is wanted. `flacenc` does **not** match libFLAC's bytes.
+
+Net: with this routing, only **zstd** (and, until ported, **flac**) require a C toolchain;
+`none`/`zlib`/`huff`/`lzma` are pure Rust. All five are permissively licensed.
+
+### D2 locked (2026-06-09): Path B — maximal pure Rust, as standalone crates
+
+Decision: **bit-exact pure-Rust ports of every codec**, built as **separate reusable crates**
+so other projects can consume them. chd-rs depends on them; the codec work is not buried
+inside chd-rs.
+
+**Status 2026-06-18 — all three crates are BUILT and bit-exact-verified** (sibling repos
+under `../`). Each has a handoff doc under [`docs/codec-ports/`](docs/codec-ports/).
+
+| Crate | Ports | Target version | Parity target needs | Aligned? |
+| --- | --- | --- | --- | --- |
+| *(existing)* `zlib-rs` | deflate (validate only) | zlib 1.3.1 | zlib 1.3.1 | ✅ (validate) |
+| *(in-tree)* MAME static Huffman | V5 map + `huff` codec | `huffman.cpp` | — | ✅ |
+| `lzma-sdk-rs` v0.2301.0 | raw LZMA encode (+dec) | LZMA SDK 23.01 | 23.01 | ✅ |
+| `libflac-rs` v0.143.0 | libFLAC encode/decode | libFLAC 1.4.3 | 1.4.3 | ✅ (glibc libm) |
+| `libzstd-bitexact-rs` v0.155.0 | libzstd encode/decode | zstd **1.5.5** | zstd **1.5.5** | ✅ |
+
+**zstd drift RESOLVED (2026-06-19):** `libzstd-bitexact-rs` **0.155.0** (byte-exact vs zstd
+1.5.5, chdman's version) is published to crates.io. chd-rs pins `=0.155` and gates `zstd`/`cdzs`
+behind `write-zstd`. chdman's per-hunk path is **unknown-pledged-size** level 22, so use
+`StreamEncoder::new(22).finish(..)` (not `with_pledged_src_size`, which downsizes windowLog and
+changes the bytes); `compress(x, 22)` is byte-identical for a single `e_end`. The 0.157.x line
+of the same crate tracks zstd 1.5.7 for other consumers. **Secondary:** `libflac-rs` float
+parity is validated against **glibc**
+libm — confirm the reference chdman is a glibc build (FLAC bit-exactness is libm-dependent on
+both sides). The shared success criterion remains: **byte-identical output to the exact
+bundled C version at the exact settings CHD uses**, proven by differential tests.
+
+## 10. Out of scope (matches libchdman-rs TODO)
+
+- GD-ROM (`creategd`/`extractgd`), Laserdisc/AV (`createld`/`createav`).
+- v3/v4 *creation* (read stays supported).
+- Reimplementing the `chdman` CLI wholesale (rchdman stays a thin proof-of-concept).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -26,8 +26,9 @@ ECC, CHT2); then F (parent/diff + `HdImage`), G (`info`/`verify`, rchdman).
 
 **Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
 "Verification gates" below. **43 write/compat tests green** (the 5 failing `read_*` tests are
-pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`):
-clones the sibling codec crates at their tags, then builds/tests on ubuntu/windows/macos + fmt.
+pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`) and **verified green on GitHub Actions** (all 4 jobs:
+lint + test on ubuntu/windows/macos): clones the sibling codec crates at their tags (they're public),
+then `cargo build -p chd` + `cargo test -p chd --features write-zstd -- --skip tests::read` + fmt.
 **`Chd::info()` + `ChdInfo`** (read-side) also landed (Phase G partial).
 
 **CI:** chd-rs has **no CI** (siblings do). Blocked: the `write` feature's optional **path deps** on

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -12,27 +12,30 @@ Legend: `[ ]` todo · `[~]` in progress · `[x]` done & verified · `[!]` blocke
 
 ## Current focus
 
-**`chdman createraw` parity is COMPLETE & byte-identical to chdman 0.288** — uncompressed +
-compressed (now **multi-codec**: zlib/huff/lzma/zstd + **flac**), **self-hunk dedup**, header,
-`compress_v5_map`, and SHA-1, all verified end-to-end. All five bit-exact codec encoders are wired
-(flac via `libflac-rs`, round-trip-verified through chdman; byte-identity is libm-gated — see below).
+**The chd-rs write-support / libchdman parity initiative is COMPLETE — all phases A–G done, output
+byte-for-byte identical to chdman 0.288.** Pure-Rust create/extract for raw/hd/cd(+GD-ROM)/dvd, copy,
+metadata add/delete, parent/diff (compressed child + the `HdImage` runtime block device), plus
+read-side `info`/`verify`, all verified against the chdman oracle. The `rchdman` CLI is a
+chdman-style front-end over the whole surface, and the write docs (README + `chdman-mapping.md`) are
+in place.
 
-**Now:** **Phases A, B, C, D are done, and Phase E `createcd` is byte-identical.** A: `codec`
-module, `flac` encoder, multi-codec `write_raw`, `CompressionProgress` + `progress`/`cancel`, public
-`hd` createraw + extract + geometry. B: full **`createhd`** (metadata writer + overall SHA-1 +
-GDDD/IDNT). C: **`copy`** + **`write_metadata`/`delete_metadata`** on existing CHDs. D: **`dvd`**
-(`createdvd`/`extractdvd`). E (in progress): CD codec encoders (cdzl/cdlz/cdzs) **and the
-**`createcd`** container** — `cd` module with a pure-Rust CUE/ISO TOC parser, CHT2 metadata, and
-`create_from_cue`/`create_from_iso`, all **byte-identical to `chdman createcd`**. Remaining E:
-`extractcd`, GDI/Nero, `list_tracks`, `CdCookedReader`, `cdfl`. Then F (parent/diff + `HdImage`),
-G (`info`/`verify`, rchdman).
+**Done (A–G):** A `codec`/`flac`/multi-codec `write_raw`/`progress`-cancel/public `hd`. B `createhd`
+(metadata writer + overall SHA-1 + GDDD/IDNT). C `copy` + `write_metadata`/`delete_metadata`. D
+`dvd`. E `cd` — createcd (CUE/ISO/GDI) + extractcd (cue/bin/gdi) + `extract_to_iso`/`CdCookedReader`
++ `list_tracks`, all four codecs incl. glibc-verified `cdfl`. F parent/diff
+(`create_raw_from_path_with_parent`, byte-identical to `createraw -op`) + `HdImage`. G `Chd::verify`
+(+ `verify` feature) + rchdman CLI + docs.
 
-**Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
-"Verification gates" below. **65 write/compat/unit tests green** (+2 `#[ignore]`d glibc-chdman FLAC
-dump checks; the 5 failing `read_*` tests are pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`) and **verified green on GitHub Actions** (all 4 jobs:
-lint + test on ubuntu/windows/macos): clones the sibling codec crates at their tags (they're public),
-then `cargo build -p chd` + `cargo test -p chd --features write-zstd -- --skip tests::read` + fmt.
-**`Chd::info()` + `ChdInfo`** (read-side) also landed (Phase G partial).
+**Deferred (documented, not blocking):** Nero (`.nrg`) input (binary TOC, unverifiable — chdman
+can't write `.nrg` so no fixture); `copy` re-doing legacy CD metadata (CHCD/CHTR/CHGT→CHT2) for
+legacy-source copies; the crates.io version-dep switch (CI currently clones the sibling crates).
+
+**Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target) + a **glibc-built
+chdman 0.288** (built this session in WSL at `~/repos/mame`) for FLAC byte-identity. See
+"Verification gates" below. **67 write/compat/unit tests green** (+2 `#[ignore]`d glibc-chdman FLAC
+dump checks; the 5 failing `read_*` tests are pre-existing missing-fixture cases, unrelated to write). **CI** (`.github/workflows/ci.yml`) **green on GitHub Actions** (lint + test on ubuntu/windows/macos):
+clones the sibling codec crates at their tags, then `cargo build -p chd` +
+`cargo test -p chd --features write-zstd -- --skip tests::read` + fmt.
 
 **CI:** chd-rs has **no CI** (siblings do). Blocked: the `write` feature's optional **path deps** on
 the sibling crates (`../../lzma-sdk-rs`, …) make even the default build's dependency resolution fail
@@ -224,10 +227,17 @@ decision (may become a new crate).
       `write::write_empty_diff` builds the initial diff. Round-trip verified **and chdman
       `extracthd -ip` reads our diff** (chdman-compatible format).
 
-## M8 — rchdman + docs
+## M8 — rchdman + docs ✅
 
-- [ ] rchdman: `createhd`/`createcd`/`createdvd`/`copy`/`addmeta`/`delmeta`
-- [ ] Port `docs/format-modules.md` + `docs/chdman-mapping.md`; README rewrite
+- [x] **`Chd::verify()`** ✅ — `verify` feature (pulls only `sha1`; `write` enables it). Recomputes
+      raw (over logical bytes) + overall (metadata-inclusive) SHA-1, compares to header →
+      `VerifyResult`. Tested (data + metadata corruption + partial-hunk + uncompressed).
+- [x] **rchdman** ✅ — `createraw`(+`--outputparent`)/`createhd`/`createcd`/`createdvd`/`copy`/
+      `addmeta`/`delmeta`/`extractcd`/`extractdvd` + full `verify` (via `Chd::verify`). Smoke-tested
+      end-to-end (create → verify → extract round-trips).
+- [x] **Docs** ✅ — README "Writing CHDs" section + `docs/chdman-mapping.md` (every chdman command →
+      chd-rs API + rchdman). (`format-modules.md` is libchdman-internal; covered by chdman-mapping +
+      libchdman-parity.)
 
 ---
 
@@ -280,10 +290,28 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
   all four codecs incl. glibc-verified `cdfl`. Only Nero (`.nrg`) deferred (unverifiable).
 - [x] **F** — parent/diff + `HdImage` ✅ — `create_raw_from_path_with_parent` (compressed child,
   byte-identical to `createraw -op`) + `HdImage` (uncompressed diff + sector R/W; chdman reads it).
-- [~] **G** — `Chd::info` ✅ + `ChdInfo`; `verify` (needs a read-side SHA-1 dep) + rchdman + docs.
+- [x] **G** — `Chd::info`/`ChdInfo` ✅ + **`Chd::verify`** ✅ (`verify` feature) + **rchdman**
+  (create/extract/copy/meta/verify) ✅ + **docs** (README + chdman-mapping) ✅.
+
+**All phases A–G complete.** The pure-Rust write surface matches `chdman` 0.288 byte-for-byte across
+createraw/hd/cd(+GD)/dvd, all extracts, copy, metadata add/del, parent/diff, and the `HdImage`
+runtime device, plus read-side `info`/`verify`. Deferred (documented): Nero `.nrg` input
+(unverifiable without a fixture); legacy-CD-metadata re-do in `copy`; the crates.io version-dep
+switch for CI.
 
 ## Session log
 
+- 2026-06-20: **Phase G COMPLETE — `verify` + rchdman + docs (initiative done).** (1) **`Chd::verify()`**
+  behind a new `verify` feature (pulls only `sha1`; `write` enables it transitively, so the default
+  read build still adds nothing). Recomputes the raw SHA-1 over the **logical** (unpadded) bytes — the
+  rchdman loop was hashing padded hunks, wrong for partial last hunks — and the overall
+  metadata-inclusive SHA-1, returning `VerifyResult{computed/expected raw+overall}` with
+  `is_valid()`/`raw_sha1_valid()`/`overall_sha1_valid()`. Tested: data + metadata corruption detected
+  independently, partial-last-hunk verifies, uncompressed refused. (2) **rchdman** grew from read-only
+  to a chdman-style CLI: createraw(+`--outputparent`)/createhd/createcd(CUE/GDI/ISO)/createdvd/copy/
+  addmeta/delmeta/extractcd/extractdvd + full verify; smoke-tested (create→verify→extract round-trips).
+  (3) **Docs**: README "Writing CHDs" + `docs/chdman-mapping.md`. **67 lib/compat tests green.**
+  **All phases A–G done.**
 - 2026-06-20: **Phase F COMPLETE — parent/diff + `HdImage`.** (1) **`HdImage`** (`hd.rs`): a
   read/write block-device view over an uncompressed HD CHD. `open` (in-place), `open_with_diff`/
   `reopen_diff` (uncompressed **diff** over a compressed parent — unwritten hunks fall through to the

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -25,9 +25,10 @@ All byte-identical to chdman 0.288. Remaining: **E (`cd`)** — the big one (TOC
 ECC, CHT2); then F (parent/diff + `HdImage`), G (`info`/`verify`, rchdman).
 
 **Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
-"Verification gates" below. **42 write/compat tests green** (the 5 failing `read_*` tests are
+"Verification gates" below. **43 write/compat tests green** (the 5 failing `read_*` tests are
 pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`):
 clones the sibling codec crates at their tags, then builds/tests on ubuntu/windows/macos + fmt.
+**`Chd::info()` + `ChdInfo`** (read-side) also landed (Phase G partial).
 
 **CI:** chd-rs has **no CI** (siblings do). Blocked: the `write` feature's optional **path deps** on
 the sibling crates (`../../lzma-sdk-rs`, …) make even the default build's dependency resolution fail
@@ -231,8 +232,8 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
   writing GDDD (+ optional IDNT), byte-identical to chdman.
 - [x] **C** — `copy` ✅ + `write_metadata`/`delete_metadata` on existing CHDs ✅ — all byte-identical.
 - [x] **D** — `dvd` ✅ — `createdvd`/`extractdvd` byte-identical (`DVD ` record, 2048 sectors).
-- [ ] **E** — `cd` · [ ] **F** — parent/diff + `HdImage` · [ ] **G** — `Chd::info`/`verify`,
-  rchdman, remaining docs.
+- [ ] **E** — `cd` · [ ] **F** — parent/diff + `HdImage` · [~] **G** — `Chd::info` ✅ + `ChdInfo`;
+  `verify` (needs a read-side SHA-1 dep) + rchdman + remaining docs pending.
 
 ## Session log
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -170,9 +170,12 @@ decision (may become a new crate).
 
 ## M6 — `cd` module
 
+- [x] **CD wrapper encoders** `CdEncoder<E,S>` ✅ — encode mirror of `CdCodec` (de-swizzle 2352+96,
+      ECC strip for verifiable data sectors via `ecc.rs`, `[ecc_flags‖complen‖sector‖subcode]`
+      header). `CdZlibEncoder`/`CdLzmaEncoder`/`CdZstdEncoder`; wired into `init_encoder`.
+      **`cdzl`/`cdlz` byte-identical to chdman** (per-hunk, MODE1 ECC-strip path) + round-trip.
+      `CdFlacEncoder` (cdfl) still TODO (libm-gated; FLAC base + zlib subcode, no ECC strip).
 - [ ] CUE/GDI/ISO/Nero TOC parser (pure Rust)
-- [ ] CD wrapper encoders `CdEncoder<E,S>` + `CdFlacEncoder` (split 2048+96, ECC strip via
-      `ecc.rs`, header) — ref `cdrom.rs` decode + `ecc.rs` `generate_ecc`
 - [ ] CHT2 metadata; `TrackInfo`/`TrackType`/`SubcodeType`; `list_tracks`
 - [ ] `create_from_cue`/`create_from_iso`; `extract_to_cue`/`extract_to_iso`/`extract_to_gdi`
 - [ ] Tests: BIN/CUE round-trip, codec matrix, multi-track, GDI
@@ -233,11 +236,22 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
   writing GDDD (+ optional IDNT), byte-identical to chdman.
 - [x] **C** — `copy` ✅ + `write_metadata`/`delete_metadata` on existing CHDs ✅ — all byte-identical.
 - [x] **D** — `dvd` ✅ — `createdvd`/`extractdvd` byte-identical (`DVD ` record, 2048 sectors).
-- [ ] **E** — `cd` · [ ] **F** — parent/diff + `HdImage` · [~] **G** — `Chd::info` ✅ + `ChdInfo`;
-  `verify` (needs a read-side SHA-1 dep) + rchdman + remaining docs pending.
+- [~] **E** — `cd`: **CD codec encoders (cdzl/cdlz) byte-identical** ✅; remaining = TOC parser +
+  CHT2 metadata + createcd/extractcd container + cdfl. · [ ] **F** — parent/diff + `HdImage` ·
+  [~] **G** — `Chd::info` ✅ + `ChdInfo`; `verify` (needs a read-side SHA-1 dep) + rchdman + docs.
 
 ## Session log
 
+- 2026-06-20: **Phase E started — CD codec encoders, byte-identical to chdman.** Added
+  `CdEncoder<Engine, SubEngine>` (`compression/cdrom.rs`), the encode mirror of `CdCodec`: port of
+  MAME `chd_cd_compressor::compress` — de-swizzle `[sector(2352)‖subcode(96)]` frames, strip the
+  sync header + P/Q ECC of verifiable data sectors (recording an ECC-flag bitmap, regenerated on
+  decode), compress the sector run + subcode run, emit `[ecc_flags‖complen‖sector‖subcode]`.
+  `CdZlibEncoder`/`CdLzmaEncoder`/`CdZstdEncoder` wired into `init_encoder`. Made `compression::ecc`
+  `pub(crate)` for test sector synthesis. Verified: round-trip (mixed MODE1+audio) and **per-hunk
+  byte-identical to `chdman createcd -c cdzl`/`cdlz`** (MODE1/2352 CUE+BIN through the ECC-strip
+  path). Remaining for cd: TOC parser, CHT2 metadata, the createcd/extractcd container, cdfl. 47
+  write/compat tests green.
 - 2026-06-20: **Phase C completed (metadata write/delete) + CI added.** (1) `metadata::write_metadata`
   /`delete_metadata` for existing V5 CHDs (`Read+Write+Seek` free fns): ports of
   `metadata_find`/`metadata_set_previous_next`/`metadata_update_hash` — overwrite-in-place-or-append

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -17,15 +17,18 @@ compressed (now **multi-codec**: zlib/huff/lzma/zstd + **flac**), **self-hunk de
 `compress_v5_map`, and SHA-1, all verified end-to-end. All five bit-exact codec encoders are wired
 (flac via `libflac-rs`, round-trip-verified through chdman; byte-identity is libm-gated — see below).
 
-**Now:** **Phases A, B, C, and D are done.** A: `codec` module, `flac` encoder, multi-codec
-`write_raw`, `CompressionProgress` + `progress`/`cancel`, public `hd` createraw + extract + geometry.
-B: full **`createhd`** (metadata writer + overall SHA-1 + GDDD/IDNT). C: **`copy`** +
-**`write_metadata`/`delete_metadata`** on existing CHDs. D: **`dvd`** (`createdvd`/`extractdvd`).
-All byte-identical to chdman 0.288. Remaining: **E (`cd`)** — the big one (TOC parser, CD codecs,
-ECC, CHT2); then F (parent/diff + `HdImage`), G (`info`/`verify`, rchdman).
+**Now:** **Phases A, B, C, D are done, and Phase E `createcd` is byte-identical.** A: `codec`
+module, `flac` encoder, multi-codec `write_raw`, `CompressionProgress` + `progress`/`cancel`, public
+`hd` createraw + extract + geometry. B: full **`createhd`** (metadata writer + overall SHA-1 +
+GDDD/IDNT). C: **`copy`** + **`write_metadata`/`delete_metadata`** on existing CHDs. D: **`dvd`**
+(`createdvd`/`extractdvd`). E (in progress): CD codec encoders (cdzl/cdlz/cdzs) **and the
+**`createcd`** container** — `cd` module with a pure-Rust CUE/ISO TOC parser, CHT2 metadata, and
+`create_from_cue`/`create_from_iso`, all **byte-identical to `chdman createcd`**. Remaining E:
+`extractcd`, GDI/Nero, `list_tracks`, `CdCookedReader`, `cdfl`. Then F (parent/diff + `HdImage`),
+G (`info`/`verify`, rchdman).
 
 **Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
-"Verification gates" below. **43 write/compat tests green** (the 5 failing `read_*` tests are
+"Verification gates" below. **54 write/compat/unit tests green** (the 5 failing `read_*` tests are
 pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`) and **verified green on GitHub Actions** (all 4 jobs:
 lint + test on ubuntu/windows/macos): clones the sibling codec crates at their tags (they're public),
 then `cargo build -p chd` + `cargo test -p chd --features write-zstd -- --skip tests::read` + fmt.
@@ -175,10 +178,18 @@ decision (may become a new crate).
       header). `CdZlibEncoder`/`CdLzmaEncoder`/`CdZstdEncoder`; wired into `init_encoder`.
       **`cdzl`/`cdlz` byte-identical to chdman** (per-hunk, MODE1 ECC-strip path) + round-trip.
       `CdFlacEncoder` (cdfl) still TODO (libm-gated; FLAC base + zlib subcode, no ECC strip).
-- [ ] CUE/GDI/ISO/Nero TOC parser (pure Rust)
-- [ ] CHT2 metadata; `TrackInfo`/`TrackType`/`SubcodeType`; `list_tracks`
-- [ ] `create_from_cue`/`create_from_iso`; `extract_to_cue`/`extract_to_iso`/`extract_to_gdi`
-- [ ] Tests: BIN/CUE round-trip, codec matrix, multi-track, GDI
+- [x] **CUE + ISO TOC parser** (pure Rust) ✅ — `parse_cue` (port of `cdrom.cpp:2336`: FILE/TRACK/
+      INDEX/PREGAP/POSTGAP, single- and multi-file BIN, the common MODE1/MODE2/AUDIO types, audio
+      byte-swap, 4-frame track padding) + `parse_iso` (size-inferred single track). GDI/Nero still TODO.
+- [x] **CHT2 metadata + `TrackType`/`SubcodeType`** ✅ — `CDROM_TRACK_METADATA2_FORMAT` payload
+      (string **+ NUL terminator**, *no* trailing space — verified vs chdman 0.288). `TrackInfo`/
+      `list_tracks` (read-side) still TODO.
+- [x] **`create_from_cue`/`create_from_iso`** ✅ — assemble the 2448-frame logical image (port of
+      `chd_cd_compressor::read_data`) + CHT2 + `write_create`; **byte-identical to `chdman createcd`**.
+      `extract_to_cue`/`extract_to_iso`/`extract_to_gdi` still TODO.
+- [x] **Tests** ✅ — `createcd -c cdzl`/`cdlz` byte-identical: single MODE1/2352 (partial last hunk),
+      **multi-track MODE1+AUDIO+in-file pregap** (V-prefixed PGTYPE, swap), and flat-ISO MODE1/2048.
+- [ ] GDI/Nero parser; `extractcd` (→cue/bin/gdi); `CdCookedReader`; `list_tracks`; `cdfl` encoder
 
 ## M7 — Parent/diff + `HdImage`
 
@@ -236,12 +247,28 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
   writing GDDD (+ optional IDNT), byte-identical to chdman.
 - [x] **C** — `copy` ✅ + `write_metadata`/`delete_metadata` on existing CHDs ✅ — all byte-identical.
 - [x] **D** — `dvd` ✅ — `createdvd`/`extractdvd` byte-identical (`DVD ` record, 2048 sectors).
-- [~] **E** — `cd`: **CD codec encoders (cdzl/cdlz) byte-identical** ✅; remaining = TOC parser +
-  CHT2 metadata + createcd/extractcd container + cdfl. · [ ] **F** — parent/diff + `HdImage` ·
+- [~] **E** — `cd`: CD codec encoders (cdzl/cdlz/cdzs) ✅ **and `createcd` (CUE/ISO parser + CHT2 +
+  `create_from_cue`/`create_from_iso`) byte-identical** ✅; remaining = `extractcd`, GDI/Nero,
+  `list_tracks`, `CdCookedReader`, `cdfl`. · [ ] **F** — parent/diff + `HdImage` ·
   [~] **G** — `Chd::info` ✅ + `ChdInfo`; `verify` (needs a read-side SHA-1 dep) + rchdman + docs.
 
 ## Session log
 
+- 2026-06-20: **Phase E `createcd` container — byte-identical to `chdman createcd`.** New public
+  `cd` module (`cd.rs`): a pure-Rust **CUE parser** (`parse_cue`, port of `cdrom.cpp:2336` — FILE/
+  TRACK/INDEX/PREGAP/POSTGAP, single- and multi-file BIN, MODE1/MODE2/AUDIO, the audio byte-swap,
+  the `idx0`/`idx1` track-length calc) + **ISO parser** (`parse_iso`, size-inferred single track);
+  `TrackType`/`SubcodeType` enums (+ `type_string`/`subtype_string`); **logical-image assembly**
+  (port of `chd_cd_compressor::read_data` — `(frames+extraframes)*2448` per track, source frames
+  zero-padded into 2448-byte slots, 4-frame `TRACK_PADDING`); **CHT2 metadata** per track; and
+  `create_from_cue`/`create_from_iso` reusing `write::write_create`. **Empirically corrected the
+  CHT2 format** by dumping a real chdman 0.288 CD: the payload is the `CDROM_TRACK_METADATA2_FORMAT`
+  string **+ a single NUL** (`strlen+1` bytes), with **NO trailing space** (the prior handoff note's
+  trailing space was wrong; the live MAME format string has none). Verified byte-identical to
+  `chdman createcd -c cdzl`/`cdlz`: single MODE1/2352 (partial last hunk), **multi-track
+  MODE1+AUDIO+in-file pregap** (V-prefixed PGTYPE), and flat-ISO MODE1/2048. 54 lib/compat tests
+  green (+4 createcd byte-identity, +3 cd unit). Remaining cd: `extractcd`, GDI/Nero, `list_tracks`,
+  `CdCookedReader`, `cdfl`.
 - 2026-06-20: **Phase E started — CD codec encoders, byte-identical to chdman.** Added
   `CdEncoder<Engine, SubEngine>` (`compression/cdrom.rs`), the encode mirror of `CdCodec`: port of
   MAME `chd_cd_compressor::compress` — de-swizzle `[sector(2352)‖subcode(96)]` frames, strip the

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,327 @@
+# chd-rs write support — execution tracker
+
+**Living document.** This is the task-level plan we tick off as we build. Strategy, decisions,
+and rationale live in [PARITY_PLAN.md](PARITY_PLAN.md); codec-crate specs in
+[docs/codec-ports/](docs/codec-ports/); the encode-layer design in
+[docs/encode-integration.md](docs/encode-integration.md). This file tracks *what's done and
+what's next*.
+
+Legend: `[ ]` todo · `[~]` in progress · `[x]` done & verified · `[!]` blocked/needs decision
+
+---
+
+## Current focus
+
+**`chdman createraw` parity is COMPLETE & byte-identical to chdman 0.288** — uncompressed +
+compressed (now **multi-codec**: zlib/huff/lzma/zstd + **flac**), **self-hunk dedup**, header,
+`compress_v5_map`, and SHA-1, all verified end-to-end. All five bit-exact codec encoders are wired
+(flac via `libflac-rs`, round-trip-verified through chdman; byte-identity is libm-gated — see below).
+
+**Now:** **Phases A, B, and the `copy` half of C are done.** A: `codec` module, `flac` encoder,
+multi-codec `write_raw`, `CompressionProgress` + `progress`/`cancel`, public `hd` createraw +
+extract + geometry. B: full **`createhd`** (metadata writer + overall SHA-1 + GDDD/IDNT),
+byte-identical. C: **`copy`** (`copy::copy` + `CopyOptions`) — recompress + clone metadata,
+byte-identical to `chdman copy`. Remaining in C: `write_metadata`/`delete_metadata` on *existing*
+CHDs (splice the on-disk linked list). Then D (`dvd`), E (`cd`), F (parent/diff + `HdImage`),
+G (`info`/`verify`, rchdman).
+
+**Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
+"Verification gates" below. **36 write/compat tests green** (the 5 failing `read_*` tests are
+pre-existing missing-fixture cases, unrelated to write).
+
+---
+
+## Dependencies (codec crates) — status
+
+- [x] `lzma-sdk-rs` v0.2301.0 — byte-exact vs LZMA SDK 23.01 ✅ (aligned)
+- [x] `libflac-rs` v0.143.0 — byte-exact vs libFLAC 1.4.3 ✅ (aligned; glibc-libm caveat). **Wired
+  into chd-rs** (`write` dep) as the raw `flac` encoder (`RawFlacEncoder`, `compression/flac.rs`);
+  `cdfl` + DVD default reuse it later. ⚠️ Byte-identity is **libm-gated**: validated vs glibc libm,
+  but `C:\Tools\chdman` is a Windows/MSVC build → flac is verified **round-trip** (chd-rs encode →
+  chdman `extractraw` reproduces the input), not byte-identity, against this chdman.
+- [x] `libzstd-bitexact-rs` **v0.155.0** — byte-exact vs zstd **1.5.5** ✅ (aligned; published to
+  crates.io 2026-06-19; chd-rs pins `=0.155` and gates `zstd`/`cdzs` behind `write-zstd`).
+  ⚠️ chdman uses **unknown-pledged-size** level 22 → `StreamEncoder::new(22).finish(..)` (NOT
+  `with_pledged_src_size`); `compress(x,22)` is byte-identical for a single `e_end`.
+- [x] **`zlib-bitexact-rs` v0.131.0** — byte-exact vs stock zlib **1.3.1** ✅ (published to
+  crates.io 2026-06-20; wired into chd-rs under `write`, encoder swapped in `compression/zlib.rs`;
+  decoder stays on flate2). **`zlib_bit_exact_vs_chdman` passes** + full `-c zlib` CHD byte-identical
+  to chdman. zlib was the HD default + every CD codec's deflate → now unblocked.
+
+---
+
+## M0 — Foundations
+
+- [x] `write` feature in `chd-rs/chd-rs/Cargo.toml` (off by default; gates all encode code)
+- [x] `CodecEncode` trait (`CompressionEncoder` + `CodecEncodeImplementation`) in `compression/mod.rs`
+- [x] `CodecType::init_encoder(hunk_size)` dispatch (none/zlib/lzma/zstd) — `header.rs`
+- [x] ~~`CodecsEncode` enum~~ — not needed; the driver calls `CodecType::init_encoder` directly.
+- [x] `sha1` dep + SHA-1 generation: `raw_sha1`=SHA1(logical), `sha1`=SHA1(raw_sha1) when no
+      metadata (ref `chd.cpp:1709` `compute_overall_sha1`). *(Metadata-checksummed overall SHA-1
+      lands with the metadata writer, M4.)*
+- [x] Round-trip test harness pattern (encode → existing decode → assert equal)
+- [ ] `NOTICE` attribution for ported BSD-3 algorithms (Aaron Giles / MAME)
+
+## M1 — V5 writer core + `none`/`zlib`
+
+- [x] `NoneEncoder` (copy) + round-trip ✅
+- [x] `ZlibEncoder` — backed by `zlib-bitexact-rs` 0.131 (was flate2/`zlib-rs`, which wasn't
+      byte-exact); round-trip + reject-incompressible tests ✅
+- [x] **zlib bit-exact** — resolved via `zlib-bitexact-rs` 0.131 (`zlib_bit_exact_vs_chdman`
+      passes); the old `zlib-rs` deflate was ~2 bytes off stock zlib 1.3.1. See Dependencies.
+- [x] V5 header writer (124-byte BE layout, verified against chdman) — `write.rs`
+- [x] **Uncompressed CHD writer — byte-identical to `chdman createraw -c none`** ✅
+      (`write_raw_uncompressed`; header + 4-byte map (entry = offset/hunk_bytes) + hunk-aligned
+      data + last-hunk zero-pad; SHA-1 fields zero, as chdman leaves them for uncompressed).
+      End-to-end test `raw_uncompressed_chd_bit_exact_vs_chdman` green (incl. partial last hunk).
+      *Learned:* `createraw` requires `logical_bytes % unit_bytes == 0`.
+- [x] **V5 compressed-map encoder `compress_v5_map` — byte-identical to chdman** ✅
+      (`write.rs`; RLE + 16-code/8-bit Huffman via `export_tree_rle`, per-entry length/crc/self/
+      parent bits, 16-byte header, CRC-16 reusing `block_hash::CRC16`). Isolation test
+      `compress_v5_map_bit_exact_vs_chdman` green (rawmap reconstructed from a chdman CHD).
+- [x] SHA-1 generation (`sha1` dep): `raw_sha1 = SHA1(logical)`, `sha1 = SHA1(raw_sha1)` (no
+      metadata). For uncompressed createraw, SHA-1 fields are zero (chdman behavior).
+- [x] Per-hunk driver (`write_raw_compressed`): codec-or-NONE (`complen < hunk_bytes`),
+      byte-packed data, rawmap build, **+ self-hunk dedup** (a hunk byte-identical to an earlier
+      written one → `COMPRESSION_SELF` ref, keyed by whole-hunk crc16+sha1, first wins — exactly
+      `chd_file_compressor::compress_continue`). Now **fully general** for `createraw` (no-parent).
+- [x] **Compressed CHD byte-identical to chdman** ✅ — `raw_compressed_zlib` (HD default),
+      `raw_compressed_huff` (in-tree), and `raw_compressed_lzma_partial` (external crate + partial
+      last hunk) all green. (Byte-identity ⇒ `chdman verify` passes.)
+- [x] **self-hunk dedup** ✅ (`raw_compressed_dedup` e2e: byte-identical to chdman incl.
+      consecutive/far/zero duplicates). Parent-hunk dedup deferred to M7 (needs parent CHDs).
+
+## M2 — Codec encoders
+
+- [x] `HuffmanEncoder` in-tree ✅ — faithful port of MAME `huffman.cpp` (`build_tree`,
+      `compute_tree_from_histo`, `assign_canonical_codes`, `export_tree_huffman`) + MSB-first
+      `BitWriter` (port of `bitstream_out`) in `huffman_encode.rs`; round-trip green. The
+      `BitWriter` + `HuffEncoder<16,8>` are **reused by the V5 map writer** (M1).
+- [x] `LzmaEncoder` via `lzma-sdk-rs` (`LzmaProps::chd_for_hunk` + `encode`) + round-trip ✅
+      **(cross-crate integration proven)**
+- [x] `RawFlacEncoder` via `libflac-rs` ✅ — `EncoderConfig::chd(blocksize)` + `encode_frames` with
+      the `'L'`/`'B'` both-endian trial (ties → `'L'`), `blocksize = bytes/4 halved while >2048`,
+      and MAME's `hunkbytes-1` overflow guard (`compression/flac.rs`). Round-trip green + chdman
+      `extractraw` of our flac CHD reproduces the input.
+- [x] `ZstdEncoder` via `libzstd-bitexact-rs` 0.155 (`StreamEncoder::new(22).finish`) — gated
+      `write-zstd`; round-trip ✅
+- [x] Per-codec round-trip (none/zlib/lzma/zstd/huff/flac) ✅
+- [x] **Bit-exact vs chdman 0.288** (`chdman_compat` tests, `createraw -c <codec>`, compare our
+      encoder's bytes to chdman's stored compressed bytes per hunk):
+  - [x] **zlib** ✅ · **huff** ✅ · **lzma** ✅ · **zstd** ✅ — all byte-identical to chdman 0.288
+  - [x] **multi-codec** ✅ — `-c lzma,zlib` (per-hunk `find_best_compressor`) byte-identical
+  - [~] **flac** — **round-trip** verified (libm-gated byte-identity; this chdman is MSVC, not glibc)
+
+## M3 — `hd` module + `codec` module
+
+> **API-parity handoff:** [docs/libchdman-parity.md](docs/libchdman-parity.md) maps every
+> libchdman-rs public item → chd-rs equivalent + the phased roadmap (A–G) to full parity.
+
+- [x] `codec` module ✅ — `CHD_CODEC_*` consts, `parse_codec_spec` / `codec_name` / `codec_exists`
+      (`src/codec.rs`, re-exported at crate root, matches libchdman-rs; unconditional, no `write`
+      dep). 3 unit tests + doctest green.
+- [x] `compute_chs` ✅ — faithful port of `guess_chs` (`chdman.cpp:1115`); verified to reproduce
+      chdman's chosen geometry (`hd.rs`).
+- [x] `format_gddd` / `read_geometry` ✅ — `"CYLS:%d,HEADS:%d,SECS:%d,BPS:%d"` + NUL; `read_geometry`
+      parses chdman's `createhd` `GDDD` record.
+- [x] `HdCreateOptions` + `create_raw_from_path`/`create_raw_from_reader` + `extract_to_*` ✅
+      (`hd.rs`; createraw byte-identical, multi-codec, `progress`/`cancel`; extract via the existing
+      decoder).
+- [x] **Full `createhd`** ✅ — `create_from_reader`/`create_from_path` write GDDD (+ optional IDNT)
+      via the metadata writer; byte-identical to `chdman createhd` (`-c none`/`zlib`/`lzma` + IDNT).
+- [x] Tests ✅ — compute_chs vs chdman, GDDD format/parse round-trip, `create_raw` byte-identical +
+      callbacks + cancel, extract round-trip (partial last hunk), `read_geometry` vs chdman,
+      **createhd byte-identical** (none/zlib/lzma + GDDD/IDNT 2-entry list).
+
+## M4 — Metadata write/delete + `copy`
+
+- [x] Metadata linked-list **writer for new files** ✅ — `write::build_metadata_blob` +
+      `compute_overall_sha1` (port of `chd.cpp:1709`: `SHA1(raw_sha1 ‖ sorted[tag(4)‖SHA1(payload)])`),
+      wired into `write_raw_inner` (metadata before hunks) and `write_uncompressed_inner` (after map).
+      Verified via createhd byte-identity. Layout learned: compressed = header→meta→hunks→map
+      (`meta_offset=124`); uncompressed = header→map→meta→pad→data (`meta_offset=124+mapsize`,
+      SHA-1 zero).
+- [ ] `write_metadata` / `delete_metadata` on **existing** CHDs (splice into the on-disk linked
+      list) — Phase C.
+- [x] `CopyOptions` + `copy` ✅ (`copy.rs`) — recompress source logical bytes (preserve
+      unit_bytes; default hunk = source's), clone all metadata in source order with flags. Byte-
+      identical to `chdman copy`.
+- [x] Tests ✅ — HD codec change (none↔zlib, lzma→zlib) byte-identical. (DVD/CD copy come with D/E.)
+
+## M5 — `dvd` module
+
+- [ ] `DvdCreateOptions` (hunk 4096, codecs `[lzma,zlib,huff,flac]`); empty `DVD ` record
+      (note the 1-NUL-byte quirk); create/extract; tests
+
+## M6 — `cd` module
+
+- [ ] CUE/GDI/ISO/Nero TOC parser (pure Rust)
+- [ ] CD wrapper encoders `CdEncoder<E,S>` + `CdFlacEncoder` (split 2048+96, ECC strip via
+      `ecc.rs`, header) — ref `cdrom.rs` decode + `ecc.rs` `generate_ecc`
+- [ ] CHT2 metadata; `TrackInfo`/`TrackType`/`SubcodeType`; `list_tracks`
+- [ ] `create_from_cue`/`create_from_iso`; `extract_to_cue`/`extract_to_iso`/`extract_to_gdi`
+- [ ] Tests: BIN/CUE round-trip, codec matrix, multi-track, GDI
+
+## M7 — Parent/diff + `HdImage`
+
+- [ ] Uncompressed diff children vs compressed parent; parent SHA-1 linkage
+- [ ] `HdImage` block device: `read_sector`/`write_sector`, `open_with_diff`/`reopen_diff`
+
+## M8 — rchdman + docs
+
+- [ ] rchdman: `createhd`/`createcd`/`createdvd`/`copy`/`addmeta`/`delmeta`
+- [ ] Port `docs/format-modules.md` + `docs/chdman-mapping.md`; README rewrite
+
+---
+
+## Verification gates (apply continuously)
+
+- **Byte-for-byte vs chdman 0.288** (the bit-for-bit goal) — `chdman_compat_tests` (dev-local):
+  create the same CHD/codec with chdman and assert the files (or per-hunk codec bytes) are
+  identical. **Implemented**: per-codec bit-exact (zlib/huff/lzma/zstd), `compress_v5_map`, and the
+  full createraw writer (uncompressed/compressed/dedup) — 16 tests. Byte-identity ⇒ `chdman verify`
+  passes for free.
+- Round-trip (encode → chd-rs decode → equal logical bytes) as a fast local gate without chdman.
+
+### Testing oracle — bit-exact verification strategy
+
+Three layers, by who provides the reference:
+
+1. **Codec crates (lzma/flac/zstd)** — already self-verified byte-exact vs their bundled C
+   oracle. Nothing to do in chd-rs beyond the round-trip integration tests (done for
+   lzma/zstd).
+2. **In-tree codec (huff)** — chd-rs's own bytes, verified **directly against chdman 0.288** via
+   the `chdman_compat` tests (byte-identical per hunk). (zlib started in-tree but became its own
+   crate, `zlib-bitexact-rs`, with a vendored-zlib-1.3.1 `cref` oracle.)
+3. **CHD container + end-to-end (header/map/metadata/SHA-1/codec-selection)** — needs a
+   **chdman reference**. ✅ **Oracle available: `C:\Tools\chdman\chdman.exe` (chdman 0.288,
+   mame0288)** — exactly the parity target. The `chdman_compat` test module (in-crate, gated
+   `chdman_compat_tests`) shells out to it. Codec-level bit-exact tests are live (M2) **and the
+   end-to-end container tests are done** (M1: uncompressed/compressed/dedup all byte-identical).
+   ⚠️ FLAC bit-exactness is libm-dependent — confirm the reference chdman is a **glibc** build to
+   match `libflac-rs` (this chdman is the Windows 0.288 build; revisit for flac).
+
+## Open decisions / waiting
+
+- ~~zlib bit-exact deflate~~ — **RESOLVED** (`zlib-bitexact-rs` 0.131, wired + bit-exact).
+- FLAC float parity is validated vs **glibc** libm; the reference chdman here is the Windows
+  0.288 build — revisit when wiring `libflac-rs` (`flac`/`cdfl`).
+
+## API parity (libchdman-rs)
+
+Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phases:
+- [x] **A** — public write surface + `codec` module + flac. ✅ `codec`, `flac` encoder, multi-codec
+  `write_raw`, `CompressionProgress` + `progress`/`cancel`, public `hd` createraw create/extract +
+  geometry helpers, and `docs/libchdman-differences.md` all landed. (createhd-with-GDDD is the only
+  hd item carried into B, since it needs the metadata writer.)
+- [x] **B** — `hd` createhd ✅ — metadata writer (new files) + overall SHA-1 + `create_from_*`
+  writing GDDD (+ optional IDNT), byte-identical to chdman.
+- [~] **C** — `copy` ✅ (`copy::copy`, byte-identical: recompress via `write_raw` + clone metadata,
+  preserve unit_bytes). Remaining: `write_metadata`/`delete_metadata` on *existing* CHDs (splice the
+  on-disk linked list). · [ ] **D** — `dvd` · [ ] **E** — `cd` · [ ] **F** — parent/diff +
+  `HdImage` · [ ] **G** — `Chd::info`/`verify`, rchdman, remaining docs.
+
+## Session log
+
+- 2026-06-20: **Phase C `copy` landed — byte-identical to `chdman copy`.** New `copy` module
+  (`copy::copy` + `CopyOptions{hunk_size:Option<u32>, codecs}`, matching libchdman-rs): open the
+  source, snapshot its metadata in linked-list order, read the full logical image via `ChdReader`
+  (truncated past last-hunk padding), then recompress with `write_raw_inner`/`write_uncompressed_inner`
+  cloning the metadata verbatim (tag/flags/payload) — **unit_bytes preserved**, default hunk = the
+  source's. Factored `resolve_codecs` into `write.rs` (shared by `hd`+`copy`). Verified byte-identical
+  to `chdman copy` for none→zlib (uncompressed→compressed + GDDD clone + overall SHA-1), zlib→none
+  (→uncompressed), and lzma→zlib. CD/GD legacy-metadata re-do is deferred to Phase E. **36
+  write/compat tests green.**
+- 2026-06-20: **Phase B landed — full `createhd`, byte-identical to chdman.** (1) **Metadata
+  writer for new files** (`write.rs`): `MetaEntry` + `build_metadata_blob` (the linked list —
+  `tag(4)+flags(1)+len(3)+next(8)+payload`, `next` chaining each entry, the header's `meta_offset`
+  pointing at the first). (2) **Overall SHA-1** `compute_overall_sha1` — port of `chd.cpp:1709`:
+  `SHA1(raw_sha1 ‖ sorted[ tag(4 BE) ‖ SHA1(payload) ])` over the CHECKSUM-flagged entries, sorted
+  by the 24-byte `(tag,sha1)` memcmp. (3) Wired both into the writers via new `pub(crate)`
+  `write_raw_inner`(+`metadata`) and `write_uncompressed_inner`(+`metadata`); **layout learned
+  empirically**: compressed createhd = header(124)→metadata(@124)→hunks→map; uncompressed =
+  header→map→metadata→pad→data (`meta_offset=124+mapsize`, SHA-1 fields stay zero). Existing
+  createraw byte-identity preserved (empty-metadata path is unchanged). (4) **`hd::create_from_reader`
+  /`create_from_path`** (`createhd`): derive geometry (or use `opts.geometry`), write GDDD (+ optional
+  IDNT), `progress`/`cancel`; refactored the create body into shared `read_and_pad` + `write_create`
+  helpers. **Byte-identical to chdman `createhd`** verified for `-c none` (uncompressed), `-c zlib`
+  and `-c lzma` (compressed → overall SHA-1), and `--ident` (GDDD+IDNT 2-entry list + sorted SHA-1).
+  **33 write/compat tests green**; read-only build clean.
+- 2026-06-20: **Phase A landed (flac + multi-codec + public `hd` surface).** (1) **Wired
+  `libflac-rs`** as `RawFlacEncoder` (`compression/flac.rs`): `EncoderConfig::chd(blocksize)` +
+  `encode_frames` with the `'L'`/`'B'` both-endian trial (ties → `'L'`), `blocksize=bytes/4 halved
+  while >2048`, MAME's `hunkbytes-1` overflow guard; registered in `init_encoder` + codecs exports;
+  added to the `write` feature. Round-trip green and **chdman `extractraw` reproduces our flac CHD**
+  (byte-identity is libm-gated — this chdman is MSVC, libflac-rs is glibc-validated). (2)
+  **Multi-codec `write_raw`** — generalized the single-codec writer to a per-hunk
+  `find_best_compressor` (slot order, strictly-smaller wins, ties → earlier slot), header
+  `compression[0..4]` per slot; `write_raw_compressed` is now `write_raw(.., &[codec])`. `-c
+  lzma,zlib` is **byte-identical to chdman**. Made `CodecType: Copy`. (3) **`CompressionProgress`**
+  `{bytes_done,bytes_total,ratio}` at the crate root + the `progress: &mut dyn FnMut(..)` /
+  `cancel: &dyn Fn()->bool` convention; threaded through `write_raw_inner` (cancel before each hunk
+  → `Error::Cancelled` *before any bytes hit `out`*). (4) **Public `hd` module** — `HdGeometry`,
+  `HdCreateOptions`, `compute_chs` (port of `guess_chs`, verified vs chdman geometry), `format_gddd`
+  /`read_geometry`, and `create_raw_from_reader`/`_path` + `extract_to_writer`/`_path`. createraw is
+  byte-identical; extract truncates past the last hunk's padding. createhd-with-GDDD deferred to
+  Phase B (needs the metadata writer). (5) Added `docs/libchdman-differences.md`. **29 write/compat
+  tests green**; read-only build clean.
+- 2026-06-18: Plan consolidated into this tracker. Codec crates built (lzma/flac aligned, zstd
+  needs 1.5.5 retarget). Integration specced (`docs/encode-integration.md`). Starting M0.
+- 2026-06-18: M0/M1/M2 foundation landed. Added `write` feature, `CompressionEncoder` /
+  `CodecEncodeImplementation` traits, `CodecType::init_encoder` dispatch, and `none`/`zlib`/
+  `lzma` encoders. All three round-trip through the existing decoders (3 tests green); the
+  lzma path wires the `lzma-sdk-rs` sibling crate (path dep, `write` feature) and proves the
+  cross-crate integration end-to-end. Read-only (no-`write`) build unaffected. Remaining
+  warnings in the `write` build are expected "never used" on the encoders until the M1 driver
+  calls them.
+- 2026-06-19: zstd drift **resolved** — `libzstd-bitexact-rs` 0.155 (byte-exact vs zstd 1.5.5)
+  published. Wired `ZstdEncoder` behind a new `write-zstd` feature using
+  `StreamEncoder::new(22).finish(..)` (chdman's unknown-pledged-size level-22 path); round-trip
+  green (the windowLog-27/LDM frame decodes through chd-rs's ruzstd decoder). 4 encode tests
+  pass. Four codecs done: none/zlib/lzma/zstd.
+- 2026-06-19: `HuffmanEncoder` ported in-tree (`huffman_encode.rs`): faithful MAME
+  `huffman.cpp` encode path + MSB-first `BitWriter` (port of `bitstream_out`). Round-trip green.
+  Five codecs done: none/zlib/lzma/zstd/huff. Added the testing-oracle strategy (above): codec
+  crates self-verify; zlib/huff can self-verify via a vendored C oracle; the CHD container needs
+  a chdman reference (chdman not on PATH — needs a binary or a libchdman-rs build).
+- 2026-06-19: **Oracle wired** — `C:\Tools\chdman\chdman.exe` (chdman **0.288**, the parity
+  target). Built the `chdman_compat` test module (`createraw -c <codec>` → compare our encoder's
+  bytes to chdman's stored compressed bytes per hunk). **Result: huff ✅, lzma ✅, zstd ✅ are
+  byte-identical to chdman 0.288.** **zlib ✗** — `zlib-rs` 0.4.2 deflate ≠ stock zlib 1.3.1
+  (2 bytes smaller); test `#[ignore]`-d pending a bit-exact deflate. zlib is the HD default →
+  **DECISION NEEDED: port stock-zlib-1.3.1 deflate (4th codec crate) vs link C zlib.** Next:
+  V5 writer core, verified end-to-end against chdman using a confirmed-bit-exact codec.
+- 2026-06-19: **First end-to-end bit-exact writer** — `write_raw_uncompressed` (`write.rs`)
+  produces a complete uncompressed CHD **byte-identical to `chdman createraw -c none`** (header,
+  4-byte map, hunk-aligned data, partial-last-hunk pad; SHA-1 fields zero as chdman leaves them).
+  Decoded the V5 layout empirically from chdman output. Learned `createraw` needs
+  `logical_bytes % unit_bytes == 0`. Next: the compressed writer core (`compress_v5_map` + SHA-1
+  + per-hunk driver).
+- 2026-06-20: **libchdman-rs API-parity handoff written** (`docs/libchdman-parity.md`) — the full
+  API map (every public item → chd-rs equivalent, marked exists/differs/done/to-build), the
+  `Chd<F>`-reader vs owned-handle reconciliation policy (keep chd-rs idioms, add parity surface as
+  free functions, document divergences), and the phased roadmap A–G. Started Phase A: shipped the
+  `codec` module (`CHD_CODEC_*`, `parse_codec_spec`/`codec_name`/`codec_exists`) matching
+  libchdman-rs, re-exported at the crate root. Remaining Phase A: flac wiring + public hd
+  create/extract + `CompressionProgress`.
+- 2026-06-20: **Self-hunk dedup — DONE.** `write_raw_compressed` now reproduces
+  `chd_file_compressor::compress_continue`: per-hunk it computes the whole-hunk crc16+sha1, and a
+  hunk byte-identical to an earlier *written* hunk becomes a `COMPRESSION_SELF` ref
+  (`type=5, complen=0, offset=refhunk, crc=0`) instead of being re-stored (first occurrence wins;
+  SELF hunks aren't re-added). `compress_v5_map`'s SELF_0/SELF_1 promotions handle the encoding.
+  `raw_compressed_dedup` e2e (10 hunks w/ consecutive, far, and zero duplicates) is byte-identical
+  to chdman. **`createraw` is now fully general.** 16 write/compat tests green.
+- 2026-06-20: **zlib bit-exact — DONE.** `zlib-bitexact-rs` 0.131.0 (byte-exact stock zlib 1.3.1)
+  published + wired into chd-rs (`write` dep; encoder swapped in `compression/zlib.rs`, decoder
+  stays flate2). Un-ignored `zlib_bit_exact_vs_chdman` → passes; added `raw_compressed_zlib` e2e →
+  full `-c zlib` CHD byte-identical to chdman. **All four primary codecs (zlib/huff/lzma/zstd) now
+  byte-identical to chdman 0.288**, and the HD default is unblocked. 15 write/compat tests green.
+  Integration handoff: `docs/codec-ports/zlib-bitexact-integration.md`.
+- 2026-06-19: **Compressed V5 writer core DONE & byte-identical to chdman 0.288.** Ported
+  `compress_v5_map` (verified byte-exact in isolation against chdman's stored map), added SHA-1
+  (`raw_sha1`=SHA1(logical), `sha1`=SHA1(raw_sha1)), and the per-hunk driver
+  (`write_raw_compressed`: codec-or-NONE, byte-packed data, compressed map at EOF). Full
+  end-to-end CHDs match chdman byte-for-byte: `-c huff` (in-tree codec) and `-c lzma` (external
+  crate + partial last hunk). Compressed layout: header(124) → byte-packed hunks → compressed
+  map at `map_offset`. 13 write/compat tests green (5 pre-existing read fixture failures
+  unrelated). Remaining: self/parent dedup, public API wrapper, flac wiring, format modules.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -28,7 +28,7 @@ GDDD/IDNT). C: **`copy`** + **`write_metadata`/`delete_metadata`** on existing C
 G (`info`/`verify`, rchdman).
 
 **Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
-"Verification gates" below. **58 write/compat/unit tests green** (+2 `#[ignore]`d glibc-chdman FLAC
+"Verification gates" below. **62 write/compat/unit tests green** (+2 `#[ignore]`d glibc-chdman FLAC
 dump checks; the 5 failing `read_*` tests are pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`) and **verified green on GitHub Actions** (all 4 jobs:
 lint + test on ubuntu/windows/macos): clones the sibling codec crates at their tags (they're public),
 then `cargo build -p chd` + `cargo test -p chd --features write-zstd -- --skip tests::read` + fmt.
@@ -198,11 +198,18 @@ decision (may become a new crate).
       `TrackInfo` reading `CHT2`/`CHTR` (port of `parse_metadata`). **Byte-identical to `chdman
       extractcd`** (cue **and** bin) + create→extract round-trip. (chdman writes the cue in text mode
       → CRLF on Windows, LF on Linux; chd-rs matches the host platform.)
-- [x] **Tests** ✅ — `createcd -c cdzl`/`cdlz` byte-identical (single MODE1/2352 partial-last-hunk,
-      **multi-track MODE1+AUDIO+in-file pregap**, flat-ISO MODE1/2048); `cdfl` round-trip + byte-
-      identical vs glibc chdman; **`extractcd` cue+bin byte-identical** (single + multi-track);
-      `list_tracks` reads CHT2.
-- [ ] GDI/Nero parser; `.gdi`/split-bin extract; `extract_to_iso`; `CdCookedReader`
+- [x] **`create_from_gdi` + `extract_to_gdi`** ✅ — Sega Dreamcast `.gdi` (GD-ROM): port of
+      `parse_gdi` + `do_extract_cd` `MODE_GDI`. `padframes` area-gap fill, audio swap, `CHGD`
+      metadata, split per-track files (`<stem>NN.bin`/`.raw`). **Byte-identical to `chdman`** both
+      ways (3-track data/audio/data synthetic GDI).
+- [x] **`extract_to_iso` + `CdCookedReader`** ✅ — single MODE1 track's cooked 2048-byte user data
+      (sync/ECC stripped at offset 16 for raw, 0 for cooked); `CdCookedReader` is `Read+Seek`.
+      Round-trip verified (chdman has no CD→iso command).
+- [x] **Tests** ✅ — `createcd -c cdzl`/`cdlz` byte-identical (single/multi-track/ISO); `cdfl`
+      byte-identical vs glibc chdman; **`extractcd` cue+bin**, **`createcd`/`extractcd` GDI**, all
+      byte-identical; `extract_to_iso`/`CdCookedReader` round-trip; `list_tracks` reads CHT2.
+- [ ] Nero (`.nrg`) TOC parser — **deferred**: binary format, no way to generate a fixture (chdman
+      can't write `.nrg`), so it can't be verified to the byte-identity bar. Documented gap.
 
 ## M7 — Parent/diff + `HdImage`
 
@@ -267,6 +274,18 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
 
 ## Session log
 
+- 2026-06-20: **CD niche formats — GDI (both ways), `extract_to_iso`, `CdCookedReader`.** (1)
+  **`CdCookedReader`** (`Read+Seek` over a MODE1 track's cooked 2048-byte user data; sync/ECC stripped
+  at offset 16 for raw, 0 for cooked) + **`extract_to_iso`** (single MODE1 → raw iso) — round-trip
+  verified. (2) **`create_from_gdi`** (port of `parse_gdi`): `.gdi` index → GD-ROM CHD; added
+  `padframes` to the track model (area-gap fill: read only `frames-padframes` real sectors,
+  zero-fill the rest), `CHGD` metadata (`GDROM_TRACK_METADATA_FORMAT`, a `PAD:` field + plain pregap
+  type) via a `gdrom` flag through `build_cd`. (3) **`extract_to_gdi`** (port of `do_extract_cd`
+  `MODE_GDI`): `.gdi` index + split `<stem>NN.bin`/`.raw` per-track files; extended the readback
+  parser for `CHGD`/`CHGT` + `PAD`. **Both GDI directions byte-identical to chdman** (synthetic
+  3-track data/audio/data GDI w/ small LBA gaps). **Nero (`.nrg`) deferred** — binary format,
+  unverifiable without a fixture chdman can't produce. 62 lib/compat tests green (+4). The CD
+  create/extract surface is now complete bar Nero.
 - 2026-06-20: **`extractcd` (cue/bin) + `list_tracks` — byte-identical to `chdman extractcd`.**
   `cd::extract_to_cue` (port of `do_extract_cd` `MODE_CUEBIN` + `output_track_metadata`,
   chdman.cpp:2638/1525): read the `CHT2`/`CHTR` track table (`read_track_metas`, port of

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -28,8 +28,8 @@ GDDD/IDNT). C: **`copy`** + **`write_metadata`/`delete_metadata`** on existing C
 G (`info`/`verify`, rchdman).
 
 **Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
-"Verification gates" below. **54 write/compat/unit tests green** (the 5 failing `read_*` tests are
-pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`) and **verified green on GitHub Actions** (all 4 jobs:
+"Verification gates" below. **55 write/compat/unit tests green** (+2 `#[ignore]`d glibc-chdman FLAC
+dump checks; the 5 failing `read_*` tests are pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`) and **verified green on GitHub Actions** (all 4 jobs:
 lint + test on ubuntu/windows/macos): clones the sibling codec crates at their tags (they're public),
 then `cargo build -p chd` + `cargo test -p chd --features write-zstd -- --skip tests::read` + fmt.
 **`Chd::info()` + `ChdInfo`** (read-side) also landed (Phase G partial).
@@ -177,7 +177,8 @@ decision (may become a new crate).
       ECC strip for verifiable data sectors via `ecc.rs`, `[ecc_flags‖complen‖sector‖subcode]`
       header). `CdZlibEncoder`/`CdLzmaEncoder`/`CdZstdEncoder`; wired into `init_encoder`.
       **`cdzl`/`cdlz` byte-identical to chdman** (per-hunk, MODE1 ECC-strip path) + round-trip.
-      `CdFlacEncoder` (cdfl) still TODO (libm-gated; FLAC base + zlib subcode, no ECC strip).
+      **`cdfl` (`CdFlacEncoder`) DONE** — separate path (FLAC base + zlib subcode, *no* ECC strip/
+      header); byte-identical to a glibc chdman (libm-gated). See the M6 cdfl entry below.
 - [x] **CUE + ISO TOC parser** (pure Rust) ✅ — `parse_cue` (port of `cdrom.cpp:2336`: FILE/TRACK/
       INDEX/PREGAP/POSTGAP, single- and multi-file BIN, the common MODE1/MODE2/AUDIO types, audio
       byte-swap, 4-frame track padding) + `parse_iso` (size-inferred single track). GDI/Nero still TODO.
@@ -187,9 +188,14 @@ decision (may become a new crate).
 - [x] **`create_from_cue`/`create_from_iso`** ✅ — assemble the 2448-frame logical image (port of
       `chd_cd_compressor::read_data`) + CHT2 + `write_create`; **byte-identical to `chdman createcd`**.
       `extract_to_cue`/`extract_to_iso`/`extract_to_gdi` still TODO.
-- [x] **Tests** ✅ — `createcd -c cdzl`/`cdlz` byte-identical: single MODE1/2352 (partial last hunk),
-      **multi-track MODE1+AUDIO+in-file pregap** (V-prefixed PGTYPE, swap), and flat-ISO MODE1/2048.
-- [ ] GDI/Nero parser; `extractcd` (→cue/bin/gdi); `CdCookedReader`; `list_tracks`; `cdfl` encoder
+- [x] **`cdfl` encoder** ✅ — `CdFlacEncoder` (`compression/flac.rs`): FLAC sector run (big-endian
+      samples, no ECC strip, no header) + zlib subcode, port of `chd_cd_flac_compressor`. **Verified
+      byte-identical to a glibc-built chdman 0.288** (`createcd -c cdfl`); libm-gated like raw `flac`
+      (round-trip-correct against the MSVC oracle). The `cd` default `[cdlz,cdzl,cdfl,0]` now works.
+- [x] **Tests** ✅ — `createcd -c cdzl`/`cdlz` byte-identical (single MODE1/2352 partial-last-hunk,
+      **multi-track MODE1+AUDIO+in-file pregap**, flat-ISO MODE1/2048); `cdfl` round-trip + byte-
+      identical vs glibc chdman (`dump_cdfl_artifacts_for_glibc_check`).
+- [ ] GDI/Nero parser; `extractcd` (→cue/bin/gdi); `CdCookedReader`; `list_tracks`
 
 ## M7 — Parent/diff + `HdImage`
 
@@ -254,6 +260,18 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
 
 ## Session log
 
+- 2026-06-20: **`cdfl` encoder DONE + built a glibc chdman 0.288 to prove FLAC byte-identity.**
+  (1) Built **chdman 0.288 from MAME source in WSL** (Ubuntu 24.04, g++ 13.3): `make TOOLS=1 OSD=sdl
+  USE_QTDEBUG=0 generate` then build only the `chdman` GENie target (pulls util + bundled 3rdparty,
+  not the emulator). (2) **Proved the libm-gating theory**: chd-rs's raw `flac` CHD is **byte-for-byte
+  identical** to this glibc chdman (`dump_flac_artifacts_for_glibc_check` → 2769==2769 bytes) — the
+  MSVC-vs-glibc libm was the only prior difference. (3) **`CdFlacEncoder`** (`compression/flac.rs`):
+  port of `chd_cd_flac_compressor::compress` (chdcodec.cpp:1634) — de-swizzle (NO ECC strip), FLAC
+  the sector run as big-endian int16 stereo (blocksize halves while >2352, NO endian flag byte),
+  raw-deflate the subcode, emit `[flac‖deflate]` (no header). Wired into `init_encoder` (`FlacCdV5`).
+  **Verified byte-identical to glibc chdman `createcd -c cdfl`** (`dump_cdfl_artifacts_for_glibc_check`
+  → 11822==11822 bytes) + round-trip. The `cd` default `[cdlz,cdzl,cdfl,0]` now works. 55 lib/compat
+  tests green (+cdfl round-trip; +2 `#[ignore]`d glibc dump tests).
 - 2026-06-20: **Phase E `createcd` container — byte-identical to `chdman createcd`.** New public
   `cd` module (`cd.rs`): a pure-Rust **CUE parser** (`parse_cue`, port of `cdrom.cpp:2336` — FILE/
   TRACK/INDEX/PREGAP/POSTGAP, single- and multi-file BIN, MODE1/MODE2/AUDIO, the audio byte-swap,

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -17,16 +17,17 @@ compressed (now **multi-codec**: zlib/huff/lzma/zstd + **flac**), **self-hunk de
 `compress_v5_map`, and SHA-1, all verified end-to-end. All five bit-exact codec encoders are wired
 (flac via `libflac-rs`, round-trip-verified through chdman; byte-identity is libm-gated — see below).
 
-**Now:** **Phases A, B, C-`copy`, and D are done.** A: `codec` module, `flac` encoder, multi-codec
+**Now:** **Phases A, B, C, and D are done.** A: `codec` module, `flac` encoder, multi-codec
 `write_raw`, `CompressionProgress` + `progress`/`cancel`, public `hd` createraw + extract + geometry.
-B: full **`createhd`** (metadata writer + overall SHA-1 + GDDD/IDNT). C: **`copy`** (recompress +
-clone metadata). D: **`dvd`** (`createdvd`/`extractdvd`, `DVD ` record). All byte-identical to
-chdman 0.288. Remaining: C's `write_metadata`/`delete_metadata` on *existing* CHDs; then E (`cd`),
-F (parent/diff + `HdImage`), G (`info`/`verify`, rchdman).
+B: full **`createhd`** (metadata writer + overall SHA-1 + GDDD/IDNT). C: **`copy`** +
+**`write_metadata`/`delete_metadata`** on existing CHDs. D: **`dvd`** (`createdvd`/`extractdvd`).
+All byte-identical to chdman 0.288. Remaining: **E (`cd`)** — the big one (TOC parser, CD codecs,
+ECC, CHT2); then F (parent/diff + `HdImage`), G (`info`/`verify`, rchdman).
 
 **Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
-"Verification gates" below. **40 write/compat tests green** (the 5 failing `read_*` tests are
-pre-existing missing-fixture cases, unrelated to write).
+"Verification gates" below. **42 write/compat tests green** (the 5 failing `read_*` tests are
+pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`):
+clones the sibling codec crates at their tags, then builds/tests on ubuntu/windows/macos + fmt.
 
 **CI:** chd-rs has **no CI** (siblings do). Blocked: the `write` feature's optional **path deps** on
 the sibling crates (`../../lzma-sdk-rs`, …) make even the default build's dependency resolution fail
@@ -146,8 +147,11 @@ decision (may become a new crate).
       Verified via createhd byte-identity. Layout learned: compressed = header→meta→hunks→map
       (`meta_offset=124`); uncompressed = header→map→meta→pad→data (`meta_offset=124+mapsize`,
       SHA-1 zero).
-- [ ] `write_metadata` / `delete_metadata` on **existing** CHDs (splice into the on-disk linked
-      list) — Phase C.
+- [x] `write_metadata` / `delete_metadata` on **existing** CHDs ✅ (`metadata.rs`, gated `write`) —
+      free fns over `Read+Write+Seek`; overwrite-in-place-or-append + relink + overall-SHA-1 update
+      (compressed only). Byte-identical to `chdman addmeta`/`delmeta` (which only edit *uncompressed*
+      CHDs — MAME refuses a writeable open of a compressed one; chd-rs additionally handles
+      compressed correctly). Ports `metadata_find`/`metadata_set_previous_next`/`metadata_update_hash`.
 - [x] `CopyOptions` + `copy` ✅ (`copy.rs`) — recompress source logical bytes (preserve
       unit_bytes; default hunk = source's), clone all metadata in source order with flags. Byte-
       identical to `chdman copy`.
@@ -225,14 +229,25 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
   hd item carried into B, since it needs the metadata writer.)
 - [x] **B** — `hd` createhd ✅ — metadata writer (new files) + overall SHA-1 + `create_from_*`
   writing GDDD (+ optional IDNT), byte-identical to chdman.
-- [~] **C** — `copy` ✅ (`copy::copy`, byte-identical). Remaining: `write_metadata`/`delete_metadata`
-  on *existing* CHDs (splice the on-disk linked list).
+- [x] **C** — `copy` ✅ + `write_metadata`/`delete_metadata` on existing CHDs ✅ — all byte-identical.
 - [x] **D** — `dvd` ✅ — `createdvd`/`extractdvd` byte-identical (`DVD ` record, 2048 sectors).
 - [ ] **E** — `cd` · [ ] **F** — parent/diff + `HdImage` · [ ] **G** — `Chd::info`/`verify`,
   rchdman, remaining docs.
 
 ## Session log
 
+- 2026-06-20: **Phase C completed (metadata write/delete) + CI added.** (1) `metadata::write_metadata`
+  /`delete_metadata` for existing V5 CHDs (`Read+Write+Seek` free fns): ports of
+  `metadata_find`/`metadata_set_previous_next`/`metadata_update_hash` — overwrite-in-place-or-append
+  + relink, overall-SHA-1 recompute on write (compressed only). **Byte-identical to `chdman
+  addmeta`/`delmeta`.** Learned chdman only edits *uncompressed* CHDs (MAME refuses a writeable open
+  of a compressed one → "File not writeable"); chd-rs's fns also handle compressed correctly. (2)
+  **CI** (`.github/workflows/ci.yml`, user chose the "clone siblings" approach): clones the four
+  sibling codec crates at their tags into the checkout's parent (so `../../<crate>` path deps
+  resolve), then `cargo build -p chd` + `cargo test -p chd --features write-zstd -- --skip
+  tests::read` on ubuntu/windows/macos, plus a `cargo fmt -p chd --check` lint job. (The 3
+  crate-level doctests were already fixed; clippy isn't `-D warnings` yet — legacy lints.) 42
+  write/compat tests green.
 - 2026-06-20: **Phase D `dvd` landed — byte-identical to `chdman createdvd`.** New `dvd` module
   (`DvdCreateOptions`, `create_from_reader`/`create_from_iso`, `extract_to_writer`/`extract_to_iso`,
   `DVD_SECTOR_SIZE`/`DEFAULT_HUNK_SIZE`). It's createhd with a `DVD ` record (1-NUL payload — chdman

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -28,7 +28,7 @@ GDDD/IDNT). C: **`copy`** + **`write_metadata`/`delete_metadata`** on existing C
 G (`info`/`verify`, rchdman).
 
 **Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
-"Verification gates" below. **62 write/compat/unit tests green** (+2 `#[ignore]`d glibc-chdman FLAC
+"Verification gates" below. **65 write/compat/unit tests green** (+2 `#[ignore]`d glibc-chdman FLAC
 dump checks; the 5 failing `read_*` tests are pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`) and **verified green on GitHub Actions** (all 4 jobs:
 lint + test on ubuntu/windows/macos): clones the sibling codec crates at their tags (they're public),
 then `cargo build -p chd` + `cargo test -p chd --features write-zstd -- --skip tests::read` + fmt.
@@ -211,10 +211,18 @@ decision (may become a new crate).
 - [ ] Nero (`.nrg`) TOC parser — **deferred**: binary format, no way to generate a fixture (chdman
       can't write `.nrg`), so it can't be verified to the byte-identity bar. Documented gap.
 
-## M7 — Parent/diff + `HdImage`
+## M7 — Parent/diff + `HdImage` ✅
 
-- [ ] Uncompressed diff children vs compressed parent; parent SHA-1 linkage
-- [ ] `HdImage` block device: `read_sector`/`write_sector`, `open_with_diff`/`reopen_diff`
+- [x] **Compressed child vs parent** ✅ — `hd::create_raw_from_path_with_parent` (chdman
+      `createraw -op`): `write::build_parent_ref` (port of `async_walk_parent` + the `compress_continue`
+      hashmap — sliding `hunk_bytes` windows at every unit offset, last hunk → 1 window, first wins) +
+      `write_raw_inner` parent hook (SELF then PARENT priority; emits `COMPRESSION_PARENT(unit)`;
+      `parent_sha1` header link). **Byte-identical to chdman** (16-hunk child, 13 parent refs).
+- [x] **`HdImage` block device** ✅ — `open` (uncompressed in-place), `open_with_diff`/`reopen_diff`
+      (uncompressed diff over a compressed parent: unwritten hunks fall through, writes materialise
+      the hunk + rewrite its 4-byte map entry), `read_sector`/`write_sector`/`sector_count`/`geometry`.
+      `write::write_empty_diff` builds the initial diff. Round-trip verified **and chdman
+      `extracthd -ip` reads our diff** (chdman-compatible format).
 
 ## M8 — rchdman + docs
 
@@ -267,13 +275,28 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
   writing GDDD (+ optional IDNT), byte-identical to chdman.
 - [x] **C** — `copy` ✅ + `write_metadata`/`delete_metadata` on existing CHDs ✅ — all byte-identical.
 - [x] **D** — `dvd` ✅ — `createdvd`/`extractdvd` byte-identical (`DVD ` record, 2048 sectors).
-- [~] **E** — `cd`: CD codec encoders (cdzl/cdlz/cdzs) ✅ **and `createcd` (CUE/ISO parser + CHT2 +
-  `create_from_cue`/`create_from_iso`) byte-identical** ✅; remaining = `extractcd`, GDI/Nero,
-  `list_tracks`, `CdCookedReader`, `cdfl`. · [ ] **F** — parent/diff + `HdImage` ·
-  [~] **G** — `Chd::info` ✅ + `ChdInfo`; `verify` (needs a read-side SHA-1 dep) + rchdman + docs.
+- [x] **E** — `cd` ✅ — createcd (CUE/ISO/GDI) + extractcd (cue/bin/gdi) + `extract_to_iso` +
+  `CdCookedReader` + `list_tracks`, all byte-identical (or round-trip where chdman has no command);
+  all four codecs incl. glibc-verified `cdfl`. Only Nero (`.nrg`) deferred (unverifiable).
+- [x] **F** — parent/diff + `HdImage` ✅ — `create_raw_from_path_with_parent` (compressed child,
+  byte-identical to `createraw -op`) + `HdImage` (uncompressed diff + sector R/W; chdman reads it).
+- [~] **G** — `Chd::info` ✅ + `ChdInfo`; `verify` (needs a read-side SHA-1 dep) + rchdman + docs.
 
 ## Session log
 
+- 2026-06-20: **Phase F COMPLETE — parent/diff + `HdImage`.** (1) **`HdImage`** (`hd.rs`): a
+  read/write block-device view over an uncompressed HD CHD. `open` (in-place), `open_with_diff`/
+  `reopen_diff` (uncompressed **diff** over a compressed parent — unwritten hunks fall through to the
+  parent, writes materialise the hunk into the diff and rewrite its 4-byte map entry), `read_sector`/
+  `write_sector`/`sector_count`/`geometry`. chd-rs's `Chd` is read-only, so `HdImage` holds the diff
+  as a raw R/W `File` + an in-memory map and keeps the parent open as a read-only `Chd`. New
+  `write::write_empty_diff` builds the initial diff (header + all-zero map + cloned metadata). Verified
+  round-trip **and chdman `extracthd -ip` reads our diff**. (2) **Compressed child** (`createraw -op`):
+  `write::build_parent_ref` (port of `async_walk_parent` + `compress_continue` hashmap — sliding
+  `hunk_bytes` windows at every unit offset, 1 window for the last hunk, first wins) + a parent hook in
+  `write_raw_inner` (SELF-then-PARENT priority, emits `COMPRESSION_PARENT(unit)`, `parent_sha1` link).
+  `hd::create_raw_from_path_with_parent` **byte-identical to `chdman createraw -op`** (16-hunk child,
+  13 parent refs). 65 lib/compat tests green (+3). Next: G (`verify` + rchdman + docs).
 - 2026-06-20: **CD niche formats — GDI (both ways), `extract_to_iso`, `CdCookedReader`.** (1)
   **`CdCookedReader`** (`Read+Seek` over a MODE1 track's cooked 2048-byte user data; sync/ECC stripped
   at offset 16 for raw, 0 for cooked) + **`extract_to_iso`** (single MODE1 → raw iso) — round-trip

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -28,7 +28,7 @@ GDDD/IDNT). C: **`copy`** + **`write_metadata`/`delete_metadata`** on existing C
 G (`info`/`verify`, rchdman).
 
 **Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
-"Verification gates" below. **55 write/compat/unit tests green** (+2 `#[ignore]`d glibc-chdman FLAC
+"Verification gates" below. **58 write/compat/unit tests green** (+2 `#[ignore]`d glibc-chdman FLAC
 dump checks; the 5 failing `read_*` tests are pre-existing missing-fixture cases, unrelated to write). **CI** added (`.github/workflows/ci.yml`) and **verified green on GitHub Actions** (all 4 jobs:
 lint + test on ubuntu/windows/macos): clones the sibling codec crates at their tags (they're public),
 then `cargo build -p chd` + `cargo test -p chd --features write-zstd -- --skip tests::read` + fmt.
@@ -192,10 +192,17 @@ decision (may become a new crate).
       samples, no ECC strip, no header) + zlib subcode, port of `chd_cd_flac_compressor`. **Verified
       byte-identical to a glibc-built chdman 0.288** (`createcd -c cdfl`); libm-gated like raw `flac`
       (round-trip-correct against the MSVC oracle). The `cd` default `[cdlz,cdzl,cdfl,0]` now works.
+- [x] **`extractcd` (cue/bin) + `list_tracks`** ✅ — `cd::extract_to_cue` (port of `do_extract_cd`
+      `MODE_CUEBIN` + `output_track_metadata`: reconstruct the combined BIN — `frames`×`datasize`,
+      audio byte-swapped back, padding dropped, subcode omitted — and the CUE), `list_tracks`/
+      `TrackInfo` reading `CHT2`/`CHTR` (port of `parse_metadata`). **Byte-identical to `chdman
+      extractcd`** (cue **and** bin) + create→extract round-trip. (chdman writes the cue in text mode
+      → CRLF on Windows, LF on Linux; chd-rs matches the host platform.)
 - [x] **Tests** ✅ — `createcd -c cdzl`/`cdlz` byte-identical (single MODE1/2352 partial-last-hunk,
       **multi-track MODE1+AUDIO+in-file pregap**, flat-ISO MODE1/2048); `cdfl` round-trip + byte-
-      identical vs glibc chdman (`dump_cdfl_artifacts_for_glibc_check`).
-- [ ] GDI/Nero parser; `extractcd` (→cue/bin/gdi); `CdCookedReader`; `list_tracks`
+      identical vs glibc chdman; **`extractcd` cue+bin byte-identical** (single + multi-track);
+      `list_tracks` reads CHT2.
+- [ ] GDI/Nero parser; `.gdi`/split-bin extract; `extract_to_iso`; `CdCookedReader`
 
 ## M7 — Parent/diff + `HdImage`
 
@@ -260,6 +267,17 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
 
 ## Session log
 
+- 2026-06-20: **`extractcd` (cue/bin) + `list_tracks` — byte-identical to `chdman extractcd`.**
+  `cd::extract_to_cue` (port of `do_extract_cd` `MODE_CUEBIN` + `output_track_metadata`,
+  chdman.cpp:2638/1525): read the `CHT2`/`CHTR` track table (`read_track_metas`, port of
+  `parse_metadata`), decode the logical image via `ChdReader`, and per track emit `frames`×`datasize`
+  bytes (audio byte-pair-swapped back to LE, 4-frame padding dropped, subcode omitted) into one
+  combined BIN + a CUE (`FILE` once, then `TRACK`/`INDEX 00/01`/`PREGAP`/`POSTGAP`). `list_tracks` →
+  `Vec<TrackInfo>`. **Byte-identical to `chdman extractcd -o cue -ob bin`** (cue **and** bin) for
+  single MODE1/2352 and multi-track MODE1+AUDIO+pregap, plus a full create→extract round-trip (the
+  extracted bin == the original). **Learned: chdman writes the cue in text mode → CRLF on Windows /
+  LF on Linux**; chd-rs matches the host platform (`#[cfg(windows)]` `\n`→`\r\n`). 58 lib/compat
+  tests green (+3). Remaining cd: GDI/Nero, `.gdi`/split-bin extract, `extract_to_iso`, `CdCookedReader`.
 - 2026-06-20: **`cdfl` encoder DONE + built a glibc chdman 0.288 to prove FLAC byte-identity.**
   (1) Built **chdman 0.288 from MAME source in WSL** (Ubuntu 24.04, g++ 13.3): `make TOOLS=1 OSD=sdl
   USE_QTDEBUG=0 generate` then build only the `chdman` GENie target (pulls util + bundled 3rdparty,

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -17,17 +17,22 @@ compressed (now **multi-codec**: zlib/huff/lzma/zstd + **flac**), **self-hunk de
 `compress_v5_map`, and SHA-1, all verified end-to-end. All five bit-exact codec encoders are wired
 (flac via `libflac-rs`, round-trip-verified through chdman; byte-identity is libm-gated — see below).
 
-**Now:** **Phases A, B, and the `copy` half of C are done.** A: `codec` module, `flac` encoder,
-multi-codec `write_raw`, `CompressionProgress` + `progress`/`cancel`, public `hd` createraw +
-extract + geometry. B: full **`createhd`** (metadata writer + overall SHA-1 + GDDD/IDNT),
-byte-identical. C: **`copy`** (`copy::copy` + `CopyOptions`) — recompress + clone metadata,
-byte-identical to `chdman copy`. Remaining in C: `write_metadata`/`delete_metadata` on *existing*
-CHDs (splice the on-disk linked list). Then D (`dvd`), E (`cd`), F (parent/diff + `HdImage`),
-G (`info`/`verify`, rchdman).
+**Now:** **Phases A, B, C-`copy`, and D are done.** A: `codec` module, `flac` encoder, multi-codec
+`write_raw`, `CompressionProgress` + `progress`/`cancel`, public `hd` createraw + extract + geometry.
+B: full **`createhd`** (metadata writer + overall SHA-1 + GDDD/IDNT). C: **`copy`** (recompress +
+clone metadata). D: **`dvd`** (`createdvd`/`extractdvd`, `DVD ` record). All byte-identical to
+chdman 0.288. Remaining: C's `write_metadata`/`delete_metadata` on *existing* CHDs; then E (`cd`),
+F (parent/diff + `HdImage`), G (`info`/`verify`, rchdman).
 
 **Verification oracle:** `C:\Tools\chdman\chdman.exe` (0.288, the parity target). See
-"Verification gates" below. **36 write/compat tests green** (the 5 failing `read_*` tests are
+"Verification gates" below. **40 write/compat tests green** (the 5 failing `read_*` tests are
 pre-existing missing-fixture cases, unrelated to write).
+
+**CI:** chd-rs has **no CI** (siblings do). Blocked: the `write` feature's optional **path deps** on
+the sibling crates (`../../lzma-sdk-rs`, …) make even the default build's dependency resolution fail
+in a fresh checkout. Unblock = switch to crates.io **version deps** (all four siblings are
+published/tagged) + a workspace `[patch.crates-io]` for local dev. Deferred pending the crate-identity
+decision (may become a new crate).
 
 ---
 
@@ -150,8 +155,12 @@ pre-existing missing-fixture cases, unrelated to write).
 
 ## M5 — `dvd` module
 
-- [ ] `DvdCreateOptions` (hunk 4096, codecs `[lzma,zlib,huff,flac]`); empty `DVD ` record
-      (note the 1-NUL-byte quirk); create/extract; tests
+- [x] `DvdCreateOptions` (hunk 4096, codecs `[lzma,zlib,huff,flac]`, unit 2048) ✅
+- [x] `create_from_reader`/`create_from_iso` + `extract_to_writer`/`extract_to_iso` ✅ — empty
+      `DVD ` record (the 1-NUL-byte quirk: chdman's `write_metadata(.., "")` stores the string's NUL
+      terminator → 1-byte payload). Reuses the createhd machinery (`DVD ` instead of GDDD).
+- [x] Tests ✅ — `createdvd -c none/zlib/lzma` byte-identical to chdman; extract round-trip
+      (partial last hunk) + non-DVD rejection.
 
 ## M6 — `cd` module
 
@@ -216,13 +225,22 @@ Tracked in detail in [docs/libchdman-parity.md](docs/libchdman-parity.md). Phase
   hd item carried into B, since it needs the metadata writer.)
 - [x] **B** — `hd` createhd ✅ — metadata writer (new files) + overall SHA-1 + `create_from_*`
   writing GDDD (+ optional IDNT), byte-identical to chdman.
-- [~] **C** — `copy` ✅ (`copy::copy`, byte-identical: recompress via `write_raw` + clone metadata,
-  preserve unit_bytes). Remaining: `write_metadata`/`delete_metadata` on *existing* CHDs (splice the
-  on-disk linked list). · [ ] **D** — `dvd` · [ ] **E** — `cd` · [ ] **F** — parent/diff +
-  `HdImage` · [ ] **G** — `Chd::info`/`verify`, rchdman, remaining docs.
+- [~] **C** — `copy` ✅ (`copy::copy`, byte-identical). Remaining: `write_metadata`/`delete_metadata`
+  on *existing* CHDs (splice the on-disk linked list).
+- [x] **D** — `dvd` ✅ — `createdvd`/`extractdvd` byte-identical (`DVD ` record, 2048 sectors).
+- [ ] **E** — `cd` · [ ] **F** — parent/diff + `HdImage` · [ ] **G** — `Chd::info`/`verify`,
+  rchdman, remaining docs.
 
 ## Session log
 
+- 2026-06-20: **Phase D `dvd` landed — byte-identical to `chdman createdvd`.** New `dvd` module
+  (`DvdCreateOptions`, `create_from_reader`/`create_from_iso`, `extract_to_writer`/`extract_to_iso`,
+  `DVD_SECTOR_SIZE`/`DEFAULT_HUNK_SIZE`). It's createhd with a `DVD ` record (1-NUL payload — chdman
+  writes an empty C string, storing the NUL terminator) instead of GDDD, unit 2048. Hoisted the
+  shared create dispatch (`read_and_pad` + `write_create`) into `write.rs` so hd/copy/dvd reuse it.
+  Verified byte-identical for `-c none/zlib/lzma` + extract round-trip / non-DVD rejection. 40
+  write/compat tests green. **Also investigated CI:** chd-rs has none; it's blocked by the write
+  feature's sibling path deps (even default resolve fails without them) — see the CI note above.
 - 2026-06-20: **Phase C `copy` landed — byte-identical to `chdman copy`.** New `copy` module
   (`copy::copy` + `CopyOptions{hunk_size:Option<u32>, codecs}`, matching libchdman-rs): open the
   source, snapshot its metadata in linked-list order, read the full logical image via `ChdReader`

--- a/README.md
+++ b/README.md
@@ -150,6 +150,65 @@ to change but should be considered mostly stable.
 In particular the type signature for [`HuffmanDecoder`](https://github.com/SnowflakePowered/chd-rs/blob/e03e093021f1705d46fe6aaa8b32593489e55467/chd-rs/src/huffman.rs#L110)
 is subject to change once [`generic_const_exprs`](https://github.com/rust-lang/rust/issues/76560) is stabilized.
 
+## Migrating
+
+### From a previous chd-rs version (read-only 0.2 / 0.3)
+
+**The read API is unchanged.** `Chd::open`, `chd.header()`, `chd.hunk(n)?.read_hunk_in(..)`,
+`chd.metadata_refs()`, and the `read::ChdReader` / `read::HunkBufReader` adapters all behave exactly
+as before — existing read code needs **no changes**.
+
+Everything new is **additive and feature-gated**, so a default build still pulls in nothing extra:
+
+| Want | Enable | Get |
+| --- | --- | --- |
+| Create / extract / copy / edit metadata | `write` | the `hd` / `cd` / `dvd` / `copy` modules, `metadata::write_metadata`/`delete_metadata`, `hd::HdImage`, `CompressionProgress` — all byte-identical to chdman 0.288 |
+| zstd / cdzs encoding | `write-zstd` | the above + the Zstandard encoders |
+| Integrity check | `verify` (also pulled in by `write`) | `Chd::verify() -> VerifyResult` |
+
+Available with **no feature** (read builds included): the `codec` module + the crate-root
+`CHD_CODEC_*` constants and `parse_codec_spec`/`codec_name`/`codec_exists`; `Chd::info() -> ChdInfo`;
+and `Header::compression() -> [u32; 4]`.
+
+**One source-breaking change:** `chd::Error` gained a `Cancelled` variant (used by the create API).
+It is appended **last**, so the `#[repr(C)]` discriminants of the existing variants — and the libchdr
+C ABI — are unchanged. Only an *exhaustive* `match` on `chd::Error` (no `_` arm) needs a new arm;
+code using `?` / `Result` is unaffected.
+
+The bundled `rchdman` CLI also gained `createraw`/`createhd`/`createcd`/`createdvd`/`copy`/`addmeta`/
+`delmeta`/`extractcd`/`extractdvd`, and its `verify` now checks the full raw + metadata SHA-1.
+
+### From libchdman-rs
+
+chd-rs offers the same create/extract/copy/verify functionality as `libchdman-rs` (a MAME C++
+wrapper) but keeps its own read idioms. The headline differences:
+
+| libchdman-rs | chd-rs |
+| --- | --- |
+| an owned, **writeable** `Chd` handle (`Chd::open(path, writeable, parent)`) | a generic, **borrowed read-only** `Chd<F: Read + Seek>`; create/extract are free functions |
+| `Chd::create*` / `Chd::write_metadata` / `Chd::write_bytes` (methods) | `hd::create_*` / `metadata::write_metadata` / `hd::HdImage::write_sector` (free fns / a dedicated type) |
+| `ChdIo: Read + Write + Seek` trait | any `Read + Seek` — no trait needed |
+| async `ChdCompressor` + `CompressStep` pull loop | synchronous create fns taking `progress` / `cancel` callbacks |
+
+```rust
+// libchdman-rs:  let chd = Chd::open(path, /*writeable=*/ false, /*parent=*/ None)?;
+// chd-rs — a Read+Seek, no `writeable`:
+let chd = chd::Chd::open(std::io::BufReader::new(std::fs::File::open(path)?), None)?;
+
+// libchdman-rs:  chd.create(..) driving ChdCompressor
+// chd-rs — a free function with progress/cancel callbacks:
+use chd::hd::{self, HdCreateOptions};
+hd::create_from_path(in_path, out_path, HdCreateOptions::default(), &mut |_p| {}, &|| false)?;
+```
+
+The owned-handle runtime read/write surface maps to `hd::HdImage` (`open` / `open_with_diff` /
+`read_sector` / `write_sector`); `CompressionProgress` matches libchdman-rs field-for-field.
+
+For the exhaustive "translate my libchdman-rs code" guide (every accessor and diverging item) see
+[docs/libchdman-differences.md](docs/libchdman-differences.md); the full API map is in
+[docs/libchdman-parity.md](docs/libchdman-parity.md), and the chdman-command mapping in
+[docs/chdman-mapping.md](docs/chdman-mapping.md).
+
 ## `rchdman` command line tool
 chd-rs ships `rchdman`, a chdman-style CLI covering read **and** create operations:
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,39 @@ to verify hunk checksums.
 chd = { version = "0.2", features = ["verify_block_crc"] }
 ```
 
+## Writing CHDs
+With the `write` feature, chd-rs can **create** CHDs whose output is **byte-for-byte identical to
+chdman 0.288**, using pure-Rust bit-exact codec implementations (the encoders live in standalone
+sibling crates). FLAC output is byte-identical against a glibc-built chdman and round-trip-correct
+otherwise.
+
+```toml
+[dependencies]
+chd = { version = "0.3", features = ["write"] }   # add "write-zstd" for zstd/cdzs
+```
+
+The create/extract surface mirrors chdman, as free functions in per-format modules:
+
+| chdman | chd-rs |
+| --- | --- |
+| `createraw` / `extractraw` | `hd::create_raw_from_path` / `hd::extract_to_path` |
+| `createhd` | `hd::create_from_path` (GDDD geometry + optional IDNT) |
+| `createcd` / `extractcd` | `cd::create_from_cue`/`create_from_gdi`/`create_from_iso`; `cd::extract_to_cue`/`extract_to_gdi`/`extract_to_iso` |
+| `createdvd` / `extractdvd` | `dvd::create_from_iso` / `dvd::extract_to_iso` |
+| `copy` | `copy::copy` |
+| `addmeta` / `delmeta` | `metadata::write_metadata` / `metadata::delete_metadata` |
+| `createraw -op` (compressed child) | `hd::create_raw_from_path_with_parent` |
+
+A runtime block device, `hd::HdImage`, supports per-sector `read_sector`/`write_sector` against an
+uncompressed CHD — in place, or as an uncompressed **diff** over a compressed parent
+(`open_with_diff`), exactly as MAME writes to a compressed image at runtime.
+
+`Chd::verify()` (the `verify` feature, also enabled by `write`) recomputes the raw + overall
+(metadata-inclusive) SHA-1 and checks them against the header.
+
+See [docs/chdman-mapping.md](docs/chdman-mapping.md) for the full command mapping, and
+[docs/libchdman-parity.md](docs/libchdman-parity.md) for API-parity details.
+
 ### Supported Codecs
 chd-rs supports the following compression codecs, with wider coverage than libchdr. For implementation details,
 see the [`chd::compression`](https://github.com/SnowflakePowered/chd-rs/tree/master/chd-rs/src/compression) module.
@@ -118,15 +151,15 @@ In particular the type signature for [`HuffmanDecoder`](https://github.com/Snowf
 is subject to change once [`generic_const_exprs`](https://github.com/rust-lang/rust/issues/76560) is stabilized.
 
 ## `rchdman` command line tool
-As a proof of concept, chd-rs implements an *extremely* basic reimplementation of chdman for read-only purposes. The following functions are available with rchdman.
+chd-rs ships `rchdman`, a chdman-style CLI covering read **and** create operations:
 
-* `info` Displays information about a CHD.
-* `verify` Verify the integrity of a CHD. Metadata integrity is not verified.
-* `extractraw` Extract the raw file from a CHD input file.
-* `dumpmeta` Dump metadata from the CHD to stdout or to a file.
+* `info`, `verify` (full raw **and** metadata-inclusive SHA-1), `benchmark`, `dumpmeta`
+* `extractraw`, `extractcd`, `extractdvd`
+* `createraw` (with `--outputparent` for a compressed child), `createhd`, `createcd`, `createdvd`, `copy`
+* `addmeta`, `delmeta`
 
-The results from rchdman should be identical from chdman. rchdman is intended to be basic and does not implement multithreading or other functions, so in general it is slower than chdman. There are
-no plans to implement write-operations into rchdman.
+Created CHDs are byte-identical to chdman. rchdman is single-threaded, so it is generally slower than
+chdman, but the output is the same.
 
 ## Performance
 By default, chd-rs uses pure Rust codecs but if maximum performance is needed, `max_perf` can be enabled. This enables the zlib-ng backend of [flate2](https://crates.io/crates/flate2)

--- a/chd-rs/Cargo.toml
+++ b/chd-rs/Cargo.toml
@@ -73,20 +73,19 @@ claxon = "0.4"
 bitreader = "0.3.6"
 ruzstd = "0.8.0"
 
-# bit-exact pure-Rust encoders (write feature). Sibling crates; path deps for local
-# dev, switch to crates.io version deps once published. See docs/codec-ports/.
-lzma-sdk-rs = { path = "../../lzma-sdk-rs", optional = true }
-# Published: zlib-bitexact-rs = "0.131" (byte-exact with stock zlib 1.3.1, chdman's version).
-# Path dep for local dev, consistent with the sibling encoder crates.
-zlib-bitexact-rs = { path = "../../zlib-bitexact-rs", optional = true }
-# Bit-exact pure-Rust libFLAC 1.4.3 encoder (raw `flac` + DVD-default codec). Float
-# parity is validated vs glibc libm; byte-identity to an MSVC/Windows chdman is not
-# guaranteed (output is always round-trip-correct). See docs/codec-ports/libflac-rs.md.
-libflac-rs = { path = "../../libflac-rs", optional = true }
+# Bit-exact pure-Rust codec encoders (write feature), each byte-exact with the C library
+# chdman 0.288 uses. Published on crates.io; see docs/codec-ports/. For co-developing one of
+# these alongside chd-rs, add an (uncommitted) `[patch.crates-io]` pointing at its working copy.
+lzma-sdk-rs = { version = "0.2301", optional = true } # LZMA SDK 23.01
+zlib-bitexact-rs = { version = "0.131", optional = true } # stock zlib 1.3.1
+# Bit-exact pure-Rust libFLAC 1.4.3 encoder (raw `flac` + DVD-default codec). Float parity is
+# validated vs glibc libm; byte-identity to an MSVC/Windows chdman is not guaranteed (output is
+# always round-trip-correct). See docs/codec-ports/libflac-rs.md.
+libflac-rs = { version = "0.143", optional = true }
 sha1 = { version = "0.10", optional = true }
-# Published form: libzstd-bitexact-rs = "=0.155" (the 1.5.5-targeted line; a bare
-# version would resolve to the 0.157.x / zstd-1.5.7 line).
-libzstd-bitexact-rs = { path = "../../libzstd-bitexact-rs", optional = true }
+# Pinned `=0.155`: the zstd-1.5.5-targeted line (chdman's version). A bare requirement would
+# resolve to the 0.157.x / zstd-1.5.7 line, which is NOT byte-exact with chdman 0.288.
+libzstd-bitexact-rs = { version = "=0.155", optional = true }
 
 zstd-safe = { version = "7.2.0", optional = true }
 # lending-iterator

--- a/chd-rs/Cargo.toml
+++ b/chd-rs/Cargo.toml
@@ -21,6 +21,15 @@ verify_block_crc = ["want_subcode", "want_raw_data_sector"]
 # currently unstable APIs
 huffman_api = []
 codec_api = []
+
+# write/encode support (off by default; gates all encode code so read-only
+# consumers pull in nothing). Pulls in the bit-exact codec crates needed for the
+# default codec sets (lzma + flac are in the DVD default).
+write = ["std", "dep:lzma-sdk-rs", "dep:zlib-bitexact-rs", "dep:libflac-rs", "dep:sha1"]
+# zstd/cdzs encode. Aligned: libzstd-bitexact-rs 0.155 is byte-exact with zstd
+# 1.5.5 (chdman's version). Separate from `write` because the zstd crate is large
+# and zstd/cdzs are not in any default codec set.
+write-zstd = ["write", "dep:libzstd-bitexact-rs"]
 unstable_lending_iterators = [ "lending-iterator", "nougat" ]
 
 # if disabled results may be unwanted
@@ -39,6 +48,11 @@ c_zlib = ["std", "flate2/zlib-ng"]
 huff_write = []
 nonstandard_channel_count = []
 
+# dev-local bit-exact verification against a real chdman binary (resolves via the
+# CHDMAN env var, then C:\Tools\chdman\chdman.exe, then `chdman` on PATH). Never
+# enabled in CI; needs a chdman 0.288 install. Use with the `write` features.
+chdman_compat_tests = []
+
 [dependencies]
 byteorder = "1"
 num-traits = "0.2"
@@ -54,6 +68,21 @@ lzma-rs = { package = "lzma-rs-perf-exp", version = "0.2", features = ["raw_deco
 claxon = "0.4"
 bitreader = "0.3.6"
 ruzstd = "0.8.0"
+
+# bit-exact pure-Rust encoders (write feature). Sibling crates; path deps for local
+# dev, switch to crates.io version deps once published. See docs/codec-ports/.
+lzma-sdk-rs = { path = "../../lzma-sdk-rs", optional = true }
+# Published: zlib-bitexact-rs = "0.131" (byte-exact with stock zlib 1.3.1, chdman's version).
+# Path dep for local dev, consistent with the sibling encoder crates.
+zlib-bitexact-rs = { path = "../../zlib-bitexact-rs", optional = true }
+# Bit-exact pure-Rust libFLAC 1.4.3 encoder (raw `flac` + DVD-default codec). Float
+# parity is validated vs glibc libm; byte-identity to an MSVC/Windows chdman is not
+# guaranteed (output is always round-trip-correct). See docs/codec-ports/libflac-rs.md.
+libflac-rs = { path = "../../libflac-rs", optional = true }
+sha1 = { version = "0.10", optional = true }
+# Published form: libzstd-bitexact-rs = "=0.155" (the 1.5.5-targeted line; a bare
+# version would resolve to the 0.157.x / zstd-1.5.7 line).
+libzstd-bitexact-rs = { path = "../../libzstd-bitexact-rs", optional = true }
 
 zstd-safe = { version = "7.2.0", optional = true }
 # lending-iterator

--- a/chd-rs/Cargo.toml
+++ b/chd-rs/Cargo.toml
@@ -25,7 +25,11 @@ codec_api = []
 # write/encode support (off by default; gates all encode code so read-only
 # consumers pull in nothing). Pulls in the bit-exact codec crates needed for the
 # default codec sets (lzma + flac are in the DVD default).
-write = ["std", "dep:lzma-sdk-rs", "dep:zlib-bitexact-rs", "dep:libflac-rs", "dep:sha1"]
+write = ["std", "verify", "dep:lzma-sdk-rs", "dep:zlib-bitexact-rs", "dep:libflac-rs"]
+# Read-side integrity check: Chd::verify() recomputes the raw + overall SHA-1 and
+# compares to the header. Only adds the small pure-Rust `sha1` crate; `write`
+# enables it transitively.
+verify = ["std", "dep:sha1"]
 # zstd/cdzs encode. Aligned: libzstd-bitexact-rs 0.155 is byte-exact with zstd
 # 1.5.5 (chdman's version). Separate from `write` because the zstd crate is large
 # and zstd/cdzs are not in any default codec set.

--- a/chd-rs/src/cd.rs
+++ b/chd-rs/src/cd.rs
@@ -12,8 +12,8 @@
 //! metadata, then reuse the shared V5 writer ([`write::write_create`](crate::write)). Output is
 //! **byte-identical to `chdman createcd`** (verified for `-c cdzl`/`cdlz`).
 //!
-//! Matches libchdman-rs's `cd` module. Extraction (`extractcd`), GDI/Nero parsing, `list_tracks`,
-//! and the `cdfl` encoder are not yet implemented.
+//! Matches libchdman-rs's `cd` module. All four CD codecs (`cdlz`/`cdzl`/`cdzs`/`cdfl`) encode;
+//! extraction (`extractcd`), GDI/Nero parsing, and `list_tracks` are not yet implemented.
 
 use crate::error::{Error, Result};
 use crate::{write, CompressionProgress, CHD_CODEC_CD_FLAC, CHD_CODEC_CD_LZMA, CHD_CODEC_CD_ZLIB};
@@ -476,9 +476,9 @@ pub struct CdCreateOptions {
     pub hunk_size: u32,
     /// Codec slots. Default `[cdlz, cdzl, cdfl, 0]` (chdman's `s_default_cd_compression`).
     ///
-    /// **Note:** the `cdfl` encoder is not yet implemented, so the default set currently fails in
-    /// [`create_from_cue`]/[`create_from_iso`]; pass an explicit working set such as
-    /// `[CHD_CODEC_CD_LZMA, CHD_CODEC_CD_ZLIB, 0, 0]` until `cdfl` lands.
+    /// All three are implemented and byte-identical to chdman, with one caveat: `cdfl`'s FLAC stream
+    /// is **libm-gated** (byte-identical to a *glibc* chdman, round-trip-correct against any build —
+    /// see [`CdFlacEncoder`](crate::compression)). The `cdlz`/`cdzl` hunks are always byte-identical.
     pub codecs: [u32; 4],
 }
 

--- a/chd-rs/src/cd.rs
+++ b/chd-rs/src/cd.rs
@@ -1,0 +1,617 @@
+//! CD-ROM CHDs — chdman `createcd` parity.
+//!
+//! A CD CHD stores the disc as fixed **2448-byte frames** (`2352` sector + `96` subcode), eight
+//! frames to a `19584`-byte hunk, compressed with the CD wrapper codecs (`cdlz`/`cdzl`/`cdfl`/`cdzs`
+//! — see [`compression::cdrom`](crate::compression)). Each track gets a `CHT2`
+//! ([`CDROM_TRACK_METADATA2`](crate::metadata::KnownMetadata::CdRomTrack2)) record describing its
+//! type/subtype/frame-count.
+//!
+//! Creation is a pure-Rust port of chdman's `do_create_cd` (`chdman.cpp:2162`): parse the input TOC
+//! (a CUE sheet via [`create_from_cue`] or a flat image via [`create_from_iso`]), assemble the
+//! logical frame image (port of `chd_cd_compressor::read_data`), build the per-track `CHT2`
+//! metadata, then reuse the shared V5 writer ([`write::write_create`](crate::write)). Output is
+//! **byte-identical to `chdman createcd`** (verified for `-c cdzl`/`cdlz`).
+//!
+//! Matches libchdman-rs's `cd` module. Extraction (`extractcd`), GDI/Nero parsing, `list_tracks`,
+//! and the `cdfl` encoder are not yet implemented.
+
+use crate::error::{Error, Result};
+use crate::{write, CompressionProgress, CHD_CODEC_CD_FLAC, CHD_CODEC_CD_LZMA, CHD_CODEC_CD_ZLIB};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+/// Bytes of sector data in a CD frame (`2352`).
+pub const CD_MAX_SECTOR_DATA: u32 = crate::cdrom::CD_MAX_SECTOR_DATA;
+/// Bytes of subcode data in a CD frame (`96`).
+pub const CD_MAX_SUBCODE_DATA: u32 = crate::cdrom::CD_MAX_SUBCODE_DATA;
+/// Total CD frame size in bytes (`2352 + 96 = 2448`). This is the CD CHD's unit size.
+pub const CD_FRAME_SIZE: u32 = crate::cdrom::CD_FRAME_SIZE;
+/// CD frames per hunk (`8`).
+pub const FRAMES_PER_HUNK: u32 = 8;
+/// chdman's default CD hunk size (`8 * 2448 = 19584`).
+pub const DEFAULT_HUNK_SIZE: u32 = FRAMES_PER_HUNK * CD_FRAME_SIZE;
+/// Tracks are padded to a multiple of this many frames (`4`).
+pub const TRACK_PADDING: u32 = 4;
+
+/// CD-ROM track type. Mirrors MAME's `CD_TRACK_*` enum (`cdrom.h`); the discriminant order matches
+/// so the `MODE1`-valued default (`pgtype`) and the metadata strings line up with chdman.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum TrackType {
+    /// `MODE1`, 2048 data bytes/sector (cooked).
+    Mode1 = 0,
+    /// `MODE1_RAW`, 2352 data bytes/sector.
+    Mode1Raw,
+    /// `MODE2`, 2336 data bytes/sector.
+    Mode2,
+    /// `MODE2_FORM1`, 2048 data bytes/sector.
+    Mode2Form1,
+    /// `MODE2_FORM2`, 2324 data bytes/sector.
+    Mode2Form2,
+    /// `MODE2_FORM_MIX`, 2336 data bytes/sector.
+    Mode2FormMix,
+    /// `MODE2_RAW`, 2352 data bytes/sector.
+    Mode2Raw,
+    /// `AUDIO`, 2352 bytes/sector (Red Book).
+    Audio,
+}
+
+impl TrackType {
+    /// The metadata string for this type (`get_type_string`, `cdrom.cpp:835`).
+    pub fn type_string(self) -> &'static str {
+        match self {
+            TrackType::Mode1 => "MODE1",
+            TrackType::Mode1Raw => "MODE1_RAW",
+            TrackType::Mode2 => "MODE2",
+            TrackType::Mode2Form1 => "MODE2_FORM1",
+            TrackType::Mode2Form2 => "MODE2_FORM2",
+            TrackType::Mode2FormMix => "MODE2_FORM_MIX",
+            TrackType::Mode2Raw => "MODE2_RAW",
+            TrackType::Audio => "AUDIO",
+        }
+    }
+}
+
+/// CD-ROM subcode type. Mirrors MAME's `CD_SUB_*` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum SubcodeType {
+    /// `RW`, cooked 96 bytes/sector.
+    Normal = 0,
+    /// `RW_RAW`, raw uninterleaved 96 bytes/sector.
+    Raw,
+    /// `NONE`, no subcode stored.
+    None,
+}
+
+impl SubcodeType {
+    /// The metadata string for this subtype (`get_subtype_string`, `cdrom.cpp:867`).
+    pub fn subtype_string(self) -> &'static str {
+        match self {
+            SubcodeType::Normal => "RW",
+            SubcodeType::Raw => "RW_RAW",
+            SubcodeType::None => "NONE",
+        }
+    }
+}
+
+/// Map a CUE/TOC track-type string to `(type, data size)`, exactly as chdman's
+/// `get_info_from_type_string` (`cdrom.cpp:643`).
+fn type_from_string(s: &str) -> Option<(TrackType, u32)> {
+    Some(match s {
+        "MODE1" | "MODE1/2048" => (TrackType::Mode1, 2048),
+        "MODE1_RAW" | "MODE1/2352" => (TrackType::Mode1Raw, 2352),
+        "MODE2" | "MODE2/2336" => (TrackType::Mode2, 2336),
+        "MODE2_FORM1" | "MODE2/2048" => (TrackType::Mode2Form1, 2048),
+        "MODE2_FORM2" | "MODE2/2324" => (TrackType::Mode2Form2, 2324),
+        "MODE2_FORM_MIX" => (TrackType::Mode2FormMix, 2336),
+        "MODE2_RAW" | "MODE2/2352" | "CDI/2352" => (TrackType::Mode2Raw, 2352),
+        "AUDIO" => (TrackType::Audio, 2352),
+        _ => return None,
+    })
+}
+
+/// One parsed TOC track plus the input-file binding needed to assemble its frames. Combines the
+/// fields chdman keeps split across `cdrom_file::track_info` + `track_input_entry`.
+#[derive(Debug, Clone)]
+struct CdTrack {
+    trktype: TrackType,
+    subtype: SubcodeType,
+    datasize: u32,
+    subsize: u32,
+    frames: u32,
+    extraframes: u32,
+    pregap: u32,
+    postgap: u32,
+    pgtype: TrackType,
+    pgsub: SubcodeType,
+    pgdatasize: u32,
+    // input binding
+    fname: PathBuf,
+    offset: u64,
+    swap: bool,
+    idx0: i64,
+    idx1: i64,
+}
+
+impl CdTrack {
+    fn new(trktype: TrackType, datasize: u32, fname: PathBuf, swap: bool) -> Self {
+        CdTrack {
+            trktype,
+            subtype: SubcodeType::None,
+            datasize,
+            subsize: 0,
+            frames: 0,
+            extraframes: 0,
+            pregap: 0,
+            postgap: 0,
+            // pgtype defaults to MODE1 (chdman's zero-initialised `pgtype`), pgsub to NONE.
+            pgtype: TrackType::Mode1,
+            pgsub: SubcodeType::None,
+            pgdatasize: 0,
+            fname,
+            offset: 0,
+            swap,
+            idx0: -1,
+            idx1: -1,
+        }
+    }
+}
+
+/// Split a CUE line into tokens, honouring single/double quotes (port of `cdrom_file::tokenize`,
+/// `cdrom.cpp:1524`): leading whitespace is skipped, quote characters toggle quoting and are
+/// dropped, and unquoted whitespace ends a token. Assumes ASCII (CUE keywords + paths).
+fn tokenize_line(line: &str) -> Vec<String> {
+    let bytes = line.as_bytes();
+    let n = bytes.len();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < n {
+        while i < n && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= n {
+            break;
+        }
+        let mut tok = String::new();
+        let mut singlequote = false;
+        let mut doublequote = false;
+        while i < n {
+            let c = bytes[i];
+            if !singlequote && c == b'"' {
+                doublequote = !doublequote;
+            } else if !doublequote && c == b'\'' {
+                singlequote = !singlequote;
+            } else if !singlequote && !doublequote && c.is_ascii_whitespace() {
+                break;
+            } else {
+                tok.push(c as char);
+            }
+            i += 1;
+        }
+        tokens.push(tok);
+    }
+    tokens
+}
+
+/// Convert an `m:s:f` (or bare-frame) token to a frame count (port of `msf_to_frames`,
+/// `cdrom.cpp:1578`). A token with no `:` is taken as a raw frame count; otherwise it is
+/// `(m*60 + s)*75 + f`.
+fn msf_to_frames(token: &str) -> i64 {
+    let parts: Vec<&str> = token.split(':').collect();
+    let m: i64 = parts
+        .first()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0);
+    if parts.len() == 1 {
+        return m;
+    }
+    let s: i64 = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let f: i64 = parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+    (m * 60 + s) * 75 + f
+}
+
+/// Parse a BIN/CUE sheet into a track list, a pure-Rust port of `cdrom_file::parse_cue`
+/// (`cdrom.cpp:2336`) covering the common single- and multi-file cases (`FILE`/`TRACK`/`INDEX`/
+/// `PREGAP`/`POSTGAP`/`FLAGS`). GD-ROM (`is_gdicue`), multisession, lead-in/out, and `WAVE` inputs
+/// are not supported.
+fn parse_cue(cue_path: &Path) -> Result<Vec<CdTrack>> {
+    let text = std::fs::read_to_string(cue_path)?;
+    let dir = cue_path.parent().unwrap_or_else(|| Path::new(""));
+
+    let mut tracks: Vec<CdTrack> = Vec::new();
+    let mut lastfname: Option<PathBuf> = None;
+    // The FILE type sets the byte-swap flag of the *next* track only (chdman's
+    // `outinfo.track[trknum+1].swap`); consumed when that track is defined.
+    let mut next_swap: Option<bool> = None;
+
+    for line in text.lines() {
+        let tokens = tokenize_line(line);
+        let Some(cmd) = tokens.first() else { continue };
+        match cmd.as_str() {
+            "FILE" => {
+                let name = tokens.get(1).ok_or(Error::InvalidData)?;
+                lastfname = Some(dir.join(name));
+                match tokens.get(2).map(String::as_str).unwrap_or("") {
+                    "BINARY" => next_swap = Some(false),
+                    "MOTOROLA" => next_swap = Some(true),
+                    // WAVE needs sample parsing; other types are unknown.
+                    _ => return Err(Error::UnsupportedFormat),
+                }
+            }
+            "TRACK" => {
+                let typestr = tokens.get(2).ok_or(Error::InvalidData)?;
+                let (trktype, datasize) =
+                    type_from_string(typestr).ok_or(Error::UnsupportedFormat)?;
+                let fname = lastfname.clone().ok_or(Error::InvalidData)?;
+                let swap = next_swap.take().unwrap_or(false);
+                let mut t = CdTrack::new(trktype, datasize, fname, swap);
+                // optional subtype token (RW / RW_RAW); anything else leaves SUBTYPE:NONE.
+                if let Some(sub) = tokens.get(3) {
+                    match sub.as_str() {
+                        "RW" => {
+                            t.subtype = SubcodeType::Normal;
+                            t.subsize = 96;
+                        }
+                        "RW_RAW" => {
+                            t.subtype = SubcodeType::Raw;
+                            t.subsize = 96;
+                        }
+                        _ => {}
+                    }
+                }
+                tracks.push(t);
+            }
+            "INDEX" => {
+                let t = tracks.last_mut().ok_or(Error::InvalidData)?;
+                let idx: i64 = tokens
+                    .get(1)
+                    .and_then(|s| s.parse().ok())
+                    .ok_or(Error::InvalidData)?;
+                let frames = msf_to_frames(tokens.get(2).ok_or(Error::InvalidData)?);
+                if idx == 0 {
+                    t.idx0 = frames;
+                } else if idx == 1 {
+                    t.idx1 = frames;
+                }
+                if idx == 1 {
+                    if t.pregap == 0 && t.idx0 != -1 {
+                        t.pregap = (t.idx1 - t.idx0) as u32;
+                        t.pgtype = t.trktype;
+                        t.pgdatasize = t.datasize;
+                    } else if t.idx0 == -1 {
+                        // pregap not physically present; idx 0 is used for the length calc.
+                        t.idx0 = frames;
+                    }
+                }
+            }
+            "PREGAP" => {
+                let t = tracks.last_mut().ok_or(Error::InvalidData)?;
+                t.pregap = msf_to_frames(tokens.get(1).ok_or(Error::InvalidData)?) as u32;
+            }
+            "POSTGAP" => {
+                let t = tracks.last_mut().ok_or(Error::InvalidData)?;
+                t.postgap = msf_to_frames(tokens.get(1).ok_or(Error::InvalidData)?) as u32;
+            }
+            // FLAGS/REM and anything else: no effect on the created CHD.
+            _ => {}
+        }
+    }
+
+    if tracks.is_empty() {
+        return Err(Error::InvalidData);
+    }
+
+    compute_track_lengths(&mut tracks)?;
+    Ok(tracks)
+}
+
+/// Second pass of `parse_cue` (`cdrom.cpp:2656`): fill in each track's `frames` and source-file
+/// `offset` from the index markers and the bin file sizes.
+fn compute_track_lengths(tracks: &mut [CdTrack]) -> Result<()> {
+    let numtrks = tracks.len();
+    for i in 0..numtrks {
+        if tracks[i].idx1 == -1 {
+            // INDEX 01 is required.
+            return Err(Error::InvalidData);
+        }
+        if tracks[i].trktype == TrackType::Audio {
+            tracks[i].swap = true;
+        }
+        if tracks[i].offset != 0 {
+            continue;
+        }
+
+        // Snapshot neighbour values (already finalised for i-1; parse-time for i+1).
+        let prev_same = i > 0 && tracks[i].fname == tracks[i - 1].fname;
+        let next_same = i + 1 < numtrks && tracks[i].fname == tracks[i + 1].fname;
+        let prev_offset = if i > 0 { tracks[i - 1].offset } else { 0 };
+        let prev_frames = if i > 0 { tracks[i - 1].frames } else { 0 };
+        let prev_bpf = if i > 0 {
+            (tracks[i - 1].datasize + tracks[i - 1].subsize) as u64
+        } else {
+            0
+        };
+        let next_idx0 = if i + 1 < numtrks {
+            tracks[i + 1].idx0
+        } else {
+            0
+        };
+        let this_idx0 = tracks[i].idx0;
+        let bpf = (tracks[i].datasize + tracks[i].subsize) as u64;
+
+        if i + 1 >= numtrks && i > 0 && prev_same {
+            // last track sharing the previous track's file
+            let tlen = file_size(&tracks[i].fname)?;
+            let offset = prev_offset + prev_frames as u64 * prev_bpf;
+            tracks[i].offset = offset;
+            tracks[i].frames = ((tlen - offset) / bpf) as u32;
+        } else if next_same {
+            // same file as the next track: length is the gap between the two index-0 markers
+            let frames = next_idx0 - this_idx0;
+            if frames <= 0 {
+                return Err(Error::InvalidData);
+            }
+            tracks[i].frames = frames as u32;
+            if i > 0 {
+                tracks[i].offset = prev_offset + prev_frames as u64 * prev_bpf;
+            }
+        } else if tracks[i].frames == 0 {
+            // a file of its own
+            let tlen = file_size(&tracks[i].fname)?;
+            tracks[i].frames = (tlen / bpf) as u32;
+            tracks[i].offset = 0;
+        }
+    }
+    Ok(())
+}
+
+/// Parse a flat sector image (`.iso`/`.bin`) into a single-track TOC, a port of
+/// `cdrom_file::parse_iso` (`cdrom.cpp:2027`): the track type is inferred from the file size's
+/// divisibility (2048 → `MODE1`, 2336 → `MODE2`, 2352 → `MODE2_RAW`).
+fn parse_iso(iso_path: &Path) -> Result<Vec<CdTrack>> {
+    let size = file_size(iso_path)?;
+    let (trktype, datasize) = if size % 2048 == 0 {
+        (TrackType::Mode1, 2048)
+    } else if size % 2336 == 0 {
+        (TrackType::Mode2, 2336)
+    } else if size % 2352 == 0 {
+        (TrackType::Mode2Raw, 2352)
+    } else {
+        return Err(Error::UnsupportedFormat);
+    };
+    let mut t = CdTrack::new(trktype, datasize, iso_path.to_path_buf(), false);
+    t.frames = (size / datasize as u64) as u32;
+    t.idx0 = 0;
+    t.idx1 = 0;
+    Ok(vec![t])
+}
+
+fn file_size(path: &Path) -> Result<u64> {
+    Ok(std::fs::metadata(path)?.len())
+}
+
+/// Assemble the logical frame image from the parsed TOC — a port of `chd_cd_compressor::read_data`
+/// (`chdman.cpp:437`). Each track occupies `(frames + extraframes) * 2448` bytes; for every one of
+/// its `frames` data frames, the source's `datasize + subsize` bytes are read contiguously from
+/// `offset` and placed at the start of the 2448-byte frame (the remainder staying zero), byte-pair
+/// swapped over the first 2352 bytes when the track is flagged `swap` (Red Book audio / `MOTOROLA`).
+/// The `extraframes` padding frames are left zero. Returns the image plus the per-track frame
+/// counts (`frames`, used for the `CHT2` records).
+fn assemble_logical(tracks: &mut [CdTrack]) -> Result<Vec<u8>> {
+    let mut total_frames: u64 = 0;
+    for t in tracks.iter_mut() {
+        let padded = t.frames.div_ceil(TRACK_PADDING) * TRACK_PADDING;
+        t.extraframes = padded - t.frames;
+        total_frames += (t.frames + t.extraframes) as u64;
+    }
+
+    let frame_size = CD_FRAME_SIZE as usize;
+    let sector_data = CD_MAX_SECTOR_DATA as usize;
+    let mut logical = vec![0u8; total_frames as usize * frame_size];
+
+    let mut dest_frame: u64 = 0;
+    for t in tracks.iter() {
+        let bpf = (t.datasize + t.subsize) as usize;
+        if t.frames > 0 {
+            let mut f = File::open(&t.fname)?;
+            f.seek(SeekFrom::Start(t.offset))?;
+            let mut block = vec![0u8; t.frames as usize * bpf];
+            f.read_exact(&mut block)?;
+            for fr in 0..t.frames as usize {
+                let dst = (dest_frame as usize + fr) * frame_size;
+                logical[dst..dst + bpf].copy_from_slice(&block[fr * bpf..(fr + 1) * bpf]);
+                if t.swap {
+                    let sector = &mut logical[dst..dst + sector_data];
+                    let mut k = 0;
+                    while k + 1 < sector_data {
+                        sector.swap(k, k + 1);
+                        k += 2;
+                    }
+                }
+            }
+        }
+        dest_frame += (t.frames + t.extraframes) as u64;
+    }
+    Ok(logical)
+}
+
+/// Build the per-track `CHT2` metadata payloads (`CDROM_TRACK_METADATA2_FORMAT`, `chd.cpp:39` +
+/// `write_metadata`, `cdrom.cpp:1065`). Each payload is the formatted C string **plus its NUL
+/// terminator** (chdman stores `string.length() + 1` bytes). `PGTYPE` is the pregap type string,
+/// prefixed with `V` when the pregap carries data (`pgdatasize > 0`).
+fn build_cht2_payloads(tracks: &[CdTrack]) -> Vec<Vec<u8>> {
+    tracks
+        .iter()
+        .enumerate()
+        .map(|(i, t)| {
+            let submode = if t.pgdatasize > 0 {
+                format!("V{}", t.pgtype.type_string())
+            } else {
+                t.pgtype.type_string().to_string()
+            };
+            let s = format!(
+                "TRACK:{} TYPE:{} SUBTYPE:{} FRAMES:{} PREGAP:{} PGTYPE:{} PGSUB:{} POSTGAP:{}",
+                i + 1,
+                t.trktype.type_string(),
+                t.subtype.subtype_string(),
+                t.frames,
+                t.pregap,
+                submode,
+                t.pgsub.subtype_string(),
+                t.postgap,
+            );
+            let mut bytes = s.into_bytes();
+            bytes.push(0); // C-string NUL terminator, included in the stored length
+            bytes
+        })
+        .collect()
+}
+
+/// Options for CD CHD creation. Matches libchdman-rs's `CdCreateOptions`.
+#[derive(Debug, Clone)]
+pub struct CdCreateOptions {
+    /// Hunk size in bytes. Default `19584` (`8 * 2448`). Must be a non-zero multiple of `2448`.
+    pub hunk_size: u32,
+    /// Codec slots. Default `[cdlz, cdzl, cdfl, 0]` (chdman's `s_default_cd_compression`).
+    ///
+    /// **Note:** the `cdfl` encoder is not yet implemented, so the default set currently fails in
+    /// [`create_from_cue`]/[`create_from_iso`]; pass an explicit working set such as
+    /// `[CHD_CODEC_CD_LZMA, CHD_CODEC_CD_ZLIB, 0, 0]` until `cdfl` lands.
+    pub codecs: [u32; 4],
+}
+
+impl Default for CdCreateOptions {
+    fn default() -> Self {
+        Self {
+            hunk_size: DEFAULT_HUNK_SIZE,
+            codecs: [CHD_CODEC_CD_LZMA, CHD_CODEC_CD_ZLIB, CHD_CODEC_CD_FLAC, 0],
+        }
+    }
+}
+
+/// Shared back end for [`create_from_cue`]/[`create_from_iso`]: assemble the logical image + `CHT2`
+/// metadata from `tracks` and hand off to the V5 writer, **byte-identical to `chdman createcd`**.
+fn build_cd<W: Write + Seek>(
+    mut tracks: Vec<CdTrack>,
+    out: &mut W,
+    opts: CdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    if opts.hunk_size == 0 || opts.hunk_size % CD_FRAME_SIZE != 0 {
+        return Err(Error::InvalidParameter);
+    }
+    let logical = assemble_logical(&mut tracks)?;
+    let payloads = build_cht2_payloads(&tracks);
+    let entries: Vec<write::MetaEntry> = payloads
+        .iter()
+        .map(|p| write::MetaEntry {
+            tag: crate::make_tag(b"CHT2"),
+            flags: write::CHD_MDFLAGS_CHECKSUM,
+            payload: p,
+        })
+        .collect();
+
+    let codecs = write::resolve_codecs(&opts.codecs)?;
+    write::write_create(
+        out,
+        &logical,
+        opts.hunk_size,
+        CD_FRAME_SIZE,
+        &codecs,
+        &entries,
+        progress,
+        cancel,
+    )
+}
+
+/// Create a CD CHD from a BIN/CUE sheet at `cue_path`, **byte-identical to `chdman createcd`**.
+///
+/// Parses the CUE (single- or multi-file BIN, the common `MODE1`/`MODE2`/`AUDIO` track types),
+/// assembles the 2448-byte-frame logical image (padding each track to a 4-frame boundary), writes a
+/// `CHT2` record per track, and compresses with `opts.codecs`. `progress`/`cancel` follow the usual
+/// convention (cancel → [`Error::Cancelled`] before any bytes hit `out`). On any error the partial
+/// `out_path` is removed.
+///
+/// GD-ROM cue sheets, multisession discs, and `WAVE` track inputs are not supported.
+pub fn create_from_cue(
+    cue_path: &Path,
+    out_path: &Path,
+    opts: CdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let tracks = parse_cue(cue_path)?;
+    create_to_path(tracks, out_path, opts, progress, cancel)
+}
+
+/// Create a CD CHD from a flat sector image (`.iso`/`.bin`) at `iso_path`, **byte-identical to
+/// `chdman createcd`**. The single track's type is inferred from the file size (port of
+/// `parse_iso`): 2048 → `MODE1`, 2336 → `MODE2`, 2352 → `MODE2_RAW`. See [`create_from_cue`] for
+/// the callback/cleanup behaviour.
+pub fn create_from_iso(
+    iso_path: &Path,
+    out_path: &Path,
+    opts: CdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let tracks = parse_iso(iso_path)?;
+    create_to_path(tracks, out_path, opts, progress, cancel)
+}
+
+fn create_to_path(
+    tracks: Vec<CdTrack>,
+    out_path: &Path,
+    opts: CdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let mut out = File::create(out_path)?;
+    let res = build_cd(tracks, &mut out, opts, progress, cancel);
+    if res.is_err() {
+        drop(out);
+        let _ = std::fs::remove_file(out_path);
+    }
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn msf_parsing() {
+        assert_eq!(msf_to_frames("00:00:00"), 0);
+        assert_eq!(msf_to_frames("00:02:00"), 150);
+        assert_eq!(msf_to_frames("00:04:00"), 300);
+        assert_eq!(msf_to_frames("01:00:00"), 4500);
+        assert_eq!(msf_to_frames("150"), 150); // bare frame count
+    }
+
+    #[test]
+    fn tokenize_quotes() {
+        assert_eq!(
+            tokenize_line("  FILE \"my disc.bin\" BINARY"),
+            vec!["FILE", "my disc.bin", "BINARY"]
+        );
+        assert_eq!(
+            tokenize_line("    TRACK 01 MODE1/2352"),
+            vec!["TRACK", "01", "MODE1/2352"]
+        );
+    }
+
+    #[test]
+    fn type_strings_round_trip() {
+        assert_eq!(
+            type_from_string("MODE1/2352").unwrap().0,
+            TrackType::Mode1Raw
+        );
+        assert_eq!(TrackType::Mode1Raw.type_string(), "MODE1_RAW");
+        assert_eq!(TrackType::Mode1.type_string(), "MODE1"); // default pgtype
+        assert_eq!(TrackType::Audio.type_string(), "AUDIO");
+        assert_eq!(SubcodeType::None.subtype_string(), "NONE");
+    }
+}

--- a/chd-rs/src/cd.rs
+++ b/chd-rs/src/cd.rs
@@ -16,8 +16,10 @@
 //! track table back, and [`extract_to_iso`] / [`CdCookedReader`] expose a single MODE1 track's
 //! cooked 2048-byte user data.
 //!
+//! [`create_from_gdi`] handles Sega Dreamcast `.gdi` indices (GD-ROM, `CHGD` metadata).
+//!
 //! Matches libchdman-rs's `cd` module. All four CD codecs (`cdlz`/`cdzl`/`cdzs`/`cdfl`) encode.
-//! GDI/Nero TOC parsing and `.gdi`/split-bin extraction are not yet implemented.
+//! Nero (`.nrg`) TOC parsing and `.gdi`/split-bin extraction are not yet implemented.
 
 use crate::error::{Error, Result};
 use crate::metadata::Metadata;
@@ -166,6 +168,8 @@ struct CdTrack {
     subsize: u32,
     frames: u32,
     extraframes: u32,
+    /// Trailing zero-padding frames inside `frames` (GDI area-gap fill); not read from the source.
+    padframes: u32,
     pregap: u32,
     postgap: u32,
     pgtype: TrackType,
@@ -188,6 +192,7 @@ impl CdTrack {
             subsize: 0,
             frames: 0,
             extraframes: 0,
+            padframes: 0,
             pregap: 0,
             postgap: 0,
             // pgtype defaults to MODE1 (chdman's zero-initialised `pgtype`), pgsub to NONE.
@@ -458,12 +463,15 @@ fn assemble_logical(tracks: &mut [CdTrack]) -> Result<Vec<u8>> {
     let mut dest_frame: u64 = 0;
     for t in tracks.iter() {
         let bpf = (t.datasize + t.subsize) as usize;
-        if t.frames > 0 {
+        // The trailing `padframes` (GDI area-gap fill) and `extraframes` (4-frame alignment) have no
+        // source data — only `frames - padframes` real sectors are read; the rest stay zero.
+        let real = t.frames.saturating_sub(t.padframes) as usize;
+        if real > 0 {
             let mut f = File::open(&t.fname)?;
             f.seek(SeekFrom::Start(t.offset))?;
-            let mut block = vec![0u8; t.frames as usize * bpf];
+            let mut block = vec![0u8; real * bpf];
             f.read_exact(&mut block)?;
-            for fr in 0..t.frames as usize {
+            for fr in 0..real {
                 let dst = (dest_frame as usize + fr) * frame_size;
                 logical[dst..dst + bpf].copy_from_slice(&block[fr * bpf..(fr + 1) * bpf]);
                 if t.swap {
@@ -481,31 +489,47 @@ fn assemble_logical(tracks: &mut [CdTrack]) -> Result<Vec<u8>> {
     Ok(logical)
 }
 
-/// Build the per-track `CHT2` metadata payloads (`CDROM_TRACK_METADATA2_FORMAT`, `chd.cpp:39` +
-/// `write_metadata`, `cdrom.cpp:1065`). Each payload is the formatted C string **plus its NUL
-/// terminator** (chdman stores `string.length() + 1` bytes). `PGTYPE` is the pregap type string,
-/// prefixed with `V` when the pregap carries data (`pgdatasize > 0`).
-fn build_cht2_payloads(tracks: &[CdTrack]) -> Vec<Vec<u8>> {
+/// Build the per-track metadata payloads (`write_metadata`, `cdrom.cpp:1065`). For a CD this is the
+/// `CHT2` `CDROM_TRACK_METADATA2_FORMAT` (`chd.cpp:39`) where `PGTYPE` is `V`-prefixed when the
+/// pregap carries data; for a GD-ROM (`gdrom`) it's the `CHGD` `GDROM_TRACK_METADATA_FORMAT`
+/// (`chd.cpp:40`) which adds a `PAD:` field and uses the plain pregap type string. Each payload is
+/// the formatted C string **plus its NUL terminator** (chdman stores `string.length() + 1` bytes).
+fn build_track_metadata(tracks: &[CdTrack], gdrom: bool) -> Vec<Vec<u8>> {
     tracks
         .iter()
         .enumerate()
         .map(|(i, t)| {
-            let submode = if t.pgdatasize > 0 {
-                format!("V{}", t.pgtype.type_string())
+            let s = if gdrom {
+                format!(
+                    "TRACK:{} TYPE:{} SUBTYPE:{} FRAMES:{} PAD:{} PREGAP:{} PGTYPE:{} PGSUB:{} POSTGAP:{}",
+                    i + 1,
+                    t.trktype.type_string(),
+                    t.subtype.subtype_string(),
+                    t.frames,
+                    t.padframes,
+                    t.pregap,
+                    t.pgtype.type_string(),
+                    t.pgsub.subtype_string(),
+                    t.postgap,
+                )
             } else {
-                t.pgtype.type_string().to_string()
+                let submode = if t.pgdatasize > 0 {
+                    format!("V{}", t.pgtype.type_string())
+                } else {
+                    t.pgtype.type_string().to_string()
+                };
+                format!(
+                    "TRACK:{} TYPE:{} SUBTYPE:{} FRAMES:{} PREGAP:{} PGTYPE:{} PGSUB:{} POSTGAP:{}",
+                    i + 1,
+                    t.trktype.type_string(),
+                    t.subtype.subtype_string(),
+                    t.frames,
+                    t.pregap,
+                    submode,
+                    t.pgsub.subtype_string(),
+                    t.postgap,
+                )
             };
-            let s = format!(
-                "TRACK:{} TYPE:{} SUBTYPE:{} FRAMES:{} PREGAP:{} PGTYPE:{} PGSUB:{} POSTGAP:{}",
-                i + 1,
-                t.trktype.type_string(),
-                t.subtype.subtype_string(),
-                t.frames,
-                t.pregap,
-                submode,
-                t.pgsub.subtype_string(),
-                t.postgap,
-            );
             let mut bytes = s.into_bytes();
             bytes.push(0); // C-string NUL terminator, included in the stored length
             bytes
@@ -535,10 +559,12 @@ impl Default for CdCreateOptions {
     }
 }
 
-/// Shared back end for [`create_from_cue`]/[`create_from_iso`]: assemble the logical image + `CHT2`
-/// metadata from `tracks` and hand off to the V5 writer, **byte-identical to `chdman createcd`**.
+/// Shared back end for the create paths: assemble the logical image + per-track metadata from
+/// `tracks` and hand off to the V5 writer, **byte-identical to `chdman createcd`**. `gdrom` selects
+/// the `CHGD` (GD-ROM) vs `CHT2` (CD) metadata record.
 fn build_cd<W: Write + Seek>(
     mut tracks: Vec<CdTrack>,
+    gdrom: bool,
     out: &mut W,
     opts: CdCreateOptions,
     progress: &mut dyn FnMut(CompressionProgress),
@@ -548,11 +574,16 @@ fn build_cd<W: Write + Seek>(
         return Err(Error::InvalidParameter);
     }
     let logical = assemble_logical(&mut tracks)?;
-    let payloads = build_cht2_payloads(&tracks);
+    let payloads = build_track_metadata(&tracks, gdrom);
+    let tag = if gdrom {
+        crate::make_tag(b"CHGD")
+    } else {
+        crate::make_tag(b"CHT2")
+    };
     let entries: Vec<write::MetaEntry> = payloads
         .iter()
         .map(|p| write::MetaEntry {
-            tag: crate::make_tag(b"CHT2"),
+            tag,
             flags: write::CHD_MDFLAGS_CHECKSUM,
             payload: p,
         })
@@ -588,7 +619,7 @@ pub fn create_from_cue(
     cancel: &dyn Fn() -> bool,
 ) -> Result<()> {
     let tracks = parse_cue(cue_path)?;
-    create_to_path(tracks, out_path, opts, progress, cancel)
+    create_to_path(tracks, false, out_path, opts, progress, cancel)
 }
 
 /// Create a CD CHD from a flat sector image (`.iso`/`.bin`) at `iso_path`, **byte-identical to
@@ -603,23 +634,117 @@ pub fn create_from_iso(
     cancel: &dyn Fn() -> bool,
 ) -> Result<()> {
     let tracks = parse_iso(iso_path)?;
-    create_to_path(tracks, out_path, opts, progress, cancel)
+    create_to_path(tracks, false, out_path, opts, progress, cancel)
+}
+
+/// Create a GD-ROM CHD from a Sega Dreamcast `.gdi` index at `gdi_path`, **byte-identical to
+/// `chdman createcd`**. Port of `parse_gdi` (`cdrom.cpp:2115`): each track's frame count comes from
+/// its file size, and the gap up to the next track's LBA becomes trailing `padframes` on the
+/// previous track (the high-density area split). Writes `CHGD` (GD-ROM) metadata. See
+/// [`create_from_cue`] for callback/cleanup behaviour.
+pub fn create_from_gdi(
+    gdi_path: &Path,
+    out_path: &Path,
+    opts: CdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let tracks = parse_gdi(gdi_path)?;
+    create_to_path(tracks, true, out_path, opts, progress, cancel)
 }
 
 fn create_to_path(
     tracks: Vec<CdTrack>,
+    gdrom: bool,
     out_path: &Path,
     opts: CdCreateOptions,
     progress: &mut dyn FnMut(CompressionProgress),
     cancel: &dyn Fn() -> bool,
 ) -> Result<()> {
     let mut out = File::create(out_path)?;
-    let res = build_cd(tracks, &mut out, opts, progress, cancel);
+    let res = build_cd(tracks, gdrom, &mut out, opts, progress, cancel);
     if res.is_err() {
         drop(out);
         let _ = std::fs::remove_file(out_path);
     }
     res
+}
+
+/// Parse a Sega Dreamcast `.gdi` index into a track list (port of `cdrom_file::parse_gdi`,
+/// `cdrom.cpp:2115`). First line is the track count; each subsequent line is
+/// `tracknum lba type sectorsize "file" offset` (`type` 4 = data, 0 = audio). Each track's frames
+/// come from its file size; the LBA gap to the next track becomes the previous track's `padframes`.
+fn parse_gdi(gdi_path: &Path) -> Result<Vec<CdTrack>> {
+    let text = std::fs::read_to_string(gdi_path)?;
+    let dir = gdi_path.parent().unwrap_or_else(|| Path::new(""));
+
+    let mut lines = text.lines();
+    let numtracks: usize = lines
+        .next()
+        .and_then(|l| l.split_whitespace().next())
+        .and_then(|t| t.parse().ok())
+        .ok_or(Error::InvalidData)?;
+    if numtracks == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    let mut slots: Vec<Option<CdTrack>> = (0..numtracks).map(|_| None).collect();
+    let mut physframeofs = vec![0u32; numtracks];
+    for line in lines {
+        let toks = tokenize_line(line);
+        if toks.is_empty() {
+            continue;
+        }
+        if toks.len() != 6 {
+            return Err(Error::InvalidData);
+        }
+        let trknum = toks[0]
+            .parse::<i64>()
+            .ok()
+            .filter(|&n| n >= 1)
+            .ok_or(Error::InvalidData)? as usize
+            - 1;
+        if trknum >= numtracks {
+            return Err(Error::InvalidData);
+        }
+        let pfo: u32 = toks[1].parse().map_err(|_| Error::InvalidData)?;
+        let trktype: u32 = toks[2].parse().map_err(|_| Error::InvalidData)?;
+        let trksize: u32 = toks[3].parse().map_err(|_| Error::InvalidData)?;
+        if trksize == 0 {
+            return Err(Error::InvalidData);
+        }
+        let (tt, datasize, swap) = match (trktype, trksize) {
+            (4, 2352) => (TrackType::Mode1Raw, 2352, false),
+            (4, 2048) => (TrackType::Mode1, 2048, false),
+            (0, _) => (TrackType::Audio, 2352, true),
+            _ => return Err(Error::UnsupportedFormat),
+        };
+        let fname = dir.join(&toks[4]);
+        let sz = file_size(&fname)?;
+        let mut t = CdTrack::new(tt, datasize, fname, swap);
+        t.frames = (sz / trksize as u64) as u32;
+        physframeofs[trknum] = pfo;
+        slots[trknum] = Some(t);
+    }
+
+    let mut tracks: Vec<CdTrack> = slots
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .ok_or(Error::InvalidData)?;
+
+    // The gap between a track's LBA and the previous track's end is padding appended to the
+    // previous track (chdman's `frames[trk-1] += dif; padframes[trk-1] = dif`).
+    for trk in 1..numtracks {
+        let prev_end = tracks[trk - 1].frames as i64 + physframeofs[trk - 1] as i64;
+        let dif = physframeofs[trk] as i64 - prev_end;
+        if dif < 0 {
+            return Err(Error::InvalidData);
+        }
+        tracks[trk - 1].frames += dif as u32;
+        tracks[trk - 1].padframes = dif as u32;
+    }
+
+    Ok(tracks)
 }
 
 // ---------------------------------------------------------------------------

--- a/chd-rs/src/cd.rs
+++ b/chd-rs/src/cd.rs
@@ -12,11 +12,12 @@
 //! metadata, then reuse the shared V5 writer ([`write::write_create`](crate::write)). Output is
 //! **byte-identical to `chdman createcd`** (verified for `-c cdzl`/`cdlz`).
 //!
-//! [`extract_to_cue`] reverses this (chdman `extractcd`), and [`list_tracks`] reads the track
-//! table back. Both are byte-identical to chdman.
+//! [`extract_to_cue`] reverses this (chdman `extractcd`, byte-identical), [`list_tracks`] reads the
+//! track table back, and [`extract_to_iso`] / [`CdCookedReader`] expose a single MODE1 track's
+//! cooked 2048-byte user data.
 //!
 //! Matches libchdman-rs's `cd` module. All four CD codecs (`cdlz`/`cdzl`/`cdzs`/`cdfl`) encode.
-//! GDI/Nero parsing, `.gdi`/split-bin extraction, and `CdCookedReader` are not yet implemented.
+//! GDI/Nero TOC parsing and `.gdi`/split-bin extraction are not yet implemented.
 
 use crate::error::{Error, Result};
 use crate::metadata::Metadata;
@@ -26,8 +27,11 @@ use crate::{
 };
 use std::convert::TryInto;
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{self, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+
+/// Cooked MODE1/MODE2-Form1 user-data size (`2048`).
+const COOKED_SECTOR: usize = 2048;
 
 /// Bytes of sector data in a CD frame (`2352`).
 pub const CD_MAX_SECTOR_DATA: u32 = crate::cdrom::CD_MAX_SECTOR_DATA;
@@ -851,6 +855,174 @@ pub fn extract_to_cue(
     if res.is_err() {
         let _ = std::fs::remove_file(bin_path);
         let _ = std::fs::remove_file(cue_path);
+    }
+    res
+}
+
+/// The cooked-user-data byte offset within a decoded 2448-byte frame for a MODE1 track: `0` for a
+/// cooked `MODE1` (2048) track, `16` for a raw `MODE1_RAW` (skip the 12-byte sync + 4-byte header).
+/// Other track types have no 2048-byte cooked representation here.
+fn cooked_offset(trktype: TrackType) -> Option<usize> {
+    match trktype {
+        TrackType::Mode1 => Some(0),
+        TrackType::Mode1Raw => Some(16),
+        _ => None,
+    }
+}
+
+/// A `Read + Seek` stream over a MODE1 track's **cooked 2048-byte sectors**, so an ISO9660/UDF
+/// parser can consume a CD CHD directly without extracting to a `.iso` first. The sync header,
+/// address, and ECC/EDC of raw (`MODE1_RAW`) sectors are stripped on the fly, so the stream length
+/// is always `frames * 2048` regardless of how the track was stored.
+///
+/// Matches libchdman-rs's `CdCookedReader`, but wraps chd-rs's owned [`Chd`] (via [`ChdReader`])
+/// and currently supports only `MODE1`/`MODE1_RAW` tracks (other types →
+/// [`Error::UnsupportedFormat`]).
+pub struct CdCookedReader<F: Read + Seek> {
+    reader: ChdReader<F>,
+    chd_frame_start: u64,
+    total_frames: u32,
+    cooked_offset: usize,
+    pos: u64,
+    cache_frame: Option<u32>,
+    cache: [u8; COOKED_SECTOR],
+}
+
+impl<F: Read + Seek> CdCookedReader<F> {
+    /// Open a **single-track** CD CHD as a cooked sector stream. Errors with
+    /// [`Error::UnsupportedFormat`] if there is more than one track (use [`open_track`] for those)
+    /// or the track is not MODE1.
+    ///
+    /// [`open_track`]: CdCookedReader::open_track
+    pub fn open(mut chd: Chd<F>) -> Result<Self> {
+        if read_track_metas(&mut chd)?.len() != 1 {
+            return Err(Error::UnsupportedFormat);
+        }
+        Self::open_track(chd, 0)
+    }
+
+    /// Open a specific (0-based) track of a CD CHD as a cooked sector stream. Position 0 is the
+    /// start of that track's user data. The track must be `MODE1`/`MODE1_RAW`.
+    pub fn open_track(mut chd: Chd<F>, track_index: usize) -> Result<Self> {
+        let metas = read_track_metas(&mut chd)?;
+        if track_index >= metas.len() {
+            return Err(Error::InvalidParameter);
+        }
+        let cooked_offset =
+            cooked_offset(metas[track_index].trktype).ok_or(Error::UnsupportedFormat)?;
+        let total_frames = metas[track_index].frames;
+        // logical-image frame where this track's data starts (cumulative frames + 4-frame padding)
+        let chd_frame_start: u64 = metas[..track_index]
+            .iter()
+            .map(|m| (m.frames + m.extraframes) as u64)
+            .sum();
+        Ok(CdCookedReader {
+            reader: ChdReader::new(chd),
+            chd_frame_start,
+            total_frames,
+            cooked_offset,
+            pos: 0,
+            cache_frame: None,
+            cache: [0u8; COOKED_SECTOR],
+        })
+    }
+
+    /// Total length of the cooked stream in bytes (`frames * 2048`).
+    pub fn len(&self) -> u64 {
+        self.total_frames as u64 * COOKED_SECTOR as u64
+    }
+
+    /// Whether the track has no sectors.
+    pub fn is_empty(&self) -> bool {
+        self.total_frames == 0
+    }
+
+    fn load_frame(&mut self, frame: u32) -> io::Result<()> {
+        if self.cache_frame == Some(frame) {
+            return Ok(());
+        }
+        let off = (self.chd_frame_start + frame as u64) * CD_FRAME_SIZE as u64;
+        self.reader.seek(SeekFrom::Start(off))?;
+        let mut full = [0u8; CD_FRAME_SIZE as usize];
+        self.reader.read_exact(&mut full)?;
+        self.cache
+            .copy_from_slice(&full[self.cooked_offset..self.cooked_offset + COOKED_SECTOR]);
+        self.cache_frame = Some(frame);
+        Ok(())
+    }
+}
+
+impl<F: Read + Seek> Read for CdCookedReader<F> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let total = self.len();
+        if self.pos >= total || buf.is_empty() {
+            return Ok(0);
+        }
+        let want = (buf.len() as u64).min(total - self.pos) as usize;
+        let frame = (self.pos / COOKED_SECTOR as u64) as u32;
+        let off = (self.pos % COOKED_SECTOR as u64) as usize;
+        let n = want.min(COOKED_SECTOR - off);
+        self.load_frame(frame)?;
+        buf[..n].copy_from_slice(&self.cache[off..off + n]);
+        self.pos += n as u64;
+        Ok(n)
+    }
+}
+
+impl<F: Read + Seek> Seek for CdCookedReader<F> {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let total = self.len() as i128;
+        let new_pos: i128 = match pos {
+            SeekFrom::Start(v) => v as i128,
+            SeekFrom::End(v) => total + v as i128,
+            SeekFrom::Current(v) => self.pos as i128 + v as i128,
+        };
+        if new_pos < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "seek before start of cooked stream",
+            ));
+        }
+        self.pos = new_pos as u64;
+        Ok(self.pos)
+    }
+}
+
+/// Extract a **single-track** MODE1 CD CHD to a raw `.iso` (2048 cooked bytes per sector), matching
+/// libchdman-rs's `extract_to_iso`. Rejects multi-track or non-MODE1 CHDs with
+/// [`Error::UnsupportedFormat`]. `progress` is called with the running byte count. On error the
+/// partial `iso_path` is removed.
+///
+/// (chdman has no direct CD→iso command — `extractcd` emits cue/bin or gdi — so this is a chd-rs /
+/// libchdman convenience verified by round-trip, not byte-identity.)
+pub fn extract_to_iso(
+    chd_path: &Path,
+    iso_path: &Path,
+    progress: &mut dyn FnMut(u64),
+) -> Result<()> {
+    let f = BufReader::new(File::open(chd_path).map_err(Error::from)?);
+    let chd = Chd::open(f, None)?;
+    let mut reader = CdCookedReader::open(chd)?;
+
+    let res = (|| -> Result<()> {
+        let mut out = BufWriter::new(File::create(iso_path).map_err(Error::from)?);
+        let mut buf = vec![0u8; COOKED_SECTOR * 16];
+        let mut written = 0u64;
+        loop {
+            let n = reader.read(&mut buf).map_err(Error::from)?;
+            if n == 0 {
+                break;
+            }
+            out.write_all(&buf[..n]).map_err(Error::from)?;
+            written += n as u64;
+            progress(written);
+        }
+        out.flush().map_err(Error::from)?;
+        Ok(())
+    })();
+
+    if res.is_err() {
+        let _ = std::fs::remove_file(iso_path);
     }
     res
 }

--- a/chd-rs/src/cd.rs
+++ b/chd-rs/src/cd.rs
@@ -1,4 +1,4 @@
-//! CD-ROM CHDs — chdman `createcd` parity.
+//! CD-ROM CHDs — chdman `createcd` / `extractcd` parity.
 //!
 //! A CD CHD stores the disc as fixed **2448-byte frames** (`2352` sector + `96` subcode), eight
 //! frames to a `19584`-byte hunk, compressed with the CD wrapper codecs (`cdlz`/`cdzl`/`cdfl`/`cdzs`
@@ -12,13 +12,21 @@
 //! metadata, then reuse the shared V5 writer ([`write::write_create`](crate::write)). Output is
 //! **byte-identical to `chdman createcd`** (verified for `-c cdzl`/`cdlz`).
 //!
-//! Matches libchdman-rs's `cd` module. All four CD codecs (`cdlz`/`cdzl`/`cdzs`/`cdfl`) encode;
-//! extraction (`extractcd`), GDI/Nero parsing, and `list_tracks` are not yet implemented.
+//! [`extract_to_cue`] reverses this (chdman `extractcd`), and [`list_tracks`] reads the track
+//! table back. Both are byte-identical to chdman.
+//!
+//! Matches libchdman-rs's `cd` module. All four CD codecs (`cdlz`/`cdzl`/`cdzs`/`cdfl`) encode.
+//! GDI/Nero parsing, `.gdi`/split-bin extraction, and `CdCookedReader` are not yet implemented.
 
 use crate::error::{Error, Result};
-use crate::{write, CompressionProgress, CHD_CODEC_CD_FLAC, CHD_CODEC_CD_LZMA, CHD_CODEC_CD_ZLIB};
+use crate::metadata::Metadata;
+use crate::read::ChdReader;
+use crate::{
+    write, Chd, CompressionProgress, CHD_CODEC_CD_FLAC, CHD_CODEC_CD_LZMA, CHD_CODEC_CD_ZLIB,
+};
+use std::convert::TryInto;
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 /// Bytes of sector data in a CD frame (`2352`).
@@ -93,6 +101,38 @@ impl SubcodeType {
             SubcodeType::Raw => "RW_RAW",
             SubcodeType::None => "NONE",
         }
+    }
+}
+
+/// Per-track summary read back from a CD CHD's metadata (or a parsed TOC). Matches libchdman-rs's
+/// `TrackInfo`. Returned by [`list_tracks`].
+#[derive(Debug, Clone)]
+pub struct TrackInfo {
+    /// 1-based track number.
+    pub track_num: u32,
+    /// Track data type.
+    pub track_type: TrackType,
+    /// Subcode type.
+    pub subcode_type: SubcodeType,
+    /// Number of frames (sectors) in the track.
+    pub frames: u32,
+    /// Pregap length in frames.
+    pub pregap: u32,
+    /// Postgap length in frames.
+    pub postgap: u32,
+    /// Pregap sector type (`MODE1` unless the pregap carries data).
+    pub pregap_type: TrackType,
+    /// Pregap subcode type.
+    pub pregap_subcode: SubcodeType,
+}
+
+/// Map a subcode-type string to its [`SubcodeType`] (`RW`/`RW_RAW`, else `NONE`), as chdman's
+/// `convert_subtype_string_to_track_info` (`cdrom.cpp:777`).
+fn subtype_from_string(s: &str) -> SubcodeType {
+    match s {
+        "RW" => SubcodeType::Normal,
+        "RW_RAW" => SubcodeType::Raw,
+        _ => SubcodeType::None,
     }
 }
 
@@ -574,6 +614,243 @@ fn create_to_path(
     if res.is_err() {
         drop(out);
         let _ = std::fs::remove_file(out_path);
+    }
+    res
+}
+
+// ---------------------------------------------------------------------------
+// extractcd: read a CD CHD's track metadata + reconstruct cue/bin
+// ---------------------------------------------------------------------------
+
+/// A track parsed back from a CD CHD's `CHT2`/`CHTR` metadata, with the derived sizes the extractor
+/// needs (the read-side analogue of [`CdTrack`]). Port of `cdrom_file::parse_metadata`
+/// (`cdrom.cpp:899`) for the modern (`CHT2`) and legacy (`CHTR`) records.
+struct TrackMeta {
+    trktype: TrackType,
+    datasize: u32,
+    subtype: SubcodeType,
+    frames: u32,
+    extraframes: u32,
+    pregap: u32,
+    postgap: u32,
+    pgtype: TrackType,
+    pgsub: SubcodeType,
+    pgdatasize: u32,
+}
+
+/// Parse a `CHT2` (`"TRACK:.. TYPE:.. SUBTYPE:.. FRAMES:.. PREGAP:.. PGTYPE:.. PGSUB:.. POSTGAP:.."`)
+/// or legacy `CHTR` (`"TRACK:.. TYPE:.. SUBTYPE:.. FRAMES:.."`) payload. Mirrors
+/// `parse_metadata`: the pregap type/subcode are applied only when `pregap > 0` (and `PGTYPE` is
+/// `V`-prefixed for a data-bearing pregap); the 4-frame `extraframes` padding is recomputed here.
+fn parse_track_metadata(payload: &[u8]) -> Option<TrackMeta> {
+    let s = std::str::from_utf8(payload).ok()?;
+    let s = s.trim_end_matches('\0');
+
+    let (mut typ, mut subtype, mut pgtype_s, mut pgsub_s) = ("", "", "", "");
+    let (mut frames, mut pregap, mut postgap) = (None::<u32>, 0u32, 0u32);
+    for tok in s.split_whitespace() {
+        let (k, v) = tok.split_once(':')?;
+        match k {
+            "TYPE" => typ = v,
+            "SUBTYPE" => subtype = v,
+            "FRAMES" => frames = Some(v.parse().ok()?),
+            "PREGAP" => pregap = v.parse().ok()?,
+            "PGTYPE" => pgtype_s = v,
+            "PGSUB" => pgsub_s = v,
+            "POSTGAP" => postgap = v.parse().ok()?,
+            _ => {} // TRACK: (we rely on stored order) and anything else
+        }
+    }
+    let frames = frames?;
+    let (trktype, datasize) = type_from_string(typ)?;
+    let subtype = subtype_from_string(subtype);
+    let extraframes = frames.div_ceil(TRACK_PADDING) * TRACK_PADDING - frames;
+
+    // pregap defaults to MODE1/NONE; only a non-zero pregap reads PGTYPE/PGSUB (as parse_metadata).
+    let (mut pgtype, mut pgsub, mut pgdatasize) = (TrackType::Mode1, SubcodeType::None, 0u32);
+    if pregap > 0 {
+        if let Some(stripped) = pgtype_s.strip_prefix('V') {
+            if let Some((t, ds)) = type_from_string(stripped) {
+                pgtype = t;
+                pgdatasize = ds;
+            }
+        }
+        pgsub = subtype_from_string(pgsub_s);
+    }
+
+    Some(TrackMeta {
+        trktype,
+        datasize,
+        subtype,
+        frames,
+        extraframes,
+        pregap,
+        postgap,
+        pgtype,
+        pgsub,
+        pgdatasize,
+    })
+}
+
+/// Read all `CHT2`/`CHTR` track records from a CD CHD in stored (track) order.
+fn read_track_metas<F: Read + Seek>(chd: &mut Chd<F>) -> Result<Vec<TrackMeta>> {
+    let cht2 = crate::make_tag(b"CHT2");
+    let chtr = crate::make_tag(b"CHTR");
+    let metas: Vec<Metadata> = chd.metadata_refs().try_into()?;
+    let mut out = Vec::new();
+    for m in &metas {
+        if m.metatag == cht2 || m.metatag == chtr {
+            out.push(parse_track_metadata(&m.value).ok_or(Error::InvalidData)?);
+        }
+    }
+    if out.is_empty() {
+        return Err(Error::UnsupportedFormat);
+    }
+    Ok(out)
+}
+
+/// List a CD CHD's tracks (chdman's `cdrom_file::parse_metadata`), reading the `CHT2`/`CHTR`
+/// metadata. Takes `&mut Chd` (chd-rs reads metadata through a mutable borrow) rather than
+/// libchdman-rs's `&Chd`.
+pub fn list_tracks<F: Read + Seek>(chd: &mut Chd<F>) -> Result<Vec<TrackInfo>> {
+    let metas = read_track_metas(chd)?;
+    Ok(metas
+        .iter()
+        .enumerate()
+        .map(|(i, t)| TrackInfo {
+            track_num: i as u32 + 1,
+            track_type: t.trktype,
+            subcode_type: t.subtype,
+            frames: t.frames,
+            pregap: t.pregap,
+            postgap: t.postgap,
+            pregap_type: t.pgtype,
+            pregap_subcode: t.pgsub,
+        })
+        .collect())
+}
+
+/// MAME's `msf_string_from_frames` (`chdman.cpp:1072`): `"%02d:%02d:%02d"` (minutes:seconds:frames,
+/// 75 frames/second).
+fn msf_string(frames: u32) -> String {
+    format!(
+        "{:02}:{:02}:{:02}",
+        frames / (75 * 60),
+        (frames / 75) % 60,
+        frames % 75
+    )
+}
+
+/// Append one track's CUE lines (port of `output_track_metadata`'s `MODE_CUEBIN` branch,
+/// `chdman.cpp:1534`). `frameoffs` is the track's disc LBA (cumulative frames, no padding);
+/// `outputoffs` is the byte offset in the bin file (the `FILE` line is emitted only at offset 0).
+fn append_cue_track(
+    cue: &mut String,
+    idx: usize,
+    t: &TrackMeta,
+    frameoffs: u32,
+    bin_name: &str,
+    outputoffs: u64,
+) {
+    use std::fmt::Write;
+    if outputoffs == 0 {
+        let _ = writeln!(cue, "FILE \"{bin_name}\" BINARY");
+    }
+    let typestr = match t.trktype {
+        TrackType::Mode1 | TrackType::Mode1Raw => format!("MODE1/{:04}", t.datasize),
+        TrackType::Mode2
+        | TrackType::Mode2Form1
+        | TrackType::Mode2Form2
+        | TrackType::Mode2FormMix
+        | TrackType::Mode2Raw => format!("MODE2/{:04}", t.datasize),
+        TrackType::Audio => "AUDIO".to_string(),
+    };
+    let _ = writeln!(cue, "  TRACK {:02} {typestr}", idx + 1);
+    if t.pregap > 0 && t.pgdatasize == 0 {
+        let _ = writeln!(cue, "    PREGAP {}", msf_string(t.pregap));
+        let _ = writeln!(cue, "    INDEX 01 {}", msf_string(frameoffs));
+    } else if t.pregap > 0 && t.pgdatasize > 0 {
+        let _ = writeln!(cue, "    INDEX 00 {}", msf_string(frameoffs));
+        let _ = writeln!(cue, "    INDEX 01 {}", msf_string(frameoffs + t.pregap));
+    }
+    if t.pregap == 0 {
+        let _ = writeln!(cue, "    INDEX 01 {}", msf_string(frameoffs));
+    }
+    if t.postgap > 0 {
+        let _ = writeln!(cue, "    POSTGAP {}", msf_string(t.postgap));
+    }
+}
+
+/// Extract a CD CHD to a single CUE sheet + BIN (chdman `extractcd`, the `MODE_CUEBIN` non-split
+/// path), **byte-identical to `chdman extractcd -o <cue> -ob <bin>`**.
+///
+/// Reconstructs the combined BIN (each track's `frames` sectors of `datasize` bytes, audio tracks
+/// byte-pair-swapped back to little-endian, the 4-frame padding between tracks dropped, subcode
+/// omitted) and the CUE (one `FILE` line + per-track `TRACK`/`INDEX`/`PREGAP`/`POSTGAP`, exactly as
+/// `output_track_metadata`). `progress` is called with the running BIN byte count.
+///
+/// GD-ROM, split-bin, and `.gdi`/`.toc` outputs are not yet supported; a track that stored subcode
+/// has it silently dropped (as bin/cue cannot represent it).
+pub fn extract_to_cue(
+    chd_path: &Path,
+    cue_path: &Path,
+    bin_path: &Path,
+    progress: &mut dyn FnMut(u64),
+) -> Result<()> {
+    let f = BufReader::new(File::open(chd_path).map_err(Error::from)?);
+    let mut chd = Chd::open(f, None)?;
+    let tracks = read_track_metas(&mut chd)?;
+
+    let bin_name = bin_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or(Error::InvalidParameter)?
+        .to_string();
+
+    let res = (|| -> Result<()> {
+        let mut bin = BufWriter::new(File::create(bin_path).map_err(Error::from)?);
+        let mut cue = String::new();
+        let mut reader = ChdReader::new(chd);
+        let mut frame = vec![0u8; CD_FRAME_SIZE as usize];
+        let mut discoffs = 0u32; // disc LBA (cumulative frames, no padding) — for the cue
+        let mut written = 0u64; // bin byte offset
+
+        for (i, t) in tracks.iter().enumerate() {
+            append_cue_track(&mut cue, i, t, discoffs, &bin_name, written);
+
+            let ds = t.datasize as usize;
+            for _ in 0..t.frames {
+                reader.read_exact(&mut frame).map_err(Error::from)?;
+                if t.trktype == TrackType::Audio {
+                    let mut k = 0;
+                    while k + 1 < ds {
+                        frame.swap(k, k + 1);
+                        k += 2;
+                    }
+                }
+                bin.write_all(&frame[..ds]).map_err(Error::from)?;
+                written += ds as u64;
+            }
+            // consume (drop) the track's 4-frame-boundary padding so the next track aligns
+            for _ in 0..t.extraframes {
+                reader.read_exact(&mut frame).map_err(Error::from)?;
+            }
+            discoffs += t.frames;
+            progress(written);
+        }
+
+        bin.flush().map_err(Error::from)?;
+        // chdman writes the TOC in text mode, so its line endings follow the host platform (CRLF on
+        // Windows, LF elsewhere). Match the same-platform chdman for byte-identity.
+        #[cfg(windows)]
+        let cue = cue.replace('\n', "\r\n");
+        std::fs::write(cue_path, cue.as_bytes()).map_err(Error::from)?;
+        Ok(())
+    })();
+
+    if res.is_err() {
+        let _ = std::fs::remove_file(bin_path);
+        let _ = std::fs::remove_file(cue_path);
     }
     res
 }

--- a/chd-rs/src/cd.rs
+++ b/chd-rs/src/cd.rs
@@ -16,10 +16,11 @@
 //! track table back, and [`extract_to_iso`] / [`CdCookedReader`] expose a single MODE1 track's
 //! cooked 2048-byte user data.
 //!
-//! [`create_from_gdi`] handles Sega Dreamcast `.gdi` indices (GD-ROM, `CHGD` metadata).
+//! [`create_from_gdi`] / [`extract_to_gdi`] handle Sega Dreamcast `.gdi` indices (GD-ROM, `CHGD`
+//! metadata, split per-track files), both byte-identical to chdman.
 //!
-//! Matches libchdman-rs's `cd` module. All four CD codecs (`cdlz`/`cdzl`/`cdzs`/`cdfl`) encode.
-//! Nero (`.nrg`) TOC parsing and `.gdi`/split-bin extraction are not yet implemented.
+//! Matches libchdman-rs's `cd` module. All four CD codecs (`cdlz`/`cdzl`/`cdzs`/`cdfl`) encode. Only
+//! Nero (`.nrg`) TOC parsing is not yet implemented.
 
 use crate::error::{Error, Result};
 use crate::metadata::Metadata;
@@ -751,15 +752,16 @@ fn parse_gdi(gdi_path: &Path) -> Result<Vec<CdTrack>> {
 // extractcd: read a CD CHD's track metadata + reconstruct cue/bin
 // ---------------------------------------------------------------------------
 
-/// A track parsed back from a CD CHD's `CHT2`/`CHTR` metadata, with the derived sizes the extractor
-/// needs (the read-side analogue of [`CdTrack`]). Port of `cdrom_file::parse_metadata`
-/// (`cdrom.cpp:899`) for the modern (`CHT2`) and legacy (`CHTR`) records.
+/// A track parsed back from a CD CHD's `CHT2`/`CHTR`/`CHGD`/`CHGT` metadata, with the derived sizes
+/// the extractor needs (the read-side analogue of [`CdTrack`]). Port of `cdrom_file::parse_metadata`
+/// (`cdrom.cpp:899`).
 struct TrackMeta {
     trktype: TrackType,
     datasize: u32,
     subtype: SubcodeType,
     frames: u32,
     extraframes: u32,
+    padframes: u32,
     pregap: u32,
     postgap: u32,
     pgtype: TrackType,
@@ -767,8 +769,7 @@ struct TrackMeta {
     pgdatasize: u32,
 }
 
-/// Parse a `CHT2` (`"TRACK:.. TYPE:.. SUBTYPE:.. FRAMES:.. PREGAP:.. PGTYPE:.. PGSUB:.. POSTGAP:.."`)
-/// or legacy `CHTR` (`"TRACK:.. TYPE:.. SUBTYPE:.. FRAMES:.."`) payload. Mirrors
+/// Parse a `CHT2`/`CHTR` (CD) or `CHGD`/`CHGT` (GD-ROM, with a `PAD:` field) track payload. Mirrors
 /// `parse_metadata`: the pregap type/subcode are applied only when `pregap > 0` (and `PGTYPE` is
 /// `V`-prefixed for a data-bearing pregap); the 4-frame `extraframes` padding is recomputed here.
 fn parse_track_metadata(payload: &[u8]) -> Option<TrackMeta> {
@@ -776,13 +777,14 @@ fn parse_track_metadata(payload: &[u8]) -> Option<TrackMeta> {
     let s = s.trim_end_matches('\0');
 
     let (mut typ, mut subtype, mut pgtype_s, mut pgsub_s) = ("", "", "", "");
-    let (mut frames, mut pregap, mut postgap) = (None::<u32>, 0u32, 0u32);
+    let (mut frames, mut pregap, mut postgap, mut padframes) = (None::<u32>, 0u32, 0u32, 0u32);
     for tok in s.split_whitespace() {
         let (k, v) = tok.split_once(':')?;
         match k {
             "TYPE" => typ = v,
             "SUBTYPE" => subtype = v,
             "FRAMES" => frames = Some(v.parse().ok()?),
+            "PAD" => padframes = v.parse().ok()?,
             "PREGAP" => pregap = v.parse().ok()?,
             "PGTYPE" => pgtype_s = v,
             "PGSUB" => pgsub_s = v,
@@ -813,6 +815,7 @@ fn parse_track_metadata(payload: &[u8]) -> Option<TrackMeta> {
         subtype,
         frames,
         extraframes,
+        padframes,
         pregap,
         postgap,
         pgtype,
@@ -821,28 +824,35 @@ fn parse_track_metadata(payload: &[u8]) -> Option<TrackMeta> {
     })
 }
 
-/// Read all `CHT2`/`CHTR` track records from a CD CHD in stored (track) order.
-fn read_track_metas<F: Read + Seek>(chd: &mut Chd<F>) -> Result<Vec<TrackMeta>> {
+/// Read all CD/GD track records (`CHT2`/`CHTR`/`CHGD`/`CHGT`) from a CHD in stored (track) order,
+/// plus whether they are GD-ROM (`CHGD`/`CHGT`) records.
+fn read_track_metas<F: Read + Seek>(chd: &mut Chd<F>) -> Result<(Vec<TrackMeta>, bool)> {
     let cht2 = crate::make_tag(b"CHT2");
     let chtr = crate::make_tag(b"CHTR");
+    let chgd = crate::make_tag(b"CHGD");
+    let chgt = crate::make_tag(b"CHGT");
     let metas: Vec<Metadata> = chd.metadata_refs().try_into()?;
     let mut out = Vec::new();
+    let mut gdrom = false;
     for m in &metas {
         if m.metatag == cht2 || m.metatag == chtr {
+            out.push(parse_track_metadata(&m.value).ok_or(Error::InvalidData)?);
+        } else if m.metatag == chgd || m.metatag == chgt {
+            gdrom = true;
             out.push(parse_track_metadata(&m.value).ok_or(Error::InvalidData)?);
         }
     }
     if out.is_empty() {
         return Err(Error::UnsupportedFormat);
     }
-    Ok(out)
+    Ok((out, gdrom))
 }
 
 /// List a CD CHD's tracks (chdman's `cdrom_file::parse_metadata`), reading the `CHT2`/`CHTR`
 /// metadata. Takes `&mut Chd` (chd-rs reads metadata through a mutable borrow) rather than
 /// libchdman-rs's `&Chd`.
 pub fn list_tracks<F: Read + Seek>(chd: &mut Chd<F>) -> Result<Vec<TrackInfo>> {
-    let metas = read_track_metas(chd)?;
+    let (metas, _gdrom) = read_track_metas(chd)?;
     Ok(metas
         .iter()
         .enumerate()
@@ -928,7 +938,7 @@ pub fn extract_to_cue(
 ) -> Result<()> {
     let f = BufReader::new(File::open(chd_path).map_err(Error::from)?);
     let mut chd = Chd::open(f, None)?;
-    let tracks = read_track_metas(&mut chd)?;
+    let (tracks, _gdrom) = read_track_metas(&mut chd)?;
 
     let bin_name = bin_path
         .file_name()
@@ -1020,7 +1030,7 @@ impl<F: Read + Seek> CdCookedReader<F> {
     ///
     /// [`open_track`]: CdCookedReader::open_track
     pub fn open(mut chd: Chd<F>) -> Result<Self> {
-        if read_track_metas(&mut chd)?.len() != 1 {
+        if read_track_metas(&mut chd)?.0.len() != 1 {
             return Err(Error::UnsupportedFormat);
         }
         Self::open_track(chd, 0)
@@ -1029,7 +1039,7 @@ impl<F: Read + Seek> CdCookedReader<F> {
     /// Open a specific (0-based) track of a CD CHD as a cooked sector stream. Position 0 is the
     /// start of that track's user data. The track must be `MODE1`/`MODE1_RAW`.
     pub fn open_track(mut chd: Chd<F>, track_index: usize) -> Result<Self> {
-        let metas = read_track_metas(&mut chd)?;
+        let (metas, _gdrom) = read_track_metas(&mut chd)?;
         if track_index >= metas.len() {
             return Err(Error::InvalidParameter);
         }
@@ -1150,6 +1160,118 @@ pub fn extract_to_iso(
         let _ = std::fs::remove_file(iso_path);
     }
     res
+}
+
+/// Extract a CD/GD-ROM CHD to a Sega `.gdi` index plus one split file per track, matching chdman's
+/// `extractcd` GDI output (`MODE_GDI` in `do_extract_cd`), **byte-identical** to it.
+///
+/// Writes `gdi_path` — first line the track count, then one `num lba type datasize "file" 0` line
+/// per track (`type` 4 = data, 0 = audio) — and, alongside it, `<stem>NN.bin` (data) / `<stem>NN.raw`
+/// (audio) per track, where `<stem>` is `gdi_path` with its extension removed and `NN` is the
+/// zero-padded track number (chdman's `%02t` scheme). Audio is byte-swapped to little-endian (the CHD
+/// stores it big-endian), the `padframes` area-gap fill is dropped, and subcode is omitted. On error
+/// the partial outputs are removed.
+pub fn extract_to_gdi(
+    chd_path: &Path,
+    gdi_path: &Path,
+    progress: &mut dyn FnMut(u64),
+) -> Result<()> {
+    let f = BufReader::new(File::open(chd_path).map_err(Error::from)?);
+    let mut chd = Chd::open(f, None)?;
+    let (tracks, _gdrom) = read_track_metas(&mut chd)?;
+
+    let dir = gdi_path.parent().map(Path::to_path_buf).unwrap_or_default();
+    let stem = gdi_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or(Error::InvalidParameter)?
+        .to_string();
+
+    let mut written_files: Vec<PathBuf> = Vec::new();
+    let res = extract_gdi_inner(
+        chd,
+        &tracks,
+        gdi_path,
+        &dir,
+        &stem,
+        &mut written_files,
+        progress,
+    );
+    if res.is_err() {
+        for p in &written_files {
+            let _ = std::fs::remove_file(p);
+        }
+        let _ = std::fs::remove_file(gdi_path);
+    }
+    res
+}
+
+fn extract_gdi_inner<F: Read + Seek>(
+    chd: Chd<F>,
+    tracks: &[TrackMeta],
+    gdi_path: &Path,
+    dir: &Path,
+    stem: &str,
+    written_files: &mut Vec<PathBuf>,
+    progress: &mut dyn FnMut(u64),
+) -> Result<()> {
+    let mut gdi = format!("{}\n", tracks.len());
+    let mut reader = ChdReader::new(chd);
+    let mut frame = vec![0u8; CD_FRAME_SIZE as usize];
+    let mut discoffs = 0u32; // disc LBA (cumulative frames incl. padding) — the track's start
+    let mut chd_frame = 0u64; // logical-image frame offset
+    let mut total = 0u64;
+
+    for (i, t) in tracks.iter().enumerate() {
+        let is_audio = t.trktype == TrackType::Audio;
+        let name = format!(
+            "{stem}{:02}.{}",
+            i + 1,
+            if is_audio { "raw" } else { "bin" }
+        );
+        let q = if name.contains(' ') { "\"" } else { "" };
+        let tracktype = if is_audio { 0 } else { 4 };
+        // GDI line: tracknum LBA type datasize "file" offset(=0, each track its own file)
+        gdi.push_str(&format!(
+            "{} {} {} {} {q}{name}{q} 0\n",
+            i + 1,
+            discoffs,
+            tracktype,
+            t.datasize
+        ));
+
+        let path = dir.join(&name);
+        written_files.push(path.clone());
+        let mut tf = BufWriter::new(File::create(&path).map_err(Error::from)?);
+        let ds = t.datasize as usize;
+        let actual = t.frames.saturating_sub(t.padframes); // splitframes are 0 for our GD-ROMs
+        reader
+            .seek(SeekFrom::Start(chd_frame * CD_FRAME_SIZE as u64))
+            .map_err(Error::from)?;
+        for _ in 0..actual {
+            reader.read_exact(&mut frame).map_err(Error::from)?;
+            if is_audio {
+                let mut k = 0;
+                while k + 1 < ds {
+                    frame.swap(k, k + 1);
+                    k += 2;
+                }
+            }
+            tf.write_all(&frame[..ds]).map_err(Error::from)?;
+            total += ds as u64;
+        }
+        tf.flush().map_err(Error::from)?;
+
+        discoffs += t.frames;
+        chd_frame += (t.frames + t.extraframes) as u64;
+        progress(total);
+    }
+
+    // chdman writes the .gdi index in text mode — CRLF on Windows, LF elsewhere.
+    #[cfg(windows)]
+    let gdi = gdi.replace('\n', "\r\n");
+    std::fs::write(gdi_path, gdi.as_bytes()).map_err(Error::from)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/chd-rs/src/chdfile.rs
+++ b/chd-rs/src/chdfile.rs
@@ -103,6 +103,69 @@ impl<F: Read + Seek> Chd<F> {
         &self.map
     }
 
+    /// Returns an aggregate [`ChdInfo`](crate::ChdInfo) snapshot of this CHD's header and metadata
+    /// (the data chdman's `info` subcommand reports; mirrors libchdman-rs's `Chd::info`).
+    ///
+    /// Walks the metadata once to derive the tag list, track count, and the `is_hd`/`is_cd`/
+    /// `is_gd`/`is_dvd`/`is_av` type flags (each a metadata-tag-presence check, exactly as MAME's
+    /// `check_is_*`).
+    pub fn info(&mut self) -> Result<crate::ChdInfo> {
+        use crate::make_tag;
+        use crate::metadata::MetadataTag;
+
+        let h = self.header();
+        let version = h.version() as u32;
+        let hunk_bytes = h.hunk_size();
+        let unit_bytes = h.unit_bytes();
+        let hunk_count = h.hunk_count();
+        let logical_bytes = h.logical_bytes();
+        let codecs = h.compression();
+        let sha1 = h.sha1().unwrap_or([0u8; 20]);
+        let raw_sha1 = h.raw_sha1().unwrap_or([0u8; 20]);
+        let parent_sha1 = h.parent_sha1().unwrap_or([0u8; 20]);
+        let has_parent = h.has_parent();
+        let compressed = codecs[0] != 0;
+
+        // Walk the metadata once, recording each entry's tag + its per-tag index.
+        let mut metadata_tags: Vec<(u32, u32)> = Vec::new();
+        let mut per_tag: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
+        for m in self.metadata_refs() {
+            let tag = m.metatag();
+            let idx = per_tag.entry(tag).or_insert(0);
+            metadata_tags.push((tag, *idx));
+            *idx += 1;
+        }
+
+        let has = |t: &[u8; 4]| metadata_tags.iter().any(|&(tag, _)| tag == make_tag(t));
+        let count = |t: &[u8; 4]| {
+            metadata_tags
+                .iter()
+                .filter(|&&(tag, _)| tag == make_tag(t))
+                .count() as u32
+        };
+
+        Ok(crate::ChdInfo {
+            version,
+            hunk_bytes,
+            unit_bytes,
+            hunk_count,
+            logical_bytes,
+            codecs,
+            sha1,
+            raw_sha1,
+            parent_sha1,
+            track_count: count(b"CHT2") + count(b"CHTR") + count(b"CHGD"),
+            is_hd: has(b"GDDD"),
+            is_cd: has(b"CHCD") || has(b"CHTR") || has(b"CHT2"),
+            is_gd: has(b"CHGT") || has(b"CHGD"),
+            is_dvd: has(b"DVD "),
+            is_av: has(b"AVAV"),
+            metadata_tags,
+            compressed,
+            has_parent,
+        })
+    }
+
     /// Returns a reference to the given hunk in this CHD file.
     ///
     /// If the requested hunk is larger than the number of hunks in the CHD file,

--- a/chd-rs/src/chdfile.rs
+++ b/chd-rs/src/chdfile.rs
@@ -17,6 +17,36 @@ use num_traits::ToPrimitive;
 use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::panic::AssertUnwindSafe;
 
+/// Read-side port of `chd_file::compute_overall_sha1` (`chd.cpp:1709`):
+/// `SHA1(raw_sha1 ‖ sorted[ tag(4 BE) ‖ SHA1(payload) ])` over the CHECKSUM-flagged metadata
+/// (sorted by the 24-byte `(tag, sha1)` tuple). Used by [`Chd::verify`].
+#[cfg(feature = "verify")]
+fn verify_overall_sha1(raw_sha1: &[u8; 20], metas: &[crate::metadata::Metadata]) -> [u8; 20] {
+    use sha1::{Digest, Sha1};
+    const CHD_MDFLAGS_CHECKSUM: u8 = 0x01;
+    let mut hashes: Vec<[u8; 24]> = Vec::new();
+    for m in metas {
+        if m.flags & CHD_MDFLAGS_CHECKSUM == 0 {
+            continue;
+        }
+        let mut h = [0u8; 24];
+        h[0..4].copy_from_slice(&m.metatag.to_be_bytes());
+        let mut sh = Sha1::new();
+        sh.update(&m.value);
+        let payload_sha1: [u8; 20] = sh.finalize().into();
+        h[4..24].copy_from_slice(&payload_sha1);
+        hashes.push(h);
+    }
+    hashes.sort_unstable();
+
+    let mut hasher = Sha1::new();
+    hasher.update(raw_sha1);
+    for h in &hashes {
+        hasher.update(h);
+    }
+    hasher.finalize().into()
+}
+
 /// A CHD (MAME Compressed Hunks of Data) file.
 pub struct Chd<F: Read + Seek> {
     file: F,
@@ -184,6 +214,58 @@ impl<F: Read + Seek> Chd<F> {
     pub fn get_hunksized_buffer(&self) -> Vec<u8> {
         let hunk_size = self.header.hunk_size() as usize;
         vec![0u8; hunk_size]
+    }
+
+    /// Verify a compressed CHD's integrity by recomputing its SHA-1 checksums and comparing them to
+    /// the header (chdman `verify`). Decompresses every hunk to recompute the **raw** SHA-1 (over the
+    /// logical, unpadded bytes) and the **overall** SHA-1 (`SHA1(raw_sha1 ‖ sorted checksummed
+    /// metadata hashes)`); the returned [`VerifyResult`](crate::VerifyResult) carries both computed
+    /// and expected values (check [`is_valid`](crate::VerifyResult::is_valid)).
+    ///
+    /// Returns [`Error::UnsupportedFormat`] for an **uncompressed** CHD (those carry no stored
+    /// checksum — chdman likewise refuses). If the CHD references a parent, it must have been opened
+    /// with that parent (parent-ref hunks are read through it). Available with the `verify` feature.
+    #[cfg(feature = "verify")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+    pub fn verify(&mut self) -> Result<crate::VerifyResult> {
+        use sha1::{Digest, Sha1};
+
+        if !self.header.is_compressed() {
+            return Err(Error::UnsupportedFormat);
+        }
+        let expected_raw_sha1 = self
+            .header
+            .raw_sha1()
+            .or_else(|| self.header.sha1())
+            .ok_or(Error::UnsupportedFormat)?;
+        let expected_sha1 = self.header.sha1().unwrap_or(expected_raw_sha1);
+        let logical = self.header.logical_bytes();
+        let hunk_bytes = self.header.hunk_size() as u64;
+        let hunk_count = self.header.hunk_count();
+
+        // Collect the metadata first (owns its bytes), then hash the hunks.
+        let metas: Vec<crate::metadata::Metadata> = self.metadata_refs().try_into()?;
+
+        // raw_sha1 is over the *logical* (unpadded) bytes — drop the final hunk's zero padding.
+        let mut hasher = Sha1::new();
+        let mut comp = Vec::new();
+        let mut buf = vec![0u8; hunk_bytes as usize];
+        let mut remaining = logical;
+        for i in 0..hunk_count {
+            self.hunk(i)?.read_hunk_in(&mut comp, &mut buf)?;
+            let take = remaining.min(hunk_bytes) as usize;
+            hasher.update(&buf[..take]);
+            remaining -= take as u64;
+        }
+        let computed_raw_sha1: [u8; 20] = hasher.finalize().into();
+        let computed_sha1 = verify_overall_sha1(&computed_raw_sha1, &metas);
+
+        Ok(crate::VerifyResult {
+            computed_raw_sha1,
+            computed_sha1,
+            expected_raw_sha1,
+            expected_sha1,
+        })
     }
 
     #[cfg_attr(docsrs, doc(cfg(unstable_lending_iterators)))]
@@ -519,5 +601,113 @@ impl Codecs {
                 _ => None,
             }
         }
+    }
+}
+
+#[cfg(all(test, feature = "write"))]
+mod verify_tests {
+    use crate::Chd;
+    use std::io::Cursor;
+
+    /// Deterministic mixed-compressibility bytes.
+    fn make_input(len: usize) -> Vec<u8> {
+        let mut v = Vec::with_capacity(len);
+        let mut x: u32 = 0x2545_f491;
+        for i in 0..len {
+            let b = match (i / 96) % 3 {
+                0 => 0u8,
+                1 => b"the quick brown fox "[i % 20],
+                _ => {
+                    x ^= x << 13;
+                    x ^= x >> 17;
+                    x ^= x << 5;
+                    (x & 0xff) as u8
+                }
+            };
+            v.push(b);
+        }
+        v
+    }
+
+    /// `verify()` accepts a freshly written compressed CHD, and detects a corrupted stored raw SHA-1
+    /// (data path) and a corrupted metadata payload (overall-SHA-1 path) independently.
+    #[test]
+    fn verify_detects_data_and_metadata_corruption() {
+        // createhd (256 KiB) writes a GDDD record → exercises the metadata-inclusive overall SHA-1.
+        let input = make_input(256 * 1024);
+        let mut cur = Cursor::new(Vec::new());
+        crate::hd::create_from_reader(
+            &input[..],
+            &mut cur,
+            crate::hd::HdCreateOptions {
+                codecs: [crate::CHD_CODEC_ZLIB, 0, 0, 0],
+                ..Default::default()
+            },
+            &mut |_| {},
+            &|| false,
+        )
+        .unwrap();
+        let bytes = cur.into_inner();
+
+        // pristine → valid
+        let mut chd = Chd::open(Cursor::new(bytes.clone()), None).unwrap();
+        let r = chd.verify().unwrap();
+        assert!(r.is_valid(), "fresh CHD should verify: {r:?}");
+
+        // corrupt the stored raw SHA-1 (header byte 64) → raw mismatch, overall mismatch.
+        let mut c1 = bytes.clone();
+        c1[64] ^= 0xff;
+        let r1 = Chd::open(Cursor::new(c1), None).unwrap().verify().unwrap();
+        assert!(
+            !r1.raw_sha1_valid(),
+            "corrupted stored raw SHA-1 must be detected"
+        );
+        assert!(!r1.is_valid());
+
+        // corrupt a metadata payload byte → overall mismatch, but the data (raw) is intact.
+        let meta_off = u64::from_be_bytes(bytes[48..56].try_into().unwrap()) as usize;
+        let mut c2 = bytes.clone();
+        c2[meta_off + 16 + 8] ^= 0xff; // 16-byte entry header, then into the GDDD payload
+        let r2 = Chd::open(Cursor::new(c2), None).unwrap().verify().unwrap();
+        assert!(
+            r2.raw_sha1_valid(),
+            "data is intact so raw SHA-1 should still match"
+        );
+        assert!(
+            !r2.overall_sha1_valid(),
+            "corrupted metadata must fail the overall SHA-1"
+        );
+        assert!(!r2.is_valid());
+    }
+
+    /// `verify()` hashes the *logical* (unpadded) bytes: a createraw CHD with a partial last hunk
+    /// (no metadata, so overall = SHA1(raw_sha1)) verifies.
+    #[test]
+    fn verify_partial_last_hunk_and_uncompressed() {
+        // 5 full 4096-hunks + 3 × 512 units = partial last hunk.
+        let input = make_input(4096 * 5 + 512 * 3);
+        let mut cur = Cursor::new(Vec::new());
+        crate::write::write_raw(
+            &mut cur,
+            &input,
+            4096,
+            512,
+            &[crate::header::CodecType::ZLibV5],
+        )
+        .unwrap();
+        let mut chd = Chd::open(Cursor::new(cur.into_inner()), None).unwrap();
+        assert!(
+            chd.verify().unwrap().is_valid(),
+            "partial-last-hunk CHD should verify (raw SHA-1 over logical bytes)"
+        );
+
+        // uncompressed CHDs carry no checksum → verify refuses.
+        let mut cur2 = Cursor::new(Vec::new());
+        crate::write::write_raw_uncompressed(&mut cur2, &input, 4096, 512).unwrap();
+        let mut chd2 = Chd::open(Cursor::new(cur2.into_inner()), None).unwrap();
+        assert!(matches!(
+            chd2.verify(),
+            Err(crate::Error::UnsupportedFormat)
+        ));
     }
 }

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -2091,3 +2091,72 @@ fn createcd_gdi_bit_exact_vs_chdman() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Full **extractcd → `.gdi`** byte-identity (GD-ROM): build a GD-ROM CHD (via `create_from_gdi`),
+/// then extract it to a `.gdi` + split track files with both chdman (`extractcd -o disc.gdi`) and
+/// chd-rs (`cd::extract_to_gdi`); assert the `.gdi` index **and** every per-track file are
+/// byte-identical, and that the data/audio track files round-trip to the originals.
+#[test]
+fn extractcd_gdi_bit_exact_vs_chdman() {
+    use crate::cd::{self, CdCreateOptions};
+
+    let chdman = chdman_path();
+    let base = std::env::temp_dir();
+    let srcdir = base.join("chdrs_egdi_src");
+    let refdir = base.join("chdrs_egdi_ref");
+    let oursdir = base.join("chdrs_egdi_ours");
+    for d in [&srcdir, &refdir, &oursdir] {
+        let _ = std::fs::remove_dir_all(d);
+        std::fs::create_dir_all(d).unwrap();
+    }
+
+    let t1 = build_mode1_bin(90);
+    let t2 = make_audio_input(140 * 2352);
+    let t3 = build_mode1_bin(50);
+    std::fs::write(srcdir.join("t1.bin"), &t1).unwrap();
+    std::fs::write(srcdir.join("t2.raw"), &t2).unwrap();
+    std::fs::write(srcdir.join("t3.bin"), &t3).unwrap();
+    std::fs::write(
+        srcdir.join("disc.gdi"),
+        "3\n1 0 4 2352 \"t1.bin\" 0\n2 100 0 2352 \"t2.raw\" 0\n3 250 4 2352 \"t3.bin\" 0\n",
+    )
+    .unwrap();
+    let chd = srcdir.join("disc.chd");
+    cd::create_from_gdi(
+        &srcdir.join("disc.gdi"),
+        &chd,
+        CdCreateOptions {
+            codecs: [crate::CHD_CODEC_CD_LZMA, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+
+    let s = Command::new(&chdman)
+        .arg("extractcd")
+        .args(["-i".as_ref(), chd.as_os_str()])
+        .args(["-o".as_ref(), refdir.join("disc.gdi").as_os_str()])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "chdman extractcd (gdi) failed");
+
+    cd::extract_to_gdi(&chd, &oursdir.join("disc.gdi"), &mut |_| {}).unwrap();
+
+    // .gdi index + each split track file must match chdman byte-for-byte.
+    for name in ["disc.gdi", "disc01.bin", "disc02.raw", "disc03.bin"] {
+        let r = std::fs::read(refdir.join(name)).unwrap();
+        let o = std::fs::read(oursdir.join(name)).unwrap();
+        assert_eq!(o, r, "extractcd gdi: file {name} differs from chdman");
+    }
+    // round-trip: the data/audio track files reproduce the originals.
+    assert_eq!(std::fs::read(oursdir.join("disc01.bin")).unwrap(), t1);
+    assert_eq!(std::fs::read(oursdir.join("disc02.raw")).unwrap(), t2);
+    assert_eq!(std::fs::read(oursdir.join("disc03.bin")).unwrap(), t3);
+
+    for d in [&srcdir, &refdir, &oursdir] {
+        let _ = std::fs::remove_dir_all(d);
+    }
+}

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -1052,6 +1052,84 @@ fn delmeta_bit_exact_vs_chdman() {
     let _ = std::fs::remove_file(&reference);
 }
 
+/// `Chd::info` reports the right header fields + type flags (`is_hd`/`is_dvd`/…) for HD and DVD
+/// CHDs created by chd-rs.
+#[test]
+fn info_reports_hd_and_dvd() {
+    use crate::dvd::{self, DvdCreateOptions};
+    use crate::hd::{self, HdCreateOptions};
+
+    let dir = std::env::temp_dir();
+    let input = make_input(256 * 1024);
+
+    // HD (compressed zlib) → is_hd, GDDD, compressed.
+    let hd_in = dir.join("chdrs_info_hd_in.bin");
+    let hd_chd = dir.join("chdrs_info_hd.chd");
+    File::create(&hd_in).unwrap().write_all(&input).unwrap();
+    hd::create_from_path(
+        &hd_in,
+        &hd_chd,
+        HdCreateOptions {
+            codecs: [crate::CHD_CODEC_ZLIB, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+    {
+        let mut chd = Chd::open(BufReader::new(File::open(&hd_chd).unwrap()), None).unwrap();
+        let info = chd.info().unwrap();
+        assert_eq!(info.version, 5);
+        assert_eq!(info.hunk_bytes, 4096);
+        assert_eq!(info.unit_bytes, 512);
+        assert_eq!(info.logical_bytes, input.len() as u64);
+        assert_eq!(info.codecs[0], crate::CHD_CODEC_ZLIB);
+        assert!(info.compressed);
+        assert!(info.is_hd, "should be HD");
+        assert!(!info.is_dvd && !info.is_cd && !info.is_av && !info.is_gd);
+        assert!(!info.has_parent);
+        assert_eq!(info.track_count, 0);
+        assert!(info
+            .metadata_tags
+            .iter()
+            .any(|&(t, _)| t == crate::make_tag(b"GDDD")));
+    }
+
+    // DVD (uncompressed) → is_dvd, DVD record, 2048 units, not compressed.
+    let dvd_in = dir.join("chdrs_info_dvd_in.iso");
+    let dvd_chd = dir.join("chdrs_info_dvd.chd");
+    File::create(&dvd_in).unwrap().write_all(&input).unwrap();
+    dvd::create_from_iso(
+        &dvd_in,
+        &dvd_chd,
+        DvdCreateOptions {
+            codecs: [0, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+    {
+        let mut chd = Chd::open(BufReader::new(File::open(&dvd_chd).unwrap()), None).unwrap();
+        let info = chd.info().unwrap();
+        assert!(info.is_dvd, "should be DVD");
+        assert!(!info.is_hd);
+        assert!(!info.compressed);
+        assert_eq!(info.unit_bytes, 2048);
+        assert!(info
+            .metadata_tags
+            .iter()
+            .any(|&(t, _)| t == crate::make_tag(b"DVD ")));
+    }
+
+    let _ = std::fs::remove_file(&hd_in);
+    let _ = std::fs::remove_file(&hd_chd);
+    let _ = std::fs::remove_file(&dvd_in);
+    let _ = std::fs::remove_file(&dvd_chd);
+}
+
 /// Build `pattern_ids.len()` hunks; hunks sharing a pattern id are byte-identical (forcing
 /// `COMPRESSION_SELF` refs). Pattern 0 is all-zeros; others are a distinct compressible sawtooth.
 fn build_hunks(hunk_size: usize, pattern_ids: &[u8]) -> Vec<u8> {

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -1785,3 +1785,145 @@ fn createcd_iso_cdlz_bit_exact_vs_chdman() {
     let _ = std::fs::remove_file(&ours_path);
     let _ = std::fs::remove_file(&ref_path);
 }
+
+/// **extractcd** byte-identity: build a CD CHD (chdman `createcd`), extract it with both chdman
+/// (`extractcd -o out.cue -ob out.bin`) and chd-rs (`cd::extract_to_cue`), and assert the emitted
+/// CUE **and** BIN are byte-identical — plus that the extracted BIN equals the original source BIN
+/// (full create→extract round-trip). `ref`/`ours` go in sibling dirs so the cue's `FILE "out.bin"`
+/// line matches.
+fn assert_extractcd_bit_exact(name: &str, src_bin: &[u8], cue_text: &str) {
+    let chdman = chdman_path();
+    let base = std::env::temp_dir();
+    let srcdir = base.join(format!("chdrs_ecd_src_{name}"));
+    let refdir = base.join(format!("chdrs_ecd_ref_{name}"));
+    let oursdir = base.join(format!("chdrs_ecd_ours_{name}"));
+    for d in [&srcdir, &refdir, &oursdir] {
+        let _ = std::fs::remove_dir_all(d);
+        std::fs::create_dir_all(d).unwrap();
+    }
+
+    std::fs::write(srcdir.join("src.bin"), src_bin).unwrap();
+    std::fs::write(srcdir.join("src.cue"), cue_text.as_bytes()).unwrap();
+    let src_chd = srcdir.join("src.chd");
+
+    let s = Command::new(&chdman)
+        .arg("createcd")
+        .args(["-i".as_ref(), srcdir.join("src.cue").as_os_str()])
+        .args(["-o".as_ref(), src_chd.as_os_str()])
+        .args(["-c", "cdlz"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "createcd ({name}) failed");
+
+    let s = Command::new(&chdman)
+        .arg("extractcd")
+        .args(["-i".as_ref(), src_chd.as_os_str()])
+        .args(["-o".as_ref(), refdir.join("out.cue").as_os_str()])
+        .args(["-ob".as_ref(), refdir.join("out.bin").as_os_str()])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "extractcd ({name}) failed");
+
+    crate::cd::extract_to_cue(
+        &src_chd,
+        &oursdir.join("out.cue"),
+        &oursdir.join("out.bin"),
+        &mut |_| {},
+    )
+    .unwrap();
+
+    let ref_cue = std::fs::read(refdir.join("out.cue")).unwrap();
+    let ours_cue = std::fs::read(oursdir.join("out.cue")).unwrap();
+    assert_eq!(
+        ours_cue,
+        ref_cue,
+        "extractcd cue differs from chdman ({name})\n--- ours ---\n{}\n--- chdman ---\n{}",
+        String::from_utf8_lossy(&ours_cue),
+        String::from_utf8_lossy(&ref_cue),
+    );
+
+    let ref_bin = std::fs::read(refdir.join("out.bin")).unwrap();
+    let ours_bin = std::fs::read(oursdir.join("out.bin")).unwrap();
+    assert_eq!(
+        ours_bin.len(),
+        ref_bin.len(),
+        "extractcd bin size differs ({name}): ours={}, chdman={}",
+        ours_bin.len(),
+        ref_bin.len()
+    );
+    assert_eq!(
+        ours_bin, ref_bin,
+        "extractcd bin differs from chdman ({name})"
+    );
+    assert_eq!(ours_bin, src_bin, "extractcd bin != source bin ({name})");
+
+    for d in [&srcdir, &refdir, &oursdir] {
+        let _ = std::fs::remove_dir_all(d);
+    }
+}
+
+#[test]
+fn extractcd_single_mode1_bit_exact_vs_chdman() {
+    let bin = build_mode1_bin(50);
+    let cue = "FILE \"src.bin\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n";
+    assert_extractcd_bit_exact("mode1", &bin, cue);
+}
+
+#[test]
+fn extractcd_multitrack_bit_exact_vs_chdman() {
+    let mut bin = build_mode1_bin(50);
+    bin.extend_from_slice(&make_audio_input(30 * 2352));
+    let cue = "FILE \"src.bin\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n  \
+               TRACK 02 AUDIO\n    INDEX 00 00:00:50\n    INDEX 01 00:00:53\n";
+    assert_extractcd_bit_exact("multi", &bin, cue);
+}
+
+/// `list_tracks` reads back the `CHT2` records: the multi-track CD's two tracks with the right
+/// types, frame counts, and the audio track's in-file pregap.
+#[test]
+fn list_tracks_reads_cht2() {
+    use crate::cd::{SubcodeType, TrackType};
+
+    let dir = std::env::temp_dir();
+    let srcdir = dir.join("chdrs_listtracks");
+    let _ = std::fs::remove_dir_all(&srcdir);
+    std::fs::create_dir_all(&srcdir).unwrap();
+    let mut bin = build_mode1_bin(50);
+    bin.extend_from_slice(&make_audio_input(30 * 2352));
+    std::fs::write(srcdir.join("src.bin"), &bin).unwrap();
+    std::fs::write(
+        srcdir.join("src.cue"),
+        "FILE \"src.bin\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n  \
+         TRACK 02 AUDIO\n    INDEX 00 00:00:50\n    INDEX 01 00:00:53\n",
+    )
+    .unwrap();
+    let chd_path = srcdir.join("src.chd");
+    crate::cd::create_from_cue(
+        &srcdir.join("src.cue"),
+        &chd_path,
+        crate::cd::CdCreateOptions {
+            codecs: [crate::CHD_CODEC_CD_LZMA, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+
+    let mut chd = Chd::open(BufReader::new(File::open(&chd_path).unwrap()), None).unwrap();
+    let tracks = crate::cd::list_tracks(&mut chd).unwrap();
+    assert_eq!(tracks.len(), 2);
+    assert_eq!(tracks[0].track_num, 1);
+    assert_eq!(tracks[0].track_type, TrackType::Mode1Raw);
+    assert_eq!(tracks[0].frames, 50);
+    assert_eq!(tracks[0].pregap, 0);
+    assert_eq!(tracks[1].track_num, 2);
+    assert_eq!(tracks[1].track_type, TrackType::Audio);
+    assert_eq!(tracks[1].subcode_type, SubcodeType::None);
+    assert_eq!(tracks[1].frames, 30);
+    assert_eq!(tracks[1].pregap, 3);
+
+    let _ = std::fs::remove_dir_all(&srcdir);
+}

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -1130,6 +1130,108 @@ fn info_reports_hd_and_dvd() {
     let _ = std::fs::remove_file(&dvd_chd);
 }
 
+/// Per-hunk byte-identity for a **CD wrapper codec**: build a MODE1/2352 BIN+CUE (valid sync+ECC,
+/// so the codec exercises the ECC-strip path), `chdman createcd -c <mnemonic>`, then for every hunk
+/// chdman compressed with the codec, decode it (chd-rs restores sync+ECC + subcode), re-encode with
+/// our `CdEncoder`, and assert the stored bytes match.
+#[cfg(all(feature = "want_raw_data_sector", feature = "want_subcode"))]
+fn assert_cd_codec_bit_exact(mnemonic: &str, codec: CodecType) {
+    use crate::cdrom::{CD_MAX_SECTOR_DATA, CD_MODE_OFFSET, CD_SYNC_HEADER};
+    use crate::compression::ecc::ErrorCorrectedSector;
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let bin_path = dir.join(format!("chdrs_cd_{mnemonic}.bin"));
+    let cue_path = dir.join(format!("chdrs_cd_{mnemonic}.cue"));
+    let chd_path = dir.join(format!("chdrs_cd_{mnemonic}.chd"));
+
+    // 64 MODE1 sectors (8 frames/hunk → 8 full hunks). Compressible payload (via make_input) +
+    // a freshly-generated valid P/Q ECC so chdman's codec strips the sync header + ECC.
+    let nsectors = 64usize;
+    let mut bin = make_input(nsectors * CD_MAX_SECTOR_DATA as usize);
+    for s in 0..nsectors {
+        let sector = &mut bin[s * CD_MAX_SECTOR_DATA as usize..][..CD_MAX_SECTOR_DATA as usize];
+        sector[..CD_SYNC_HEADER.len()].copy_from_slice(&CD_SYNC_HEADER);
+        sector[CD_MODE_OFFSET] = 1; // MODE1
+        let mut sec = <&mut [u8; CD_MAX_SECTOR_DATA as usize]>::try_from(&mut sector[..]).unwrap();
+        sec.generate_ecc();
+    }
+    File::create(&bin_path).unwrap().write_all(&bin).unwrap();
+
+    let bin_name = bin_path.file_name().unwrap().to_str().unwrap();
+    let cue = format!("FILE \"{bin_name}\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n");
+    File::create(&cue_path)
+        .unwrap()
+        .write_all(cue.as_bytes())
+        .unwrap();
+
+    let status = Command::new(&chdman)
+        .arg("createcd")
+        .arg("-i")
+        .arg(&cue_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-c", mnemonic])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createcd -c {mnemonic} failed");
+
+    let mut chd = Chd::open(BufReader::new(File::open(&chd_path).unwrap()), None).unwrap();
+    let hunk_count = chd.header().hunk_count();
+    let hunk_size = chd.header().hunk_size();
+
+    let mut comp_buf = Vec::new();
+    let mut decoded = chd.get_hunksized_buffer();
+    let mut stored = Vec::new();
+    let mut checked = 0usize;
+    for n in 0..hunk_count {
+        let is_codec0 = matches!(
+            chd.map().get_entry(n as usize),
+            Some(MapEntry::V5Compressed(e))
+                if matches!(e.hunk_type(), Ok(CompressionTypeV5::CompressionType0))
+        );
+        if !is_codec0 {
+            continue;
+        }
+        {
+            let mut hunk = chd.hunk(n).unwrap();
+            hunk.read_hunk_in(&mut comp_buf, &mut decoded).unwrap();
+            hunk.read_raw_in(&mut stored).unwrap();
+        }
+        let mut enc = codec.init_encoder(hunk_size).unwrap();
+        let mut mine = vec![0u8; hunk_size as usize];
+        let n_enc = enc.compress(&decoded, &mut mine).unwrap();
+        assert_eq!(
+            &mine[..n_enc],
+            &stored[..],
+            "cd codec {mnemonic}: hunk {n} ({n_enc} bytes) differs from chdman ({} bytes)",
+            stored.len()
+        );
+        checked += 1;
+    }
+    assert!(
+        checked > 0,
+        "no hunks used codec {mnemonic}; test is vacuous"
+    );
+
+    let _ = std::fs::remove_file(&bin_path);
+    let _ = std::fs::remove_file(&cue_path);
+    let _ = std::fs::remove_file(&chd_path);
+}
+
+#[cfg(all(feature = "want_raw_data_sector", feature = "want_subcode"))]
+#[test]
+fn cd_zlib_bit_exact_vs_chdman() {
+    assert_cd_codec_bit_exact("cdzl", CodecType::ZLibCdV5);
+}
+
+#[cfg(all(feature = "want_raw_data_sector", feature = "want_subcode"))]
+#[test]
+fn cd_lzma_bit_exact_vs_chdman() {
+    assert_cd_codec_bit_exact("cdlz", CodecType::LzmaCdV5);
+}
+
 /// Build `pattern_ids.len()` hunks; hunks sharing a pattern id are byte-identical (forcing
 /// `COMPRESSION_SELF` refs). Pattern 0 is all-zeros; others are a distinct compressible sawtooth.
 fn build_hunks(hunk_size: usize, pattern_ids: &[u8]) -> Vec<u8> {

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -1232,6 +1232,67 @@ fn cd_lzma_bit_exact_vs_chdman() {
     assert_cd_codec_bit_exact("cdlz", CodecType::LzmaCdV5);
 }
 
+/// `HdImage` diff cross-check: chd-rs writes sectors into an uncompressed diff over a chdman-made
+/// compressed parent, then **chdman `extracthd -ip parent`** reads the diff back — proving our diff
+/// (parent_sha1 link, 4-byte map, materialised hunks) is chdman-compatible and the merged image
+/// matches (parent with our sector writes overlaid).
+#[test]
+fn hd_image_diff_readable_by_chdman() {
+    use crate::hd::HdImage;
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let parent_in = dir.join("chdrs_hddiff_in.bin");
+    let parent_chd = dir.join("chdrs_hddiff_parent.chd");
+    let diff_chd = dir.join("chdrs_hddiff_diff.chd");
+    let merged = dir.join("chdrs_hddiff_merged.bin");
+
+    let img: Vec<u8> = (0..256 * 1024).map(|i| (i * 5 + 1) as u8).collect();
+    File::create(&parent_in).unwrap().write_all(&img).unwrap();
+
+    let s = Command::new(&chdman)
+        .arg("createhd")
+        .args(["-i".as_ref(), parent_in.as_os_str()])
+        .args(["-o".as_ref(), parent_chd.as_os_str()])
+        .args(["-c", "zlib"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "chdman createhd (parent) failed");
+
+    let mut expected = img.clone();
+    {
+        let mut hd = HdImage::open_with_diff(&parent_chd, &diff_chd).unwrap();
+        let ss = hd.sector_size() as usize;
+        for &lba in &[3u64, 77, 313, 511] {
+            let pat = vec![(lba as u8) ^ 0xa5; ss];
+            hd.write_sector(lba, &pat).unwrap();
+            expected[lba as usize * ss..][..ss].copy_from_slice(&pat);
+        }
+        hd.flush().unwrap();
+    }
+
+    let s = Command::new(&chdman)
+        .arg("extracthd")
+        .args(["-i".as_ref(), diff_chd.as_os_str()])
+        .args(["-ip".as_ref(), parent_chd.as_os_str()])
+        .args(["-o".as_ref(), merged.as_os_str()])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "chdman extracthd of our diff failed");
+
+    assert_eq!(
+        std::fs::read(&merged).unwrap(),
+        expected,
+        "chdman-extracted diff differs from the expected merged image"
+    );
+
+    for p in [&parent_in, &parent_chd, &diff_chd, &merged] {
+        let _ = std::fs::remove_file(p);
+    }
+}
+
 /// Build `pattern_ids.len()` hunks; hunks sharing a pattern id are byte-identical (forcing
 /// `COMPRESSION_SELF` refs). Pattern 0 is all-zeros; others are a distinct compressible sawtooth.
 fn build_hunks(hunk_size: usize, pattern_ids: &[u8]) -> Vec<u8> {

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -1927,3 +1927,107 @@ fn list_tracks_reads_cht2() {
 
     let _ = std::fs::remove_dir_all(&srcdir);
 }
+
+/// `extract_to_iso` + `CdCookedReader` on a cooked MODE1/2048 CD: the round-trip iso →
+/// `create_from_iso` → `extract_to_iso` reproduces the input exactly, and `CdCookedReader` streams
+/// the same bytes (incl. a mid-stream seek).
+#[test]
+fn cooked_iso_roundtrip_mode1_2048() {
+    use crate::cd::{self, CdCookedReader, CdCreateOptions};
+    use std::io::{Read, Seek, SeekFrom};
+
+    let dir = std::env::temp_dir();
+    let iso_in = dir.join("chdrs_cooked_2048.iso");
+    let chd = dir.join("chdrs_cooked_2048.chd");
+    let iso_out = dir.join("chdrs_cooked_2048_out.iso");
+
+    let data = make_input(2048 * 100); // 100 cooked MODE1/2048 sectors
+    File::create(&iso_in).unwrap().write_all(&data).unwrap();
+    cd::create_from_iso(
+        &iso_in,
+        &chd,
+        CdCreateOptions {
+            codecs: [crate::CHD_CODEC_CD_ZLIB, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+
+    cd::extract_to_iso(&chd, &iso_out, &mut |_| {}).unwrap();
+    assert_eq!(
+        std::fs::read(&iso_out).unwrap(),
+        data,
+        "extract_to_iso (MODE1/2048) round-trip mismatch"
+    );
+
+    // CdCookedReader streams the same bytes, and a seek lands on the right sector.
+    let opened = Chd::open(BufReader::new(File::open(&chd).unwrap()), None).unwrap();
+    let mut r = CdCookedReader::open(opened).unwrap();
+    assert_eq!(r.len(), data.len() as u64);
+    let mut got = Vec::new();
+    r.read_to_end(&mut got).unwrap();
+    assert_eq!(got, data, "CdCookedReader full read mismatch");
+    r.seek(SeekFrom::Start(2048 * 5)).unwrap();
+    let mut sector5 = vec![0u8; 2048];
+    r.read_exact(&mut sector5).unwrap();
+    assert_eq!(
+        sector5,
+        data[2048 * 5..2048 * 6],
+        "CdCookedReader seek mismatch"
+    );
+
+    for p in [&iso_in, &chd, &iso_out] {
+        let _ = std::fs::remove_file(p);
+    }
+}
+
+/// `extract_to_iso` on a raw MODE1/2352 CD yields the 2048-byte cooked user data (sync header +
+/// ECC/EDC stripped): sector `s`'s output equals `src[s*2352 + 16 ..][..2048]`.
+#[test]
+fn cooked_iso_strips_mode1_raw() {
+    use crate::cd::{self, CdCreateOptions};
+
+    let dir = std::env::temp_dir();
+    let bin = dir.join("chdrs_cooked_raw.bin");
+    let cue = dir.join("chdrs_cooked_raw.cue");
+    let chd = dir.join("chdrs_cooked_raw.chd");
+    let iso_out = dir.join("chdrs_cooked_raw_out.iso");
+
+    let nsectors = 40usize;
+    let src = build_mode1_bin(nsectors);
+    File::create(&bin).unwrap().write_all(&src).unwrap();
+    let bin_name = bin.file_name().unwrap().to_str().unwrap();
+    std::fs::write(
+        &cue,
+        format!("FILE \"{bin_name}\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n"),
+    )
+    .unwrap();
+    cd::create_from_cue(
+        &cue,
+        &chd,
+        CdCreateOptions {
+            codecs: [crate::CHD_CODEC_CD_ZLIB, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+
+    cd::extract_to_iso(&chd, &iso_out, &mut |_| {}).unwrap();
+    let out = std::fs::read(&iso_out).unwrap();
+    assert_eq!(out.len(), nsectors * 2048);
+    for s in 0..nsectors {
+        assert_eq!(
+            &out[s * 2048..(s + 1) * 2048],
+            &src[s * 2352 + 16..s * 2352 + 16 + 2048],
+            "cooked user data mismatch at sector {s}"
+        );
+    }
+
+    for p in [&bin, &cue, &chd, &iso_out] {
+        let _ = std::fs::remove_file(p);
+    }
+}

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -1505,3 +1505,231 @@ fn raw_compressed_lzma_partial_chd_bit_exact_vs_chdman() {
     let _ = std::fs::remove_file(&in_path);
     let _ = std::fs::remove_file(&chd_path);
 }
+
+/// Build `nsectors` MODE1/2352 sectors (sync header + MODE1 byte + compressible payload + a freshly
+/// generated valid P/Q ECC, so the CD codec strips them). Same construction the per-hunk CD codec
+/// test uses, hoisted for the `createcd` container tests.
+fn build_mode1_bin(nsectors: usize) -> Vec<u8> {
+    use crate::cdrom::{CD_MAX_SECTOR_DATA, CD_MODE_OFFSET, CD_SYNC_HEADER};
+    use crate::compression::ecc::ErrorCorrectedSector;
+
+    let mut bin = make_input(nsectors * CD_MAX_SECTOR_DATA as usize);
+    for s in 0..nsectors {
+        let sector = &mut bin[s * CD_MAX_SECTOR_DATA as usize..][..CD_MAX_SECTOR_DATA as usize];
+        sector[..CD_SYNC_HEADER.len()].copy_from_slice(&CD_SYNC_HEADER);
+        sector[CD_MODE_OFFSET] = 1; // MODE1
+        let mut sec = <&mut [u8; CD_MAX_SECTOR_DATA as usize]>::try_from(&mut sector[..]).unwrap();
+        sec.generate_ecc();
+    }
+    bin
+}
+
+/// Full **createcd** byte-identity for a single MODE1/2352 track: chd-rs `cd::create_from_cue`
+/// (CUE parse → 2448-byte-frame assembly → `CHT2` metadata → V5 writer) must equal
+/// `chdman createcd -c <mnemonic>` byte-for-byte. 50 frames → 7 hunks (a partial last hunk).
+fn assert_createcd_cue_bit_exact(mnemonic: &str, codecs: [u32; 4]) {
+    use crate::cd::{self, CdCreateOptions};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let bin_path = dir.join(format!("chdrs_createcd_{mnemonic}.bin"));
+    let cue_path = dir.join(format!("chdrs_createcd_{mnemonic}.cue"));
+    let ours_path = dir.join(format!("chdrs_createcd_ours_{mnemonic}.chd"));
+    let ref_path = dir.join(format!("chdrs_createcd_ref_{mnemonic}.chd"));
+
+    let bin = build_mode1_bin(50);
+    File::create(&bin_path).unwrap().write_all(&bin).unwrap();
+    let bin_name = bin_path.file_name().unwrap().to_str().unwrap();
+    let cue = format!("FILE \"{bin_name}\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n");
+    File::create(&cue_path)
+        .unwrap()
+        .write_all(cue.as_bytes())
+        .unwrap();
+
+    let status = Command::new(&chdman)
+        .arg("createcd")
+        .arg("-i")
+        .arg(&cue_path)
+        .arg("-o")
+        .arg(&ref_path)
+        .args(["-c", mnemonic])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createcd -c {mnemonic} failed");
+    let reference = std::fs::read(&ref_path).unwrap();
+
+    cd::create_from_cue(
+        &cue_path,
+        &ours_path,
+        CdCreateOptions {
+            codecs,
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+    let ours = std::fs::read(&ours_path).unwrap();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "createcd -c {mnemonic} size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "createcd -c {mnemonic} bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&bin_path);
+    let _ = std::fs::remove_file(&cue_path);
+    let _ = std::fs::remove_file(&ours_path);
+    let _ = std::fs::remove_file(&ref_path);
+}
+
+#[test]
+fn createcd_cue_cdzl_bit_exact_vs_chdman() {
+    assert_createcd_cue_bit_exact("cdzl", [crate::CHD_CODEC_CD_ZLIB, 0, 0, 0]);
+}
+
+#[test]
+fn createcd_cue_cdlz_bit_exact_vs_chdman() {
+    assert_createcd_cue_bit_exact("cdlz", [crate::CHD_CODEC_CD_LZMA, 0, 0, 0]);
+}
+
+/// **createcd** byte-identity for a **multi-track** single-BIN CUE: a MODE1/2352 data track
+/// followed by an AUDIO track with an in-file pregap (`INDEX 00`/`INDEX 01`). Exercises per-track
+/// `CHT2` (incl. the `V`-prefixed `PGTYPE` for a data-bearing pregap), the audio byte-swap, and the
+/// 4-frame track padding between tracks.
+fn assert_createcd_multitrack_bit_exact(mnemonic: &str, codecs: [u32; 4]) {
+    use crate::cd::{self, CdCreateOptions};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let bin_path = dir.join(format!("chdrs_createcd_mt_{mnemonic}.bin"));
+    let cue_path = dir.join(format!("chdrs_createcd_mt_{mnemonic}.cue"));
+    let ours_path = dir.join(format!("chdrs_createcd_mt_ours_{mnemonic}.chd"));
+    let ref_path = dir.join(format!("chdrs_createcd_mt_ref_{mnemonic}.chd"));
+
+    // 50 MODE1 frames then 30 AUDIO frames, one bin. INDEX 00 of track 2 = frame 50 (so track 1 is
+    // 50 frames), INDEX 01 = frame 53 (a 3-frame pregap).
+    let mut bin = build_mode1_bin(50);
+    bin.extend_from_slice(&make_audio_input(30 * 2352));
+    File::create(&bin_path).unwrap().write_all(&bin).unwrap();
+    let bin_name = bin_path.file_name().unwrap().to_str().unwrap();
+    let cue = format!(
+        "FILE \"{bin_name}\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n  \
+         TRACK 02 AUDIO\n    INDEX 00 00:00:50\n    INDEX 01 00:00:53\n"
+    );
+    File::create(&cue_path)
+        .unwrap()
+        .write_all(cue.as_bytes())
+        .unwrap();
+
+    let status = Command::new(&chdman)
+        .arg("createcd")
+        .arg("-i")
+        .arg(&cue_path)
+        .arg("-o")
+        .arg(&ref_path)
+        .args(["-c", mnemonic])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createcd (multitrack) failed");
+    let reference = std::fs::read(&ref_path).unwrap();
+
+    cd::create_from_cue(
+        &cue_path,
+        &ours_path,
+        CdCreateOptions {
+            codecs,
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+    let ours = std::fs::read(&ours_path).unwrap();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "createcd multitrack size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "createcd multitrack bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&bin_path);
+    let _ = std::fs::remove_file(&cue_path);
+    let _ = std::fs::remove_file(&ours_path);
+    let _ = std::fs::remove_file(&ref_path);
+}
+
+#[test]
+fn createcd_multitrack_cdlz_bit_exact_vs_chdman() {
+    assert_createcd_multitrack_bit_exact("cdlz", [crate::CHD_CODEC_CD_LZMA, 0, 0, 0]);
+}
+
+/// **createcd** from a flat `.iso` (no CUE): chd-rs `cd::create_from_iso` infers a single
+/// MODE1/2048 track from the 2048-multiple size and must match `chdman createcd` on the same file.
+#[test]
+fn createcd_iso_cdlz_bit_exact_vs_chdman() {
+    use crate::cd::{self, CdCreateOptions};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let iso_path = dir.join("chdrs_createcd_iso.iso");
+    let ours_path = dir.join("chdrs_createcd_iso_ours.chd");
+    let ref_path = dir.join("chdrs_createcd_iso_ref.chd");
+
+    // 100 cooked MODE1/2048 sectors.
+    let iso = make_input(2048 * 100);
+    File::create(&iso_path).unwrap().write_all(&iso).unwrap();
+
+    let status = Command::new(&chdman)
+        .arg("createcd")
+        .arg("-i")
+        .arg(&iso_path)
+        .arg("-o")
+        .arg(&ref_path)
+        .args(["-c", "cdlz"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createcd (iso) failed");
+    let reference = std::fs::read(&ref_path).unwrap();
+
+    cd::create_from_iso(
+        &iso_path,
+        &ours_path,
+        CdCreateOptions {
+            codecs: [crate::CHD_CODEC_CD_LZMA, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+    let ours = std::fs::read(&ours_path).unwrap();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "createcd iso size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(ours, reference, "createcd iso bytes differ from chdman");
+
+    let _ = std::fs::remove_file(&iso_path);
+    let _ = std::fs::remove_file(&ours_path);
+    let _ = std::fs::remove_file(&ref_path);
+}

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -1,0 +1,1072 @@
+//! Dev-local **bit-exact** verification of chd-rs's codec encoders against a real
+//! `chdman` 0.288 binary.
+//!
+//! Strategy (works before the CHD writer core exists): have chdman build a raw CHD with a
+//! single codec, then for every hunk chdman compressed with that codec, decode the hunk's raw
+//! data *and* read back its stored compressed bytes, re-encode the raw data with our encoder,
+//! and assert the bytes are identical. This pins each codec to chdman 0.288 byte-for-byte.
+//!
+//! Enable with `cargo test -p chd --features "write-zstd chdman_compat_tests"`. chdman is
+//! resolved via `$CHDMAN`, then `C:\Tools\chdman\chdman.exe`, then `chdman` on `PATH`.
+
+use crate::compression::CodecEncodeImplementation;
+use crate::header::{CodecType, Header};
+use crate::map::{CompressionTypeV5, MapEntry};
+use crate::Chd;
+use num_traits::ToPrimitive;
+use std::fs::File;
+use std::io::{BufReader, Write};
+use std::path::PathBuf;
+use std::process::Command;
+
+fn chdman_path() -> PathBuf {
+    if let Ok(p) = std::env::var("CHDMAN") {
+        return PathBuf::from(p);
+    }
+    let known = PathBuf::from(r"C:\Tools\chdman\chdman.exe");
+    if known.exists() {
+        return known;
+    }
+    PathBuf::from("chdman")
+}
+
+/// Deterministic, mixed-compressibility test data: alternating zero runs (very compressible),
+/// repeated text (compressible), and xorshift pseudo-random bytes (incompressible). This gives
+/// every codec hunks it will actually compress (so the comparison is not vacuous).
+fn make_input(len: usize) -> Vec<u8> {
+    let text = b"the quick brown fox jumps over the lazy dog. ";
+    let mut v = Vec::with_capacity(len);
+    let mut x: u32 = 0x2545_f491;
+    for i in 0..len {
+        let b = match (i / 96) % 3 {
+            0 => 0u8,
+            1 => text[i % text.len()],
+            _ => {
+                x ^= x << 13;
+                x ^= x >> 17;
+                x ^= x << 5;
+                (x & 0xff) as u8
+            }
+        };
+        v.push(b);
+    }
+    v
+}
+
+/// Create a single-codec raw CHD with chdman and assert our encoder reproduces chdman's
+/// compressed bytes for every hunk that used the codec.
+fn assert_codec_bit_exact(mnemonic: &str, codec: CodecType, hunk_size: u32, unit_size: u32) {
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join(format!("chdrs_bitexact_in_{mnemonic}.bin"));
+    let chd_path = dir.join(format!("chdrs_bitexact_ref_{mnemonic}.chd"));
+
+    let nhunks = 24u32;
+    let input = make_input((hunk_size * nhunks) as usize);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&chd_path);
+    let status = Command::new(&chdman)
+        .arg("createraw")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-hs", &hunk_size.to_string()])
+        .args(["-us", &unit_size.to_string()])
+        .args(["-c", mnemonic])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createraw -c {mnemonic} failed");
+
+    let mut chd = Chd::open(BufReader::new(File::open(&chd_path).unwrap()), None).unwrap();
+    let hunk_count = chd.header().hunk_count();
+
+    let mut comp_buf = Vec::new();
+    let mut decoded = chd.get_hunksized_buffer();
+    let mut stored = Vec::new();
+    let mut checked = 0usize;
+
+    for n in 0..hunk_count {
+        // Only compare hunks chdman compressed with codec slot 0 (the codec under test);
+        // others are stored uncompressed (NONE).
+        let is_codec0 = matches!(
+            chd.map().get_entry(n as usize),
+            Some(MapEntry::V5Compressed(e))
+                if matches!(e.hunk_type(), Ok(CompressionTypeV5::CompressionType0))
+        );
+        if !is_codec0 {
+            continue;
+        }
+
+        {
+            let mut hunk = chd.hunk(n).unwrap();
+            hunk.read_hunk_in(&mut comp_buf, &mut decoded).unwrap();
+            hunk.read_raw_in(&mut stored).unwrap();
+        }
+
+        let mut enc = codec.init_encoder(hunk_size).unwrap();
+        let mut mine = vec![0u8; hunk_size as usize];
+        let n_enc = enc.compress(&decoded, &mut mine).unwrap();
+
+        assert_eq!(
+            &mine[..n_enc],
+            &stored[..],
+            "codec {mnemonic}: hunk {n} ({} bytes) differs from chdman ({} bytes)",
+            n_enc,
+            stored.len()
+        );
+        checked += 1;
+    }
+
+    assert!(
+        checked > 0,
+        "no hunks used codec {mnemonic}; test is vacuous (make_input not compressible enough?)"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+}
+
+// Now backed by `zlib-bitexact-rs` (bit-exact stock zlib 1.3.1 deflate).
+#[test]
+fn zlib_bit_exact_vs_chdman() {
+    assert_codec_bit_exact("zlib", CodecType::ZLibV5, 4096, 512);
+}
+
+#[test]
+fn huff_bit_exact_vs_chdman() {
+    assert_codec_bit_exact("huff", CodecType::HuffV5, 4096, 512);
+}
+
+#[test]
+fn lzma_bit_exact_vs_chdman() {
+    assert_codec_bit_exact("lzma", CodecType::LzmaV5, 4096, 512);
+}
+
+#[cfg(feature = "write-zstd")]
+#[test]
+fn zstd_bit_exact_vs_chdman() {
+    assert_codec_bit_exact("zstd", CodecType::ZstdV5, 4096, 512);
+}
+
+/// Isolation test for `compress_v5_map`: create a compressed CHD with chdman (huff — a
+/// confirmed bit-exact codec), reconstruct its (decompressed) 12-byte rawmap from chd-rs's
+/// map entries, re-encode with our `compress_v5_map`, and assert it matches chdman's stored
+/// map bytes byte-for-byte. This validates the hardest deterministic piece of the writer
+/// independently of the per-hunk driver.
+#[test]
+fn compress_v5_map_bit_exact_vs_chdman() {
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_map_in.bin");
+    let chd_path = dir.join("chdrs_map_ref.chd");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    let input = make_input((hunk_size * 12) as usize);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&chd_path);
+    let status = Command::new(&chdman)
+        .arg("createraw")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-hs", &hunk_size.to_string()])
+        .args(["-us", &unit_size.to_string()])
+        .args(["-c", "huff"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createraw -c huff failed");
+
+    let file_bytes = std::fs::read(&chd_path).unwrap();
+    let mut chd = Chd::open(BufReader::new(File::open(&chd_path).unwrap()), None).unwrap();
+    let hunk_count = chd.header().hunk_count();
+    let map_offset = match chd.header() {
+        Header::V5Header(h) => h.map_offset,
+        _ => panic!("expected a V5 header"),
+    };
+
+    // reconstruct the 12-byte rawmap entries from chd-rs's decompressed map
+    let mut rawmap = vec![0u8; hunk_count as usize * 12];
+    for n in 0..hunk_count {
+        let entry = match chd.map().get_entry(n as usize) {
+            Some(MapEntry::V5Compressed(e)) => e,
+            _ => panic!("hunk {n}: expected a V5 compressed map entry"),
+        };
+        let type_byte = entry.hunk_type().unwrap().to_u8().unwrap();
+        let complen = entry.block_size().unwrap();
+        let offset = entry.block_offset().unwrap();
+        let crc = entry.hunk_crc().unwrap();
+
+        let base = n as usize * 12;
+        rawmap[base] = type_byte;
+        rawmap[base + 1] = (complen >> 16) as u8;
+        rawmap[base + 2] = (complen >> 8) as u8;
+        rawmap[base + 3] = complen as u8;
+        rawmap[base + 4] = (offset >> 40) as u8;
+        rawmap[base + 5] = (offset >> 32) as u8;
+        rawmap[base + 6] = (offset >> 24) as u8;
+        rawmap[base + 7] = (offset >> 16) as u8;
+        rawmap[base + 8] = (offset >> 8) as u8;
+        rawmap[base + 9] = offset as u8;
+        rawmap[base + 10] = (crc >> 8) as u8;
+        rawmap[base + 11] = crc as u8;
+    }
+
+    let ours = crate::write::compress_v5_map(&rawmap, hunk_count, hunk_size, unit_size);
+    let reference = &file_bytes[map_offset as usize..];
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "compressed-map size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        &ours[..],
+        reference,
+        "compressed-map bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+}
+
+/// End-to-end: a complete uncompressed CHD written by chd-rs must be byte-identical to
+/// `chdman createraw -c none`. Exercises the V5 header + uncompressed map + layout.
+#[test]
+fn raw_uncompressed_chd_bit_exact_vs_chdman() {
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_e2e_none_in.bin");
+    let chd_path = dir.join("chdrs_e2e_none_ref.chd");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    // 5 full hunks + a partial 6th (unit-aligned, as chdman createraw requires), to exercise
+    // the data-start rounding and last-hunk zero-padding.
+    let input = make_input((hunk_size * 5 + unit_size * 2) as usize);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&chd_path);
+    let status = Command::new(&chdman)
+        .arg("createraw")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-hs", &hunk_size.to_string()])
+        .args(["-us", &unit_size.to_string()])
+        .args(["-c", "none"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createraw -c none failed");
+
+    let reference = std::fs::read(&chd_path).unwrap();
+
+    let mut ours = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw_uncompressed(&mut ours, &input, hunk_size, unit_size).unwrap();
+    let ours = ours.into_inner();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "file size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(ours, reference, "uncompressed CHD bytes differ from chdman");
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+}
+
+/// End-to-end: a complete **compressed** CHD (huff — a confirmed bit-exact codec) written by
+/// chd-rs must be byte-identical to `chdman createraw -c huff`. Exercises the full writer core:
+/// per-hunk codec/none decision, byte-packed data, `compress_v5_map`, and SHA-1.
+#[test]
+fn raw_compressed_huff_chd_bit_exact_vs_chdman() {
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_e2e_huff_in.bin");
+    let chd_path = dir.join("chdrs_e2e_huff_ref.chd");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    let input = make_input((hunk_size * 10) as usize);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&chd_path);
+    let status = Command::new(&chdman)
+        .arg("createraw")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-hs", &hunk_size.to_string()])
+        .args(["-us", &unit_size.to_string()])
+        .args(["-c", "huff"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createraw -c huff failed");
+
+    let reference = std::fs::read(&chd_path).unwrap();
+
+    let mut ours = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw_compressed(&mut ours, &input, hunk_size, unit_size, CodecType::HuffV5)
+        .unwrap();
+    let ours = ours.into_inner();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "file size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "compressed (huff) CHD bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+}
+
+/// End-to-end **multi-codec** createraw (`-c lzma,zlib`): the per-hunk best-of-N selection must
+/// match chdman's `find_best_compressor` exactly (slot order, strictly-smaller wins), producing a
+/// byte-identical whole file. Exercises `write_raw` choosing different codec slots across hunks.
+#[test]
+fn raw_compressed_multicodec_chd_bit_exact_vs_chdman() {
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_e2e_multi_in.bin");
+    let chd_path = dir.join("chdrs_e2e_multi_ref.chd");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    let input = make_input((hunk_size * 16) as usize);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&chd_path);
+    let status = Command::new(&chdman)
+        .arg("createraw")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-hs", &hunk_size.to_string()])
+        .args(["-us", &unit_size.to_string()])
+        .args(["-c", "lzma,zlib"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createraw -c lzma,zlib failed");
+
+    let reference = std::fs::read(&chd_path).unwrap();
+
+    let mut ours = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw(
+        &mut ours,
+        &input,
+        hunk_size,
+        unit_size,
+        &[CodecType::LzmaV5, CodecType::ZLibV5],
+    )
+    .unwrap();
+    let ours = ours.into_inner();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "file size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "multi-codec (lzma,zlib) CHD bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+}
+
+/// The public `hd::create_raw_from_path` must produce a CHD byte-identical to `chdman createraw`,
+/// fire the `progress` callback, and honor `cancel` (returning `Cancelled` and leaving no file).
+#[test]
+fn hd_create_raw_bit_exact_and_callbacks() {
+    use crate::hd::{self, HdCreateOptions};
+    use crate::{CompressionProgress, CHD_CODEC_ZLIB};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_hd_in.bin");
+    let ours_path = dir.join("chdrs_hd_ours.chd");
+    let ref_path = dir.join("chdrs_hd_ref.chd");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    let input = make_input((hunk_size * 12) as usize);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&ref_path);
+    let status = Command::new(&chdman)
+        .arg("createraw")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&ref_path)
+        .args(["-hs", &hunk_size.to_string()])
+        .args(["-us", &unit_size.to_string()])
+        .args(["-c", "zlib"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createraw -c zlib failed");
+    let reference = std::fs::read(&ref_path).unwrap();
+
+    let opts = HdCreateOptions {
+        hunk_size,
+        unit_size,
+        codecs: [CHD_CODEC_ZLIB, 0, 0, 0],
+        ..Default::default()
+    };
+    let mut last = CompressionProgress {
+        bytes_done: 0,
+        bytes_total: 0,
+        ratio: 1.0,
+    };
+    let mut count = 0usize;
+    {
+        let mut prog = |p: CompressionProgress| {
+            last = p;
+            count += 1;
+        };
+        hd::create_raw_from_path(&in_path, &ours_path, opts.clone(), &mut prog, &|| false).unwrap();
+    }
+    let ours = std::fs::read(&ours_path).unwrap();
+    assert_eq!(
+        ours, reference,
+        "hd::create_raw_from_path differs from chdman createraw -c zlib"
+    );
+    assert!(count > 0, "progress callback never fired");
+    assert_eq!(last.bytes_done, input.len() as u64);
+    assert_eq!(last.bytes_total, input.len() as u64);
+
+    // cancel → Cancelled + no output file left behind
+    let cancel_path = dir.join("chdrs_hd_cancel.chd");
+    let _ = std::fs::remove_file(&cancel_path);
+    let mut noop = |_p: CompressionProgress| {};
+    let r = hd::create_raw_from_path(&in_path, &cancel_path, opts, &mut noop, &|| true);
+    assert!(
+        matches!(r, Err(crate::Error::Cancelled)),
+        "expected Cancelled, got {r:?}"
+    );
+    assert!(
+        !cancel_path.exists(),
+        "cancelled create must not leave an output file"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&ref_path);
+    let _ = std::fs::remove_file(&ours_path);
+}
+
+/// `hd::extract_to_path` must reproduce the exact logical bytes (truncated past the last hunk's
+/// zero-padding) for a compressed CHD with a partial last hunk.
+#[test]
+fn hd_extract_roundtrips() {
+    use crate::hd;
+
+    let dir = std::env::temp_dir();
+    let chd_path = dir.join("chdrs_hd_extract.chd");
+    let out_path = dir.join("chdrs_hd_extract_out.bin");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    let input = make_input((hunk_size * 7 + unit_size * 2) as usize); // partial last hunk
+
+    let mut cur = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw_compressed(&mut cur, &input, hunk_size, unit_size, CodecType::LzmaV5)
+        .unwrap();
+    std::fs::write(&chd_path, cur.into_inner()).unwrap();
+
+    let mut total = 0u64;
+    hd::extract_to_path(&chd_path, &out_path, &mut |d| total = d).unwrap();
+    let extracted = std::fs::read(&out_path).unwrap();
+    assert_eq!(
+        extracted, input,
+        "extract_to_path did not reproduce the logical bytes"
+    );
+    assert_eq!(total, input.len() as u64);
+
+    let _ = std::fs::remove_file(&chd_path);
+    let _ = std::fs::remove_file(&out_path);
+}
+
+/// `hd::read_geometry` must parse the `GDDD` record chdman's `createhd` writes, and our
+/// `compute_chs` must predict the same geometry chdman chose.
+#[test]
+fn hd_read_geometry_vs_chdman() {
+    use crate::hd;
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_geom_in.bin");
+    let chd_path = dir.join("chdrs_geom_ref.chd");
+
+    let input = make_input(256 * 1024); // 256 KiB → 1 cyl / 16 heads / 32 sectors @ 512
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&chd_path);
+    let status = Command::new(&chdman)
+        .arg("createhd")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-c", "none"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createhd failed");
+
+    let mut chd = Chd::open(BufReader::new(File::open(&chd_path).unwrap()), None).unwrap();
+    let g = hd::read_geometry(&mut chd).unwrap();
+    assert_eq!(
+        (g.cylinders, g.heads, g.sectors, g.sector_bytes),
+        (1, 16, 32, 512)
+    );
+    let predicted = hd::compute_chs(input.len() as u64, 512).unwrap();
+    assert_eq!(
+        predicted, g,
+        "compute_chs disagrees with chdman's chosen geometry"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+}
+
+/// Full **createhd** byte-identity: chd-rs `hd::create_from_path` (deriving geometry, writing the
+/// `GDDD` record) must equal `chdman createhd -c <mnemonic>` byte-for-byte — exercising the
+/// metadata writer (placement + linked list), `meta_offset`, and (compressed) the
+/// metadata-inclusive overall SHA-1.
+fn assert_createhd_bit_exact(mnemonic: &str, codecs: [u32; 4]) {
+    use crate::hd::{self, HdCreateOptions};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join(format!("chdrs_createhd_in_{mnemonic}.bin"));
+    let ours_path = dir.join(format!("chdrs_createhd_ours_{mnemonic}.chd"));
+    let ref_path = dir.join(format!("chdrs_createhd_ref_{mnemonic}.chd"));
+
+    // 256 KiB → geometry 1/16/32 @ 512, default hunk 4096 (matches chdman's createhd defaults).
+    let input = make_input(256 * 1024);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&ref_path);
+    let status = Command::new(&chdman)
+        .arg("createhd")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&ref_path)
+        .args(["-c", mnemonic])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createhd -c {mnemonic} failed");
+    let reference = std::fs::read(&ref_path).unwrap();
+
+    let opts = HdCreateOptions {
+        codecs,
+        ..Default::default()
+    };
+    let _ = std::fs::remove_file(&ours_path);
+    hd::create_from_path(&in_path, &ours_path, opts, &mut |_p| {}, &|| false).unwrap();
+    let ours = std::fs::read(&ours_path).unwrap();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "createhd -c {mnemonic} size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "createhd -c {mnemonic} bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&ours_path);
+    let _ = std::fs::remove_file(&ref_path);
+}
+
+#[test]
+fn hd_createhd_none_bit_exact_vs_chdman() {
+    assert_createhd_bit_exact("none", [0, 0, 0, 0]);
+}
+
+#[test]
+fn hd_createhd_zlib_bit_exact_vs_chdman() {
+    assert_createhd_bit_exact("zlib", [crate::CHD_CODEC_ZLIB, 0, 0, 0]);
+}
+
+#[test]
+fn hd_createhd_lzma_bit_exact_vs_chdman() {
+    assert_createhd_bit_exact("lzma", [crate::CHD_CODEC_LZMA, 0, 0, 0]);
+}
+
+/// createhd with an **IDNT** ident record (in addition to GDDD) — exercises the multi-entry
+/// metadata linked list (`next` pointers) and the **sorted** multi-entry overall SHA-1. chdman
+/// derives geometry from the ident's embedded CHS (LE u16 at offsets 2/6/12), so we pass the same
+/// geometry explicitly to chd-rs.
+#[test]
+fn hd_createhd_ident_bit_exact_vs_chdman() {
+    use crate::hd::{self, HdCreateOptions, HdGeometry};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_createhd_ident_in.bin");
+    let ident_path = dir.join("chdrs_createhd_ident.bin");
+    let ours_path = dir.join("chdrs_createhd_ident_ours.chd");
+    let ref_path = dir.join("chdrs_createhd_ident_ref.chd");
+
+    // ident blob: CHS at LE offsets 2/6/12 → 2 cyls / 4 heads / 8 sectors = 64 sectors.
+    let mut ident = vec![0u8; 16];
+    ident[0] = 0xCA;
+    ident[1] = 0xFE;
+    ident[2] = 2; // cylinders (LE u16)
+    ident[6] = 4; // heads
+    ident[12] = 8; // sectors
+    ident[14] = 0x5A;
+    ident[15] = 0xA5;
+    std::fs::write(&ident_path, &ident).unwrap();
+
+    let geom = HdGeometry {
+        cylinders: 2,
+        heads: 4,
+        sectors: 8,
+        sector_bytes: 512,
+    };
+    let input = make_input(geom.logical_bytes() as usize); // 64 * 512 = 32768
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&ref_path);
+    let status = Command::new(&chdman)
+        .arg("createhd")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&ref_path)
+        .args(["-c", "zlib"])
+        .arg("--ident")
+        .arg(&ident_path)
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createhd --ident failed");
+    let reference = std::fs::read(&ref_path).unwrap();
+
+    let opts = HdCreateOptions {
+        codecs: [crate::CHD_CODEC_ZLIB, 0, 0, 0],
+        geometry: Some(geom),
+        ident: Some(ident.clone()),
+        ..Default::default()
+    };
+    let _ = std::fs::remove_file(&ours_path);
+    hd::create_from_path(&in_path, &ours_path, opts, &mut |_p| {}, &|| false).unwrap();
+    let ours = std::fs::read(&ours_path).unwrap();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "createhd --ident size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "createhd --ident (GDDD+IDNT) bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&ident_path);
+    let _ = std::fs::remove_file(&ours_path);
+    let _ = std::fs::remove_file(&ref_path);
+}
+
+/// `copy` byte-identity: build an HD source CHD with chdman (`createhd -c <source_codec>`), then
+/// `chdman copy -c <target>` and chd-rs `copy::copy` must produce the same file — exercising
+/// re-compression, unit-size preservation, and **metadata (GDDD) cloning** (+ overall SHA-1).
+fn assert_copy_bit_exact(source_codec: &str, target_mnemonic: &str, target_codecs: [u32; 4]) {
+    use crate::copy::{self, CopyOptions};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let tag = format!("{source_codec}_{target_mnemonic}");
+    let in_path = dir.join(format!("chdrs_copy_in_{tag}.bin"));
+    let src_path = dir.join(format!("chdrs_copy_src_{tag}.chd"));
+    let ours_path = dir.join(format!("chdrs_copy_ours_{tag}.chd"));
+    let ref_path = dir.join(format!("chdrs_copy_ref_{tag}.chd"));
+
+    let input = make_input(256 * 1024);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&src_path);
+    let s = Command::new(&chdman)
+        .arg("createhd")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&src_path)
+        .args(["-c", source_codec])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "createhd source (-c {source_codec}) failed");
+
+    let _ = std::fs::remove_file(&ref_path);
+    let s = Command::new(&chdman)
+        .arg("copy")
+        .arg("-i")
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&ref_path)
+        .args(["-c", target_mnemonic])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "chdman copy -c {target_mnemonic} failed");
+    let reference = std::fs::read(&ref_path).unwrap();
+
+    let _ = std::fs::remove_file(&ours_path);
+    copy::copy(
+        &src_path,
+        &ours_path,
+        CopyOptions {
+            hunk_size: None,
+            codecs: target_codecs,
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+    let ours = std::fs::read(&ours_path).unwrap();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "copy {tag} size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(ours, reference, "copy {tag} bytes differ from chdman");
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&ours_path);
+    let _ = std::fs::remove_file(&ref_path);
+}
+
+#[test]
+fn copy_hd_none_to_zlib_bit_exact_vs_chdman() {
+    // uncompressed source → compressed copy (exercises overall SHA-1 + GDDD clone)
+    assert_copy_bit_exact("none", "zlib", [crate::CHD_CODEC_ZLIB, 0, 0, 0]);
+}
+
+#[test]
+fn copy_hd_zlib_to_none_bit_exact_vs_chdman() {
+    // compressed source → uncompressed copy (SHA-1 zero; GDDD clone after the map)
+    assert_copy_bit_exact("zlib", "none", [0, 0, 0, 0]);
+}
+
+#[test]
+fn copy_hd_lzma_to_zlib_bit_exact_vs_chdman() {
+    // compressed → compressed recompression
+    assert_copy_bit_exact("lzma", "zlib", [crate::CHD_CODEC_ZLIB, 0, 0, 0]);
+}
+
+/// Build `pattern_ids.len()` hunks; hunks sharing a pattern id are byte-identical (forcing
+/// `COMPRESSION_SELF` refs). Pattern 0 is all-zeros; others are a distinct compressible sawtooth.
+fn build_hunks(hunk_size: usize, pattern_ids: &[u8]) -> Vec<u8> {
+    let mut v = vec![0u8; hunk_size * pattern_ids.len()];
+    for (h, &pid) in pattern_ids.iter().enumerate() {
+        if pid == 0 {
+            continue; // all zeros
+        }
+        let hunk = &mut v[h * hunk_size..(h + 1) * hunk_size];
+        let period = pid as usize * 13 + 7;
+        for (i, b) in hunk.iter_mut().enumerate() {
+            *b = ((i % period) as u32 + pid as u32) as u8;
+        }
+    }
+    v
+}
+
+/// End-to-end with **self-hunk dedup**: an input with byte-identical hunks at various distances
+/// (consecutive, repeated, all-zero) must produce the same `COMPRESSION_SELF` references chdman
+/// emits — byte-identical whole file.
+#[test]
+fn raw_compressed_dedup_chd_bit_exact_vs_chdman() {
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_e2e_dedup_in.bin");
+    let chd_path = dir.join("chdrs_e2e_dedup_ref.chd");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    // hunk pattern ids: repeats force SELF refs (incl. consecutive zeros and far repeats).
+    let pattern_ids = [1u8, 2, 1, 0, 0, 2, 3, 0, 3, 1];
+    let input = build_hunks(hunk_size as usize, &pattern_ids);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&chd_path);
+    let status = Command::new(&chdman)
+        .arg("createraw")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-hs", &hunk_size.to_string()])
+        .args(["-us", &unit_size.to_string()])
+        .args(["-c", "huff"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createraw -c huff (dedup) failed");
+
+    let reference = std::fs::read(&chd_path).unwrap();
+
+    let mut ours = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw_compressed(&mut ours, &input, hunk_size, unit_size, CodecType::HuffV5)
+        .unwrap();
+    let ours = ours.into_inner();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "file size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "dedup (SELF-ref) CHD bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+}
+
+/// End-to-end compressed CHD with **zlib** — the HD-default codec, now backed by
+/// `zlib-bitexact-rs`. A full `-c zlib` CHD must be byte-identical to chdman 0.288.
+#[test]
+fn raw_compressed_zlib_chd_bit_exact_vs_chdman() {
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_e2e_zlib_in.bin");
+    let chd_path = dir.join("chdrs_e2e_zlib_ref.chd");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    let input = make_input((hunk_size * 10) as usize);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&chd_path);
+    let status = Command::new(&chdman)
+        .arg("createraw")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-hs", &hunk_size.to_string()])
+        .args(["-us", &unit_size.to_string()])
+        .args(["-c", "zlib"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createraw -c zlib failed");
+
+    let reference = std::fs::read(&chd_path).unwrap();
+
+    let mut ours = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw_compressed(&mut ours, &input, hunk_size, unit_size, CodecType::ZLibV5)
+        .unwrap();
+    let ours = ours.into_inner();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "file size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "compressed (zlib) CHD bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+}
+
+/// Audio-like 16-bit stereo PCM (a bounded triangle wave per channel), little-endian, so the
+/// FLAC codec actually compresses (instead of overflowing to NONE on incompressible data).
+fn make_audio_input(len: usize) -> Vec<u8> {
+    let mut v = Vec::with_capacity(len);
+    let (mut l, mut r, mut dl, mut dr): (i32, i32, i32, i32) = (0, 0, 37, 53);
+    while v.len() < len {
+        l += dl;
+        if !(-20000..=20000).contains(&l) {
+            dl = -dl;
+            l += 2 * dl;
+        }
+        r += dr;
+        if !(-18000..=18000).contains(&r) {
+            dr = -dr;
+            r += 2 * dr;
+        }
+        v.extend_from_slice(&(l as i16).to_le_bytes());
+        v.extend_from_slice(&(r as i16).to_le_bytes());
+    }
+    v.truncate(len);
+    v
+}
+
+/// End-to-end **flac** — a libm-dependent codec. libflac-rs's float parity is validated against
+/// **glibc** libm, while the reference chdman here is the **Windows/MSVC** 0.288 build, so we do
+/// **not** assert byte-identity to chdman (it may differ by a few bytes). Instead we assert
+/// *round-trip correctness against the oracle*: chd-rs writes a `-c flac` CHD, our own decoder
+/// reproduces the logical bytes, and **chdman extracts our CHD back to the original input**. (On a
+/// glibc chdman this can be upgraded to a byte-identity assertion like the other codecs.)
+#[test]
+fn raw_compressed_flac_roundtrips_via_chdman() {
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let chd_path = dir.join("chdrs_e2e_flac_ref.chd");
+    let out_path = dir.join("chdrs_e2e_flac_out.bin");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    let input = make_audio_input((hunk_size * 8) as usize);
+
+    // write the flac CHD with chd-rs
+    let mut ours = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw_compressed(&mut ours, &input, hunk_size, unit_size, CodecType::FlacV5)
+        .unwrap();
+    let ours = ours.into_inner();
+    std::fs::write(&chd_path, &ours).unwrap();
+
+    // sanity + chd-rs self round-trip
+    {
+        let mut chd = Chd::open(BufReader::new(File::open(&chd_path).unwrap()), None).unwrap();
+        let hunk_count = chd.header().hunk_count();
+
+        let used_codec = (0..hunk_count).any(|n| {
+            matches!(
+                chd.map().get_entry(n as usize),
+                Some(MapEntry::V5Compressed(e))
+                    if matches!(e.hunk_type(), Ok(CompressionTypeV5::CompressionType0))
+            )
+        });
+        assert!(used_codec, "no hunk used the flac codec; test is vacuous");
+
+        let mut decoded = chd.get_hunksized_buffer();
+        let mut comp = Vec::new();
+        let mut got = Vec::with_capacity(input.len());
+        for n in 0..hunk_count {
+            let mut hunk = chd.hunk(n).unwrap();
+            hunk.read_hunk_in(&mut comp, &mut decoded).unwrap();
+            got.extend_from_slice(&decoded);
+        }
+        assert_eq!(
+            &got[..input.len()],
+            &input[..],
+            "chd-rs flac self round-trip mismatch"
+        );
+    }
+
+    // the oracle must accept and losslessly extract our flac CHD
+    let _ = std::fs::remove_file(&out_path);
+    let status = Command::new(&chdman)
+        .arg("extractraw")
+        .arg("-i")
+        .arg(&chd_path)
+        .arg("-o")
+        .arg(&out_path)
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman extractraw");
+    assert!(status.success(), "chdman extractraw of our flac CHD failed");
+
+    let extracted = std::fs::read(&out_path).unwrap();
+    assert_eq!(extracted, input, "chdman-extracted bytes differ from input");
+
+    let _ = std::fs::remove_file(&chd_path);
+    let _ = std::fs::remove_file(&out_path);
+}
+
+/// End-to-end compressed CHD with **lzma** (an external-crate codec) and a **partial last
+/// hunk** — confirms the driver is codec-agnostic and that `raw_sha1` is over the logical
+/// (unpadded) data with the final hunk zero-padded.
+#[test]
+fn raw_compressed_lzma_partial_chd_bit_exact_vs_chdman() {
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_e2e_lzma_in.bin");
+    let chd_path = dir.join("chdrs_e2e_lzma_ref.chd");
+
+    let hunk_size = 4096u32;
+    let unit_size = 512u32;
+    // 7 full hunks + a partial 8th (unit-aligned).
+    let input = make_input((hunk_size * 7 + unit_size * 3) as usize);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let _ = std::fs::remove_file(&chd_path);
+    let status = Command::new(&chdman)
+        .arg("createraw")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&chd_path)
+        .args(["-hs", &hunk_size.to_string()])
+        .args(["-us", &unit_size.to_string()])
+        .args(["-c", "lzma"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createraw -c lzma failed");
+
+    let reference = std::fs::read(&chd_path).unwrap();
+
+    let mut ours = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw_compressed(&mut ours, &input, hunk_size, unit_size, CodecType::LzmaV5)
+        .unwrap();
+    let ours = ours.into_inner();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "file size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "compressed (lzma) CHD bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+}

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -2031,3 +2031,63 @@ fn cooked_iso_strips_mode1_raw() {
         let _ = std::fs::remove_file(p);
     }
 }
+
+/// Full **createcd from a `.gdi`** byte-identity (GD-ROM): a 3-track Dreamcast index (data / audio /
+/// data) with small inter-track LBA gaps → per-track `padframes`. chd-rs `cd::create_from_gdi` must
+/// equal `chdman createcd -c cdlz` byte-for-byte — exercising the GDI parser, the `padframes`
+/// zero-fill in the logical assembly, the audio byte-swap, and the `CHGD` (GD-ROM) metadata records.
+#[test]
+fn createcd_gdi_bit_exact_vs_chdman() {
+    use crate::cd::{self, CdCreateOptions};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir().join("chdrs_gdi");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // track1 data @ LBA 0 (90 frames), track2 audio @ LBA 100 (140 frames), track3 data @ LBA 250
+    // (50 frames). Gaps: track1 +10 pad (ends 90, next @ 100), track2 +10 pad (ends 240, next @ 250).
+    std::fs::write(dir.join("t1.bin"), build_mode1_bin(90)).unwrap();
+    std::fs::write(dir.join("t2.raw"), make_audio_input(140 * 2352)).unwrap();
+    std::fs::write(dir.join("t3.bin"), build_mode1_bin(50)).unwrap();
+    let gdi = "3\n1 0 4 2352 \"t1.bin\" 0\n2 100 0 2352 \"t2.raw\" 0\n3 250 4 2352 \"t3.bin\" 0\n";
+    std::fs::write(dir.join("disc.gdi"), gdi).unwrap();
+
+    let ref_chd = dir.join("ref.chd");
+    let ours_chd = dir.join("ours.chd");
+
+    let s = Command::new(&chdman)
+        .arg("createcd")
+        .args(["-i".as_ref(), dir.join("disc.gdi").as_os_str()])
+        .args(["-o".as_ref(), ref_chd.as_os_str()])
+        .args(["-c", "cdlz"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "chdman createcd (gdi) failed");
+    let reference = std::fs::read(&ref_chd).unwrap();
+
+    cd::create_from_gdi(
+        &dir.join("disc.gdi"),
+        &ours_chd,
+        CdCreateOptions {
+            codecs: [crate::CHD_CODEC_CD_LZMA, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+    let ours = std::fs::read(&ours_chd).unwrap();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "createcd gdi size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(ours, reference, "createcd gdi bytes differ from chdman");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -1452,6 +1452,58 @@ fn raw_compressed_flac_roundtrips_via_chdman() {
     let _ = std::fs::remove_file(&out_path);
 }
 
+/// Dump a chd-rs `flac` CHD + its input to `C:\Temp\flac_check\` so an **external glibc-built
+/// chdman** can be compared byte-for-byte (our `libflac-rs` is validated vs glibc libm, but the
+/// usual oracle here is the MSVC chdman). `#[ignore]`d — run explicitly when a glibc chdman is
+/// available: `cargo test ... dump_flac_artifacts_for_glibc_check -- --ignored`.
+#[test]
+#[ignore = "writes flac artifacts for an external glibc-chdman byte-identity check"]
+fn dump_flac_artifacts_for_glibc_check() {
+    let dir = std::path::Path::new(r"C:\Temp\flac_check");
+    std::fs::create_dir_all(dir).unwrap();
+    let (hunk, unit) = (4096u32, 512u32);
+    let input = make_audio_input((hunk * 8) as usize);
+    std::fs::write(dir.join("input.bin"), &input).unwrap();
+
+    let mut ours = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw_compressed(&mut ours, &input, hunk, unit, CodecType::FlacV5).unwrap();
+    std::fs::write(dir.join("ours.chd"), ours.into_inner()).unwrap();
+    eprintln!("wrote {}\\input.bin and ours.chd", dir.display());
+}
+
+/// Dump a chd-rs **`cdfl`** CD CHD (single AUDIO track of smooth PCM, so FLAC engages) + its CUE/BIN
+/// to `C:\Temp\cdfl_check\` for a byte-for-byte comparison against an external glibc chdman:
+/// `chdman createcd -i audio.cue -o chdman.chd -c cdfl`. `#[ignore]`d (libm-gated, glibc only).
+#[test]
+#[ignore = "writes cdfl artifacts for an external glibc-chdman byte-identity check"]
+fn dump_cdfl_artifacts_for_glibc_check() {
+    use crate::cd::{self, CdCreateOptions};
+
+    let dir = std::path::Path::new(r"C:\Temp\cdfl_check");
+    std::fs::create_dir_all(dir).unwrap();
+    // 64 AUDIO sectors (8 full hunks, no padding) of smooth stereo PCM.
+    let bin = make_audio_input(64 * 2352);
+    std::fs::write(dir.join("audio.bin"), &bin).unwrap();
+    std::fs::write(
+        dir.join("audio.cue"),
+        b"FILE \"audio.bin\" BINARY\n  TRACK 01 AUDIO\n    INDEX 01 00:00:00\n".as_slice(),
+    )
+    .unwrap();
+
+    cd::create_from_cue(
+        &dir.join("audio.cue"),
+        &dir.join("ours.chd"),
+        CdCreateOptions {
+            codecs: [crate::CHD_CODEC_CD_FLAC, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+    eprintln!("wrote cdfl artifacts to {}", dir.display());
+}
+
 /// End-to-end compressed CHD with **lzma** (an external-crate codec) and a **partial last
 /// hunk** — confirms the driver is codec-agnostic and that `raw_sha1` is over the logical
 /// (unpadded) data with the final hunk zero-padded.

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -797,6 +797,128 @@ fn copy_hd_lzma_to_zlib_bit_exact_vs_chdman() {
     assert_copy_bit_exact("lzma", "zlib", [crate::CHD_CODEC_ZLIB, 0, 0, 0]);
 }
 
+/// Full **createdvd** byte-identity: chd-rs `dvd::create_from_iso` (writing the `DVD ` record) must
+/// equal `chdman createdvd -c <mnemonic>` byte-for-byte — exercising the 2048-unit DVD layout, the
+/// 1-NUL `DVD ` metadata record, and (compressed) the metadata-inclusive overall SHA-1.
+fn assert_createdvd_bit_exact(mnemonic: &str, codecs: [u32; 4]) {
+    use crate::dvd::{self, DvdCreateOptions};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join(format!("chdrs_createdvd_in_{mnemonic}.iso"));
+    let ours_path = dir.join(format!("chdrs_createdvd_ours_{mnemonic}.chd"));
+    let ref_path = dir.join(format!("chdrs_createdvd_ref_{mnemonic}.chd"));
+
+    // 256 KiB = 128 × 2048-byte sectors.
+    let input = make_input(256 * 1024);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    let status = Command::new(&chdman)
+        .arg("createdvd")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&ref_path)
+        .args(["-c", mnemonic])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(status.success(), "chdman createdvd -c {mnemonic} failed");
+    let reference = std::fs::read(&ref_path).unwrap();
+
+    let opts = DvdCreateOptions {
+        codecs,
+        ..Default::default()
+    };
+    dvd::create_from_iso(&in_path, &ours_path, opts, &mut |_p| {}, &|| false).unwrap();
+    let ours = std::fs::read(&ours_path).unwrap();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "createdvd -c {mnemonic} size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "createdvd -c {mnemonic} bytes differ from chdman"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&ours_path);
+    let _ = std::fs::remove_file(&ref_path);
+}
+
+#[test]
+fn createdvd_none_bit_exact_vs_chdman() {
+    assert_createdvd_bit_exact("none", [0, 0, 0, 0]);
+}
+
+#[test]
+fn createdvd_zlib_bit_exact_vs_chdman() {
+    assert_createdvd_bit_exact("zlib", [crate::CHD_CODEC_ZLIB, 0, 0, 0]);
+}
+
+#[test]
+fn createdvd_lzma_bit_exact_vs_chdman() {
+    assert_createdvd_bit_exact("lzma", [crate::CHD_CODEC_LZMA, 0, 0, 0]);
+}
+
+/// `dvd::extract_to_iso` round-trips the logical image (partial last hunk) and rejects a non-DVD
+/// CHD with `UnsupportedFormat`.
+#[test]
+fn dvd_extract_roundtrips_and_rejects_non_dvd() {
+    use crate::dvd::{self, DvdCreateOptions};
+
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_dvd_rt_in.iso");
+    let chd_path = dir.join("chdrs_dvd_rt.chd");
+    let out_path = dir.join("chdrs_dvd_rt_out.iso");
+    let raw_path = dir.join("chdrs_dvd_rt_raw.chd");
+
+    let input = make_input(2048 * 53); // 2048-aligned, partial last 4096 hunk
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+
+    dvd::create_from_iso(
+        &in_path,
+        &chd_path,
+        DvdCreateOptions {
+            codecs: [crate::CHD_CODEC_LZMA, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_p| {},
+        &|| false,
+    )
+    .unwrap();
+
+    let mut total = 0u64;
+    dvd::extract_to_iso(&chd_path, &out_path, &mut |d| total = d).unwrap();
+    assert_eq!(
+        std::fs::read(&out_path).unwrap(),
+        input,
+        "dvd round-trip mismatch"
+    );
+    assert_eq!(total, input.len() as u64);
+
+    // a raw (non-DVD) CHD must be rejected by dvd::extract
+    let mut cur = std::io::Cursor::new(Vec::new());
+    crate::write::write_raw_compressed(&mut cur, &input, 4096, 2048, CodecType::LzmaV5).unwrap();
+    std::fs::write(&raw_path, cur.into_inner()).unwrap();
+    assert!(
+        matches!(
+            dvd::extract_to_iso(&raw_path, &out_path, &mut |_d| {}),
+            Err(crate::Error::UnsupportedFormat)
+        ),
+        "dvd::extract should reject a non-DVD CHD"
+    );
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&chd_path);
+    let _ = std::fs::remove_file(&out_path);
+    let _ = std::fs::remove_file(&raw_path);
+}
+
 /// Build `pattern_ids.len()` hunks; hunks sharing a pattern id are byte-identical (forcing
 /// `COMPRESSION_SELF` refs). Pattern 0 is all-zeros; others are a distinct compressible sawtooth.
 fn build_hunks(hunk_size: usize, pattern_ids: &[u8]) -> Vec<u8> {

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -1293,6 +1293,108 @@ fn hd_image_diff_readable_by_chdman() {
     }
 }
 
+/// Full **`createraw -op` (compressed child of a parent)** byte-identity: a child whose image
+/// shares most hunks with the parent (→ `COMPRESSION_PARENT` refs) but differs in a few (→
+/// compressed) must equal `chdman createraw -op parent` byte-for-byte — exercising the parent hash
+/// map, the `COMPRESSION_PARENT` map encoding, and the `parent_sha1` header link.
+#[test]
+fn createraw_with_parent_bit_exact_vs_chdman() {
+    use crate::hd::{self, HdCreateOptions};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let a = dir.join("chdrs_par_a.bin");
+    let b = dir.join("chdrs_par_b.bin");
+    let parent_chd = dir.join("chdrs_par_parent.chd");
+    let ref_chd = dir.join("chdrs_par_ref.chd");
+    let ours_chd = dir.join("chdrs_par_ours.chd");
+
+    let (hs, us) = (4096u32, 512u32);
+    let nhunks = 16usize;
+    let img_a = make_input(hs as usize * nhunks);
+    File::create(&a).unwrap().write_all(&img_a).unwrap();
+
+    // child shares all hunks with the parent except 3, 7, 11 (replaced with distinct data).
+    let mut img_b = img_a.clone();
+    for &h in &[3usize, 7, 11] {
+        let mut x = 0x1234_5678u32 ^ (h as u32).wrapping_mul(0x9e37_79b9);
+        for byte in &mut img_b[h * hs as usize..(h + 1) * hs as usize] {
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            *byte = (x & 0xff) as u8;
+        }
+    }
+    File::create(&b).unwrap().write_all(&img_b).unwrap();
+
+    let mk = |inp: &std::path::Path, out: &std::path::Path, parent: Option<&std::path::Path>| {
+        let mut c = Command::new(&chdman);
+        c.arg("createraw")
+            .args(["-i".as_ref(), inp.as_os_str()])
+            .args(["-o".as_ref(), out.as_os_str()])
+            .args(["-hs", &hs.to_string()])
+            .args(["-us", &us.to_string()])
+            .args(["-c", "zlib"]);
+        if let Some(p) = parent {
+            c.args(["-op".as_ref(), p.as_os_str()]);
+        }
+        assert!(
+            c.arg("-f").status().expect("run chdman").success(),
+            "chdman createraw failed"
+        );
+    };
+    mk(&a, &parent_chd, None);
+    mk(&b, &ref_chd, Some(&parent_chd));
+    let reference = std::fs::read(&ref_chd).unwrap();
+
+    hd::create_raw_from_path_with_parent(
+        &b,
+        &ours_chd,
+        &parent_chd,
+        HdCreateOptions {
+            codecs: [crate::CHD_CODEC_ZLIB, 0, 0, 0],
+            ..Default::default()
+        },
+        &mut |_| {},
+        &|| false,
+    )
+    .unwrap();
+    let ours = std::fs::read(&ours_chd).unwrap();
+
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "createraw -op size differs: ours={}, chdman={}",
+        ours.len(),
+        reference.len()
+    );
+    assert_eq!(
+        ours, reference,
+        "createraw -op child bytes differ from chdman"
+    );
+
+    // Sanity: parent refs actually fired (most hunks are COMPRESSION_PARENT, not stored).
+    let mut chd = Chd::open(BufReader::new(File::open(&ours_chd).unwrap()), None).unwrap();
+    let parent_refs = (0..chd.header().hunk_count())
+        .filter(|&n| {
+            matches!(
+                chd.map().get_entry(n as usize),
+                Some(MapEntry::V5Compressed(e))
+                    if matches!(e.hunk_type(), Ok(CompressionTypeV5::CompressionParent))
+            )
+        })
+        .count();
+    assert_eq!(
+        parent_refs,
+        nhunks - 3,
+        "expected all-but-3 hunks to be parent refs"
+    );
+
+    for p in [&a, &b, &parent_chd, &ref_chd, &ours_chd] {
+        let _ = std::fs::remove_file(p);
+    }
+}
+
 /// Build `pattern_ids.len()` hunks; hunks sharing a pattern id are byte-identical (forcing
 /// `COMPRESSION_SELF` refs). Pattern 0 is all-zeros; others are a distinct compressible sawtooth.
 fn build_hunks(hunk_size: usize, pattern_ids: &[u8]) -> Vec<u8> {

--- a/chd-rs/src/chdman_compat.rs
+++ b/chd-rs/src/chdman_compat.rs
@@ -919,6 +919,139 @@ fn dvd_extract_roundtrips_and_rejects_non_dvd() {
     let _ = std::fs::remove_file(&raw_path);
 }
 
+/// `metadata::write_metadata` must match `chdman addmeta` byte-for-byte: append a new record to a
+/// CHD (linked into the list at EOF). chdman only edits **uncompressed** CHDs (MAME refuses a
+/// writeable open of a compressed one), so the base is `-c none` and the overall SHA-1 stays zero.
+#[test]
+fn addmeta_bit_exact_vs_chdman() {
+    use crate::metadata::{self, METADATA_FLAG_CHECKSUM};
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_addmeta_in.bin");
+    let base = dir.join("chdrs_addmeta_base.chd");
+    let ours = dir.join("chdrs_addmeta_ours.chd");
+    let reference = dir.join("chdrs_addmeta_ref.chd");
+
+    let input = make_input(256 * 1024);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+    let s = Command::new(&chdman)
+        .arg("createhd")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&base)
+        .args(["-c", "none"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "createhd base failed");
+
+    std::fs::copy(&base, &ours).unwrap();
+    std::fs::copy(&base, &reference).unwrap();
+
+    // chdman addmeta mutates the input in place. `--valuetext` stores the string + NUL terminator.
+    let s = Command::new(&chdman)
+        .arg("addmeta")
+        .arg("-i")
+        .arg(&reference)
+        .args(["--tag", "TEST"])
+        .args(["--valuetext", "hello world"])
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "chdman addmeta failed");
+
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&ours)
+            .unwrap();
+        metadata::write_metadata(
+            &mut f,
+            crate::make_tag(b"TEST"),
+            0,
+            b"hello world\0", // text form: trailing NUL like chdman's std::string overload
+            METADATA_FLAG_CHECKSUM,
+        )
+        .unwrap();
+    }
+
+    let ours_bytes = std::fs::read(&ours).unwrap();
+    let ref_bytes = std::fs::read(&reference).unwrap();
+    assert_eq!(
+        ours_bytes.len(),
+        ref_bytes.len(),
+        "addmeta size differs: ours={}, chdman={}",
+        ours_bytes.len(),
+        ref_bytes.len()
+    );
+    assert_eq!(ours_bytes, ref_bytes, "addmeta bytes differ from chdman");
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&base);
+    let _ = std::fs::remove_file(&ours);
+    let _ = std::fs::remove_file(&reference);
+}
+
+/// `metadata::delete_metadata` must match `chdman delmeta` byte-for-byte: unlink the record (and,
+/// like chdman, leave the overall SHA-1 stale).
+#[test]
+fn delmeta_bit_exact_vs_chdman() {
+    use crate::metadata;
+
+    let chdman = chdman_path();
+    let dir = std::env::temp_dir();
+    let in_path = dir.join("chdrs_delmeta_in.bin");
+    let base = dir.join("chdrs_delmeta_base.chd");
+    let ours = dir.join("chdrs_delmeta_ours.chd");
+    let reference = dir.join("chdrs_delmeta_ref.chd");
+
+    let input = make_input(256 * 1024);
+    File::create(&in_path).unwrap().write_all(&input).unwrap();
+    let s = Command::new(&chdman)
+        .arg("createhd")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-o")
+        .arg(&base)
+        .args(["-c", "none"])
+        .arg("-f")
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "createhd base failed");
+
+    std::fs::copy(&base, &ours).unwrap();
+    std::fs::copy(&base, &reference).unwrap();
+
+    let s = Command::new(&chdman)
+        .arg("delmeta")
+        .arg("-i")
+        .arg(&reference)
+        .args(["--tag", "GDDD"])
+        .status()
+        .expect("failed to run chdman");
+    assert!(s.success(), "chdman delmeta failed");
+
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&ours)
+            .unwrap();
+        metadata::delete_metadata(&mut f, crate::make_tag(b"GDDD"), 0).unwrap();
+    }
+
+    let ours_bytes = std::fs::read(&ours).unwrap();
+    let ref_bytes = std::fs::read(&reference).unwrap();
+    assert_eq!(ours_bytes, ref_bytes, "delmeta bytes differ from chdman");
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&base);
+    let _ = std::fs::remove_file(&ours);
+    let _ = std::fs::remove_file(&reference);
+}
+
 /// Build `pattern_ids.len()` hunks; hunks sharing a pattern id are byte-identical (forcing
 /// `COMPRESSION_SELF` refs). Pattern 0 is all-zeros; others are a distinct compressible sawtooth.
 fn build_hunks(hunk_size: usize, pattern_ids: &[u8]) -> Vec<u8> {

--- a/chd-rs/src/codec.rs
+++ b/chd-rs/src/codec.rs
@@ -1,0 +1,129 @@
+//! CHD codec FourCC constants and compression-spec parsing.
+//!
+//! Mirrors libchdman-rs's `codec` module and chdman's `-c` syntax, so code written against
+//! libchdman-rs ports unchanged. The constant values are the same FourCCs chd-rs already uses
+//! internally ([`CodecType`](crate::header::CodecType)); this module re-exposes them under the
+//! libchdman-rs names plus the `parse_codec_spec` / `codec_name` / `codec_exists` helpers.
+
+use crate::error::{Error, Result};
+use crate::make_tag;
+
+/// No compression.
+pub const CHD_CODEC_NONE: u32 = 0;
+/// Deflate (zlib) compression (`zlib`).
+pub const CHD_CODEC_ZLIB: u32 = make_tag(b"zlib");
+/// Zstandard compression (`zstd`).
+pub const CHD_CODEC_ZSTD: u32 = make_tag(b"zstd");
+/// LZMA compression (`lzma`).
+pub const CHD_CODEC_LZMA: u32 = make_tag(b"lzma");
+/// Static Huffman compression (`huff`).
+pub const CHD_CODEC_HUFF: u32 = make_tag(b"huff");
+/// FLAC compression (`flac`).
+pub const CHD_CODEC_FLAC: u32 = make_tag(b"flac");
+/// CD Deflate compression (`cdzl`).
+pub const CHD_CODEC_CD_ZLIB: u32 = make_tag(b"cdzl");
+/// CD Zstandard compression (`cdzs`).
+pub const CHD_CODEC_CD_ZSTD: u32 = make_tag(b"cdzs");
+/// CD LZMA compression (`cdlz`).
+pub const CHD_CODEC_CD_LZMA: u32 = make_tag(b"cdlz");
+/// CD FLAC compression (`cdfl`).
+pub const CHD_CODEC_CD_FLAC: u32 = make_tag(b"cdfl");
+/// AV Huffman compression (`avhu`).
+pub const CHD_CODEC_AVHUFF: u32 = make_tag(b"avhu");
+
+/// Known codecs: `(code, mnemonic, human-readable name)`. The mnemonic is the FourCC string
+/// chdman accepts in a `-c` spec.
+const CODECS: &[(u32, &str, &str)] = &[
+    (CHD_CODEC_NONE, "none", "None"),
+    (CHD_CODEC_ZLIB, "zlib", "Deflate"),
+    (CHD_CODEC_ZSTD, "zstd", "Zstandard"),
+    (CHD_CODEC_LZMA, "lzma", "LZMA"),
+    (CHD_CODEC_HUFF, "huff", "Huffman"),
+    (CHD_CODEC_FLAC, "flac", "FLAC"),
+    (CHD_CODEC_CD_ZLIB, "cdzl", "CD Deflate"),
+    (CHD_CODEC_CD_ZSTD, "cdzs", "CD Zstandard"),
+    (CHD_CODEC_CD_LZMA, "cdlz", "CD LZMA"),
+    (CHD_CODEC_CD_FLAC, "cdfl", "CD FLAC"),
+    (CHD_CODEC_AVHUFF, "avhu", "AV Huffman"),
+];
+
+/// Returns whether `codec` is a known CHD codec FourCC (including `CHD_CODEC_NONE`).
+pub fn codec_exists(codec: u32) -> bool {
+    CODECS.iter().any(|&(c, _, _)| c == codec)
+}
+
+/// Returns the human-readable name of a codec, or `None` if unknown.
+pub fn codec_name(codec: u32) -> Option<&'static str> {
+    CODECS
+        .iter()
+        .find(|&&(c, _, _)| c == codec)
+        .map(|&(_, _, name)| name)
+}
+
+/// Parse a chdman-style `-c` compression spec into a 4-slot codec array.
+///
+/// `"none"` produces `[0; 4]` (uncompressed). Otherwise the spec is 1..=4 comma-separated
+/// four-ASCII-byte mnemonics (e.g. `"lzma,zlib"`), each of which must satisfy [`codec_exists`].
+/// Unused trailing slots are `0`.
+///
+/// ```
+/// # use chd::codec::{parse_codec_spec, CHD_CODEC_LZMA, CHD_CODEC_ZLIB};
+/// assert_eq!(parse_codec_spec("lzma,zlib").unwrap(), [CHD_CODEC_LZMA, CHD_CODEC_ZLIB, 0, 0]);
+/// assert_eq!(parse_codec_spec("none").unwrap(), [0; 4]);
+/// assert!(parse_codec_spec("bogus").is_err());
+/// ```
+pub fn parse_codec_spec(spec: &str) -> Result<[u32; 4]> {
+    if spec == "none" {
+        return Ok([0; 4]);
+    }
+
+    let mut out = [0u32; 4];
+    let parts: Vec<&str> = spec.split(',').collect();
+    if parts.is_empty() || parts.len() > 4 {
+        return Err(Error::InvalidParameter);
+    }
+    for (i, part) in parts.iter().enumerate() {
+        let bytes = part.as_bytes();
+        if bytes.len() != 4 {
+            return Err(Error::InvalidParameter);
+        }
+        let tag = make_tag(&[bytes[0], bytes[1], bytes[2], bytes[3]]);
+        if !codec_exists(tag) {
+            return Err(Error::InvalidParameter);
+        }
+        out[i] = tag;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_none_and_single_and_multi() {
+        assert_eq!(parse_codec_spec("none").unwrap(), [0; 4]);
+        assert_eq!(parse_codec_spec("zlib").unwrap(), [CHD_CODEC_ZLIB, 0, 0, 0]);
+        assert_eq!(
+            parse_codec_spec("cdlz,cdzl,cdfl").unwrap(),
+            [CHD_CODEC_CD_LZMA, CHD_CODEC_CD_ZLIB, CHD_CODEC_CD_FLAC, 0]
+        );
+    }
+
+    #[test]
+    fn rejects_bad_specs() {
+        assert!(parse_codec_spec("bogus").is_err()); // unknown 4-byte tag
+        assert!(parse_codec_spec("zlb").is_err()); // not 4 bytes
+        assert!(parse_codec_spec("zlib,zlib,zlib,zlib,zlib").is_err()); // >4
+        assert!(parse_codec_spec("").is_err()); // empty token
+    }
+
+    #[test]
+    fn names_and_existence() {
+        assert!(codec_exists(CHD_CODEC_LZMA));
+        assert!(!codec_exists(0xdead_beef));
+        assert_eq!(codec_name(CHD_CODEC_ZLIB), Some("Deflate"));
+        assert_eq!(codec_name(CHD_CODEC_NONE), Some("None"));
+        assert_eq!(codec_name(0xdead_beef), None);
+    }
+}

--- a/chd-rs/src/compression/cdrom.rs
+++ b/chd-rs/src/compression/cdrom.rs
@@ -1,5 +1,7 @@
 /// Common logic for CD-ROM decompression codecs.
-use crate::cdrom::{CD_FRAME_SIZE, CD_MAX_SECTOR_DATA, CD_MAX_SUBCODE_DATA, CD_SYNC_HEADER};
+use crate::cdrom::{
+    CD_FRAME_SIZE, CD_MAX_SECTOR_DATA, CD_MAX_SUBCODE_DATA, CD_SYNC_HEADER, CD_SYNC_NUM_BYTES,
+};
 use crate::compression::ecc::ErrorCorrectedSector;
 use crate::compression::lzma::LzmaCodec;
 use crate::compression::zlib::ZlibCodec;
@@ -252,5 +254,202 @@ impl<Engine: CodecImplementation, SubEngine: CodecImplementation> CodecImplement
         }
 
         Ok(frame_res + sub_res)
+    }
+}
+
+/// CD-ROM wrapper **compression** codec — the encode mirror of [`CdCodec`]. Generic over the
+/// sector engine `Engine` and subcode engine `SubEngine` (both [`CodecEncodeImplementation`]).
+///
+/// Reproduces MAME's `chd_cd_compressor::compress` (`chdcodec.cpp:351`): de-swizzles the hunk's
+/// interleaved `[sector(2352) ‖ subcode(96)]` frames into a sector run followed by a subcode run;
+/// for every frame that is a verifiable data sector (sync header present **and** valid ECC) it sets
+/// that frame's bit in the ECC-flag bitmap and zeroes the sync header + ECC P/Q (regenerated on
+/// decode); compresses the sector run with `Engine` and the subcode run with `SubEngine`; and emits
+/// `[ecc_flags ‖ complen ‖ sector_stream ‖ subcode_stream]` where `complen` (the sector stream
+/// length) is 2 bytes when the hunk is `< 65536` else 3. Returns [`Error::CompressionError`] if the
+/// sector stream alone is not smaller than the hunk (MAME's `complen >= srclen` check).
+#[cfg(feature = "write")]
+pub struct CdEncoder<Engine, SubEngine> {
+    engine: Engine,
+    sub_engine: SubEngine,
+    buffer: Vec<u8>,
+}
+
+#[cfg(feature = "write")]
+impl<Engine, SubEngine> crate::compression::CodecEncodeImplementation
+    for CdEncoder<Engine, SubEngine>
+where
+    Engine: crate::compression::CodecEncodeImplementation,
+    SubEngine: crate::compression::CodecEncodeImplementation,
+{
+    fn new(hunk_size: u32) -> Result<Self> {
+        if hunk_size % CD_FRAME_SIZE != 0 {
+            return Err(Error::CodecError);
+        }
+        let frames = hunk_size / CD_FRAME_SIZE;
+        Ok(CdEncoder {
+            engine: Engine::new(frames * CD_MAX_SECTOR_DATA)?,
+            sub_engine: SubEngine::new(frames * CD_MAX_SUBCODE_DATA)?,
+            buffer: vec![0u8; (frames * (CD_MAX_SECTOR_DATA + CD_MAX_SUBCODE_DATA)) as usize],
+        })
+    }
+
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize> {
+        let frames = input.len() / CD_FRAME_SIZE as usize;
+        let complen_bytes = if input.len() < 65536 { 2 } else { 3 };
+        let ecc_bytes = frames.div_ceil(8);
+        let header_bytes = ecc_bytes + complen_bytes;
+        let sect_total = frames * CD_MAX_SECTOR_DATA as usize;
+        let sub_total = frames * CD_MAX_SUBCODE_DATA as usize;
+
+        // de-swizzle [sector ‖ subcode] frames into the sector run then the subcode run
+        for f in 0..frames {
+            let src = &input[f * CD_FRAME_SIZE as usize..];
+            self.buffer[f * CD_MAX_SECTOR_DATA as usize..][..CD_MAX_SECTOR_DATA as usize]
+                .copy_from_slice(&src[..CD_MAX_SECTOR_DATA as usize]);
+            self.buffer[sect_total + f * CD_MAX_SUBCODE_DATA as usize..]
+                [..CD_MAX_SUBCODE_DATA as usize]
+                .copy_from_slice(
+                    &src[CD_MAX_SECTOR_DATA as usize..][..CD_MAX_SUBCODE_DATA as usize],
+                );
+        }
+
+        // strip the sync header + ECC of verifiable data sectors, recording which in the bitmap
+        let mut ecc_flags = vec![0u8; ecc_bytes];
+        for f in 0..frames {
+            let off = f * CD_MAX_SECTOR_DATA as usize;
+            let mut sector = <&mut [u8; CD_MAX_SECTOR_DATA as usize]>::try_from(
+                &mut self.buffer[off..off + CD_MAX_SECTOR_DATA as usize],
+            )?;
+            if sector[..CD_SYNC_NUM_BYTES] == CD_SYNC_HEADER && sector.verify_ecc() {
+                ecc_flags[f / 8] |= 1 << (f % 8);
+                sector[..CD_SYNC_NUM_BYTES].fill(0);
+                sector.clear_ecc();
+            }
+        }
+
+        // compress the sector run after the header; bail (NONE fallback) if it doesn't shrink
+        let base_n = self
+            .engine
+            .compress(&self.buffer[..sect_total], &mut output[header_bytes..])?;
+        if base_n >= input.len() {
+            return Err(Error::CompressionError);
+        }
+
+        // compress the subcode run after the sector stream
+        let sub_n = self.sub_engine.compress(
+            &self.buffer[sect_total..sect_total + sub_total],
+            &mut output[header_bytes + base_n..],
+        )?;
+
+        // header: ECC-flag bitmap followed by the sector-stream length (BE, 2 or 3 bytes)
+        output[..ecc_bytes].copy_from_slice(&ecc_flags);
+        if complen_bytes > 2 {
+            output[ecc_bytes] = (base_n >> 16) as u8;
+            output[ecc_bytes + 1] = (base_n >> 8) as u8;
+            output[ecc_bytes + 2] = base_n as u8;
+        } else {
+            output[ecc_bytes] = (base_n >> 8) as u8;
+            output[ecc_bytes + 1] = base_n as u8;
+        }
+
+        Ok(header_bytes + base_n + sub_n)
+    }
+}
+
+#[cfg(feature = "write")]
+impl<Engine, SubEngine> crate::compression::CompressionEncoder for CdEncoder<Engine, SubEngine>
+where
+    Engine: crate::compression::CodecEncodeImplementation + Send + Sync,
+    SubEngine: crate::compression::CodecEncodeImplementation + Send + Sync,
+{
+}
+
+#[cfg(all(
+    test,
+    feature = "write",
+    feature = "want_raw_data_sector",
+    feature = "want_subcode"
+))]
+mod cd_encode_tests {
+    use super::{CdEncoder, CdLzmaCodec, CdZlibCodec};
+    use crate::cdrom::{CD_FRAME_SIZE, CD_MAX_SECTOR_DATA, CD_MODE_OFFSET, CD_SYNC_HEADER};
+    use crate::compression::ecc::ErrorCorrectedSector;
+    use crate::compression::lzma::LzmaEncoder;
+    use crate::compression::zlib::ZlibEncoder;
+    use crate::compression::{CodecEncodeImplementation, CodecImplementation};
+
+    /// A CD hunk of `frames` 2448-byte frames. Even frames are MODE1 data sectors (sync header +
+    /// freshly-generated valid P/Q ECC, so the encoder strips them); odd frames are audio (no sync,
+    /// stored verbatim). Subcode is pseudo-random.
+    fn build_cd_hunk(frames: usize) -> Vec<u8> {
+        let mut x: u32 = 0x9e37_79b9;
+        let mut rng = move || {
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            (x & 0xff) as u8
+        };
+        let mut hunk = vec![0u8; frames * CD_FRAME_SIZE as usize];
+        for f in 0..frames {
+            let frame = &mut hunk[f * CD_FRAME_SIZE as usize..][..CD_FRAME_SIZE as usize];
+            let (sector, subcode) = frame.split_at_mut(CD_MAX_SECTOR_DATA as usize);
+            if f % 2 == 0 {
+                sector[..CD_SYNC_HEADER.len()].copy_from_slice(&CD_SYNC_HEADER);
+                sector[CD_MODE_OFFSET] = 1; // MODE1
+                for b in &mut sector[16..] {
+                    *b = rng();
+                }
+                // overwrite the P/Q ECC area with valid codes so the encoder strips this sector
+                let mut s =
+                    <&mut [u8; CD_MAX_SECTOR_DATA as usize]>::try_from(&mut sector[..]).unwrap();
+                s.generate_ecc();
+            } else {
+                for b in sector.iter_mut() {
+                    *b = rng();
+                }
+            }
+            for b in subcode.iter_mut() {
+                *b = rng();
+            }
+        }
+        hunk
+    }
+
+    fn roundtrip<E, S, D>(mut enc: CdEncoder<E, S>, mut dec: D, hunk_size: u32)
+    where
+        E: CodecEncodeImplementation,
+        S: CodecEncodeImplementation,
+        D: CodecImplementation,
+    {
+        let hunk = build_cd_hunk((hunk_size / CD_FRAME_SIZE) as usize);
+        let mut comp = vec![0u8; hunk_size as usize];
+        let n = enc.compress(&hunk, &mut comp).unwrap();
+        assert!(n < hunk.len(), "expected the CD hunk to shrink");
+
+        let mut out = vec![0u8; hunk_size as usize];
+        let res = dec.decompress(&comp[..n], &mut out).unwrap();
+        assert_eq!(res.total_out(), hunk_size as usize);
+        assert_eq!(out, hunk, "CD codec round-trip mismatch");
+    }
+
+    #[test]
+    fn cd_zlib_roundtrips() {
+        let hs = 8 * CD_FRAME_SIZE;
+        roundtrip::<ZlibEncoder, ZlibEncoder, _>(
+            CdEncoder::new(hs).unwrap(),
+            CdZlibCodec::new(hs).unwrap(),
+            hs,
+        );
+    }
+
+    #[test]
+    fn cd_lzma_roundtrips() {
+        let hs = 8 * CD_FRAME_SIZE;
+        roundtrip::<LzmaEncoder, ZlibEncoder, _>(
+            CdEncoder::new(hs).unwrap(),
+            CdLzmaCodec::new(hs).unwrap(),
+            hs,
+        );
     }
 }

--- a/chd-rs/src/compression/flac.rs
+++ b/chd-rs/src/compression/flac.rs
@@ -427,3 +427,152 @@ impl CodecImplementation for CdFlacCodec {
         Ok(frame_res + sub_res)
     }
 }
+
+/// Port of MAME `chd_cd_flac_compressor::blocksize` (`chdcodec.cpp:1686`): the FLAC block size in
+/// samples = `bytes / 4`, halved while `> 2352` (`MAX_SECTOR_DATA`). Note the threshold is the CD
+/// sector size, not the `2048` of the raw-FLAC [`flac_blocksize`].
+#[cfg(feature = "write")]
+fn cd_flac_blocksize(bytes: u32) -> u32 {
+    let mut bs = bytes / 4;
+    while bs > CD_MAX_SECTOR_DATA {
+        bs /= 2;
+    }
+    bs
+}
+
+/// CD-ROM wrapper **FLAC** compression codec (cdfl) — the encode mirror of [`CdFlacCodec`].
+///
+/// Reproduces MAME's `chd_cd_flac_compressor::compress` (`chdcodec.cpp:1634`), which is **unlike**
+/// the [`CdEncoder`](crate::compression::cdrom::CdEncoder)-based `cdzl`/`cdlz`/`cdzs`: there is **no
+/// ECC strip** and **no header**. It de-swizzles the hunk's interleaved `[sector(2352) ‖
+/// subcode(96)]` frames into a sector run followed by a subcode run, FLAC-encodes the sector run as
+/// 2-channel 16-bit PCM interpreted **big-endian** (matching MAME's host-swap on a little-endian
+/// build; the decoder always reads big-endian), raw-deflates the subcode run with the same
+/// [`ZlibEncoder`](crate::compression::zlib::ZlibEncoder) the other CD codecs use, and emits
+/// `[flac_stream ‖ deflate_stream]` (the FLAC stream is self-delimiting, so no length field is
+/// stored). Returns [`Error::CompressionError`] if the result is not smaller than the hunk (MAME's
+/// `complen >= srclen`), so the writer falls back to storing the hunk uncompressed.
+///
+/// ⚠️ **Byte-identity is libm-gated** (see [`RawFlacEncoder`]): validated byte-identical to a
+/// **glibc** chdman 0.288, round-trip-correct against any build.
+#[cfg(feature = "write")]
+pub struct CdFlacEncoder {
+    frames: u32,
+    block_size: u32,
+    sub_engine: super::zlib::ZlibEncoder,
+    buffer: Vec<u8>,
+}
+
+#[cfg(feature = "write")]
+impl crate::compression::CodecEncodeImplementation for CdFlacEncoder {
+    fn new(hunk_size: u32) -> Result<Self> {
+        if hunk_size % CD_FRAME_SIZE != 0 {
+            return Err(Error::CodecError);
+        }
+        let frames = hunk_size / CD_FRAME_SIZE;
+        Ok(CdFlacEncoder {
+            frames,
+            block_size: cd_flac_blocksize(frames * CD_MAX_SECTOR_DATA),
+            sub_engine: super::zlib::ZlibEncoder::new(frames * CD_MAX_SUBCODE_DATA)?,
+            buffer: vec![0u8; hunk_size as usize],
+        })
+    }
+
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize> {
+        let frames = self.frames as usize;
+        let sect_total = frames * CD_MAX_SECTOR_DATA as usize;
+        let sub_total = frames * CD_MAX_SUBCODE_DATA as usize;
+
+        // de-swizzle [sector ‖ subcode] frames into the sector run then the subcode run (no ECC strip)
+        for f in 0..frames {
+            let src = &input[f * CD_FRAME_SIZE as usize..];
+            self.buffer[f * CD_MAX_SECTOR_DATA as usize..][..CD_MAX_SECTOR_DATA as usize]
+                .copy_from_slice(&src[..CD_MAX_SECTOR_DATA as usize]);
+            self.buffer[sect_total + f * CD_MAX_SUBCODE_DATA as usize..]
+                [..CD_MAX_SUBCODE_DATA as usize]
+                .copy_from_slice(
+                    &src[CD_MAX_SECTOR_DATA as usize..][..CD_MAX_SUBCODE_DATA as usize],
+                );
+        }
+
+        // FLAC-encode the sector run as big-endian interleaved 16-bit stereo (no endian flag byte).
+        let samples: Vec<i32> = self.buffer[..sect_total]
+            .chunks_exact(2)
+            .map(|b| i16::from_be_bytes([b[0], b[1]]) as i32)
+            .collect();
+        let enc = libflac_rs::Encoder::new(libflac_rs::EncoderConfig::chd(self.block_size));
+        let flac = enc.encode_frames(&samples);
+        if flac.len() >= input.len() || flac.len() > output.len() {
+            return Err(Error::CompressionError);
+        }
+        output[..flac.len()].copy_from_slice(&flac);
+
+        // raw-deflate the subcode run directly after the FLAC stream
+        let sub_n = self.sub_engine.compress(
+            &self.buffer[sect_total..sect_total + sub_total],
+            &mut output[flac.len()..],
+        )?;
+
+        let total = flac.len() + sub_n;
+        if total >= input.len() {
+            return Err(Error::CompressionError);
+        }
+        Ok(total)
+    }
+}
+
+#[cfg(feature = "write")]
+impl crate::compression::CompressionEncoder for CdFlacEncoder {}
+
+#[cfg(all(test, feature = "write", feature = "want_subcode"))]
+mod cd_flac_tests {
+    use super::*;
+    use crate::compression::codecs::CdFlacCodec;
+    use crate::compression::{CodecEncodeImplementation, CodecImplementation};
+
+    /// `CdFlacEncoder` → `CdFlacCodec` round-trips a CD hunk of smooth big-endian stereo audio
+    /// sectors (so FLAC engages) plus pseudo-random subcode.
+    #[test]
+    fn cd_flac_roundtrips() {
+        let frames = 8usize;
+        let hs = frames as u32 * CD_FRAME_SIZE;
+        let mut hunk = vec![0u8; hs as usize];
+        let (mut l, mut r, mut dl, mut dr): (i32, i32, i32, i32) = (0, 0, 37, 53);
+        let mut x = 0x9e37_79b9u32;
+        for f in 0..frames {
+            let frame = &mut hunk[f * CD_FRAME_SIZE as usize..][..CD_FRAME_SIZE as usize];
+            let (sector, subcode) = frame.split_at_mut(CD_MAX_SECTOR_DATA as usize);
+            for s in sector.chunks_exact_mut(4) {
+                l += dl;
+                if !(-20000..=20000).contains(&l) {
+                    dl = -dl;
+                    l += 2 * dl;
+                }
+                r += dr;
+                if !(-18000..=18000).contains(&r) {
+                    dr = -dr;
+                    r += 2 * dr;
+                }
+                s[0..2].copy_from_slice(&(l as i16).to_be_bytes());
+                s[2..4].copy_from_slice(&(r as i16).to_be_bytes());
+            }
+            for b in subcode.iter_mut() {
+                x ^= x << 13;
+                x ^= x >> 17;
+                x ^= x << 5;
+                *b = (x & 0xff) as u8;
+            }
+        }
+
+        let mut enc = CdFlacEncoder::new(hs).unwrap();
+        let mut comp = vec![0u8; hs as usize];
+        let n = enc.compress(&hunk, &mut comp).unwrap();
+        assert!(n < hunk.len(), "expected cdfl to shrink the audio hunk");
+
+        let mut dec = CdFlacCodec::new(hs).unwrap();
+        let mut out = vec![0u8; hs as usize];
+        let res = dec.decompress(&comp[..n], &mut out).unwrap();
+        assert_eq!(res.total_out(), hs as usize);
+        assert_eq!(out, hunk, "cdfl round-trip mismatch");
+    }
+}

--- a/chd-rs/src/compression/flac.rs
+++ b/chd-rs/src/compression/flac.rs
@@ -145,6 +145,174 @@ impl CodecImplementation for RawFlacCodec {
     }
 }
 
+/// Port of MAME `chd_flac_compressor::blocksize` (`chdcodec.cpp:1520`): the FLAC block size in
+/// samples = `bytes / 4`, halved while `> 2048` (clamped to the ~2k "sweet spot").
+#[cfg(feature = "write")]
+fn flac_blocksize(bytes: u32) -> u32 {
+    let mut bs = bytes / 4;
+    while bs > 2048 {
+        bs /= 2;
+    }
+    bs
+}
+
+/// Raw FLAC (`flac`) compression codec.
+///
+/// Backed by [`libflac-rs`](https://docs.rs/libflac-rs), a bit-exact pure-Rust port of the
+/// libFLAC 1.4.3 encoder. Reproduces MAME's `chd_flac_compressor`: it encodes the hunk twice as
+/// 2-channel 16-bit PCM — once interpreting the bytes little-endian, once big-endian — at FLAC
+/// level 8 (block size = [`flac_blocksize`], streamable-subset off, MD5 off, raw frames with no
+/// STREAMINFO/seektable), keeps the smaller, and prepends the `'L'`/`'B'` endian flag byte. Ties
+/// keep `'L'` (MAME writes `'L'` first and switches to `'B'` only when big-endian is *strictly*
+/// smaller).
+///
+/// ⚠️ **Byte-identity to a given chdman build is libm-dependent.** libflac-rs's floating-point
+/// parity is validated against glibc libm, so the output is byte-identical to a glibc-built chdman
+/// but may differ by a few bytes from an MSVC/Windows chdman. The output is always
+/// round-trip-correct (it decodes back to the original PCM via [`RawFlacCodec`]).
+///
+/// ## Buffer Restrictions
+/// The hunk size must be a multiple of 4 (2 channels × 2 bytes). The compressed FLAC stream plus
+/// the 1-byte endian flag must fit in `hunk_size`; otherwise [`compress`](RawFlacEncoder::compress)
+/// returns [`Error::CompressionError`] so the writer falls back to storing the hunk uncompressed
+/// (matching MAME's `hunkbytes - 1` destination buffer + `complen + 1 >= hunkbytes` checks).
+#[cfg(feature = "write")]
+pub struct RawFlacEncoder {
+    hunk_bytes: u32,
+    block_size: u32,
+}
+
+#[cfg(feature = "write")]
+impl crate::compression::CodecEncodeImplementation for RawFlacEncoder {
+    fn new(hunk_size: u32) -> Result<Self> {
+        // 2-channel 16-bit PCM: the hunk must be a whole number of stereo samples.
+        if hunk_size % (2 * mem::size_of::<i16>()) as u32 != 0 {
+            return Err(Error::CodecError);
+        }
+        Ok(RawFlacEncoder {
+            hunk_bytes: hunk_size,
+            block_size: flac_blocksize(hunk_size),
+        })
+    }
+
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize> {
+        // MAME encodes into a `hunkbytes - 1` buffer (1 byte reserved for the endian flag);
+        // a stream overflowing it throws COMPRESSION_ERROR -> the driver stores the hunk NONE.
+        let cap = self.hunk_bytes as usize - 1;
+        let enc = libflac_rs::Encoder::new(libflac_rs::EncoderConfig::chd(self.block_size));
+
+        // little-endian interpretation -> 'L'
+        let le: Vec<i32> = input
+            .chunks_exact(2)
+            .map(|b| i16::from_le_bytes([b[0], b[1]]) as i32)
+            .collect();
+        let le_frames = enc.encode_frames(&le);
+
+        // big-endian interpretation -> 'B'
+        let be: Vec<i32> = input
+            .chunks_exact(2)
+            .map(|b| i16::from_be_bytes([b[0], b[1]]) as i32)
+            .collect();
+        let be_frames = enc.encode_frames(&be);
+
+        if le_frames.len() > cap || be_frames.len() > cap {
+            return Err(Error::CompressionError);
+        }
+
+        // pick the smaller; ties keep 'L' (MAME switches to 'B' only when strictly smaller).
+        let (flag, frames) = if be_frames.len() < le_frames.len() {
+            (b'B', &be_frames)
+        } else {
+            (b'L', &le_frames)
+        };
+
+        let total = frames.len() + 1;
+        // `complen + 1 >= hunkbytes` throws in MAME; also guard the caller's buffer.
+        if total >= self.hunk_bytes as usize || total > output.len() {
+            return Err(Error::CompressionError);
+        }
+        output[0] = flag;
+        output[1..total].copy_from_slice(frames);
+        Ok(total)
+    }
+}
+
+#[cfg(feature = "write")]
+impl crate::compression::CompressionEncoder for RawFlacEncoder {}
+
+#[cfg(all(test, feature = "write"))]
+mod tests {
+    use super::*;
+    use crate::compression::{CodecEncodeImplementation, CodecImplementation};
+
+    /// Smooth 16-bit stereo PCM (a bounded triangle wave per channel) that FLAC actually
+    /// compresses, so the round-trip exercises the codec instead of overflowing to NONE.
+    fn audio_hunk(bytes: usize) -> Vec<u8> {
+        let mut v = Vec::with_capacity(bytes);
+        let (mut l, mut r, mut dl, mut dr): (i32, i32, i32, i32) = (0, 0, 37, 53);
+        while v.len() < bytes {
+            l += dl;
+            if !(-20000..=20000).contains(&l) {
+                dl = -dl;
+                l += 2 * dl;
+            }
+            r += dr;
+            if !(-18000..=18000).contains(&r) {
+                dr = -dr;
+                r += 2 * dr;
+            }
+            v.extend_from_slice(&(l as i16).to_le_bytes());
+            v.extend_from_slice(&(r as i16).to_le_bytes());
+        }
+        v.truncate(bytes);
+        v
+    }
+
+    /// Cross-crate integration: libflac-rs's raw frames (with the CHD `'L'`/`'B'` endian-trial
+    /// wrapper) decode back through chd-rs's existing FLAC decoder and round-trip exactly.
+    #[test]
+    fn flac_encode_roundtrips_through_decoder() {
+        let hunk = audio_hunk(4096);
+
+        let mut enc = RawFlacEncoder::new(4096).unwrap();
+        let mut comp = vec![0u8; 4096];
+        let n = enc.compress(&hunk, &mut comp).unwrap();
+        assert!(
+            n < hunk.len(),
+            "expected flac to shrink the smooth audio hunk"
+        );
+        assert!(
+            comp[0] == b'L' || comp[0] == b'B',
+            "missing endian flag byte, got {:#x}",
+            comp[0]
+        );
+
+        let mut dec = RawFlacCodec::new(4096).unwrap();
+        let mut out = vec![0u8; 4096];
+        let res = dec.decompress(&comp[..n], &mut out).unwrap();
+        assert_eq!(res.total_out(), 4096);
+        assert_eq!(out, hunk, "flac round-trip mismatch");
+    }
+
+    /// Incompressible (random) data should overflow the FLAC stream past the hunk budget, so the
+    /// encoder reports `CompressionError` and the writer falls back to NONE (matching MAME).
+    #[test]
+    fn flac_rejects_incompressible() {
+        let mut x: u32 = 0x1234_5678;
+        let hunk: Vec<u8> = (0..4096)
+            .map(|_| {
+                x ^= x << 13;
+                x ^= x >> 17;
+                x ^= x << 5;
+                (x & 0xff) as u8
+            })
+            .collect();
+        let mut enc = RawFlacEncoder::new(4096).unwrap();
+        let mut comp = vec![0u8; 4096];
+        assert!(enc.compress(&hunk, &mut comp).is_err());
+    }
+}
+
 /// CD-ROM wrapper decompression codec (cdfl) using the FLAC
 /// for decompression of sector data and the [Deflate codec](crate::codecs::ZlibCodec) for
 /// decompression of subcode data.

--- a/chd-rs/src/compression/huff.rs
+++ b/chd-rs/src/compression/huff.rs
@@ -50,3 +50,56 @@ impl CompressionCodecType for HuffmanCodec {
 }
 
 impl CompressionCodec for HuffmanCodec {}
+
+/// MAME 8-bit Huffman (huff) compression codec.
+///
+/// Encodes via [`crate::huffman_encode::encode_8bit`], a faithful port of MAME's
+/// `huffman_8bit_encoder` (256 codes, 16-bit max) — byte-identical to chdman for a given hunk.
+#[cfg(feature = "write")]
+pub struct HuffmanEncoder;
+
+#[cfg(feature = "write")]
+impl crate::compression::CodecEncodeImplementation for HuffmanEncoder {
+    fn new(_: u32) -> Result<Self> {
+        Ok(HuffmanEncoder)
+    }
+
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize> {
+        let out = crate::huffman_encode::encode_8bit(input)
+            .map_err(|_| crate::error::Error::CompressionError)?;
+        if out.len() > output.len() {
+            return Err(crate::error::Error::CompressionError);
+        }
+        output[..out.len()].copy_from_slice(&out);
+        Ok(out.len())
+    }
+}
+
+#[cfg(feature = "write")]
+impl crate::compression::CompressionEncoder for HuffmanEncoder {}
+
+#[cfg(all(test, feature = "write"))]
+mod tests {
+    use super::*;
+    use crate::compression::{CodecEncodeImplementation, CodecImplementation};
+
+    #[test]
+    fn huff_encode_roundtrips_through_decoder() {
+        // Skewed distribution so Huffman shrinks it (result fits a hunk-sized buffer) and the
+        // tree is non-trivial.
+        let hunk: Vec<u8> = (0..4096u32)
+            .map(|i| if i % 3 == 0 { (i % 11) as u8 } else { 0 })
+            .collect();
+
+        let mut enc = HuffmanEncoder::new(4096).unwrap();
+        let mut comp = vec![0u8; 4096];
+        let n = enc.compress(&hunk, &mut comp).unwrap();
+        assert!(n < hunk.len(), "expected Huffman to shrink the skewed hunk");
+
+        let mut dec = HuffmanCodec::new(4096).unwrap();
+        let mut out = vec![0u8; 4096];
+        let res = dec.decompress(&comp[..n], &mut out).unwrap();
+        assert_eq!(res.total_out(), 4096);
+        assert_eq!(out, hunk);
+    }
+}

--- a/chd-rs/src/compression/lzma.rs
+++ b/chd-rs/src/compression/lzma.rs
@@ -164,3 +164,60 @@ impl CodecImplementation for LzmaCodec {
         Ok(DecompressResult::new(len, read.position() as usize))
     }
 }
+
+/// LZMA (lzma) compression codec.
+///
+/// Backed by [`lzma-sdk-rs`](https://docs.rs/lzma-sdk-rs), a bit-exact pure-Rust port of the
+/// 7-zip LZMA SDK 23.01 encoder. Emits a raw LZMA stream (no header, no end marker) using the
+/// CHD props (lc=3/lp=0/pb=2, dictionary reduced to the hunk size) — byte-identical to MAME's
+/// `LzmaEnc_MemEncode`. `LzmaProps::chd_for_hunk` reproduces the same dictionary derivation as
+/// [`get_lzma_dict_size`] above.
+#[cfg(feature = "write")]
+pub struct LzmaEncoder {
+    props: lzma_sdk_rs::LzmaProps,
+}
+
+#[cfg(feature = "write")]
+impl crate::compression::CodecEncodeImplementation for LzmaEncoder {
+    fn new(hunk_size: u32) -> Result<Self> {
+        Ok(LzmaEncoder {
+            props: lzma_sdk_rs::LzmaProps::chd_for_hunk(hunk_size),
+        })
+    }
+
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize> {
+        let out = lzma_sdk_rs::encode(input, &self.props);
+        if out.len() > output.len() {
+            return Err(Error::CompressionError);
+        }
+        output[..out.len()].copy_from_slice(&out);
+        Ok(out.len())
+    }
+}
+
+#[cfg(feature = "write")]
+impl crate::compression::CompressionEncoder for LzmaEncoder {}
+
+#[cfg(all(test, feature = "write"))]
+mod tests {
+    use super::*;
+    use crate::compression::{CodecEncodeImplementation, CodecImplementation};
+
+    /// Proves the cross-crate integration: lzma-sdk-rs's encoder output is decodable by
+    /// chd-rs's existing LZMA decoder with the CHD dictionary params, and round-trips.
+    #[test]
+    fn lzma_encode_roundtrips_through_decoder() {
+        let hunk: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+
+        let mut enc = LzmaEncoder::new(4096).unwrap();
+        let mut comp = vec![0u8; 4096];
+        let n = enc.compress(&hunk, &mut comp).unwrap();
+        assert!(n < hunk.len(), "expected compression to shrink the hunk");
+
+        let mut dec = LzmaCodec::new(4096).unwrap();
+        let mut out = vec![0u8; 4096];
+        let res = dec.decompress(&comp[..n], &mut out).unwrap();
+        assert_eq!(res.total_out(), 4096);
+        assert_eq!(out, hunk);
+    }
+}

--- a/chd-rs/src/compression/mod.rs
+++ b/chd-rs/src/compression/mod.rs
@@ -4,7 +4,9 @@ use std::ops::{Add, AddAssign};
 
 mod avhuff;
 mod cdrom;
-mod ecc;
+// `pub(crate)` so the dev-only chdman_compat tests can synthesize valid MODE1 sectors
+// (sync + ECC) when building CD test images. The trait inside is already `pub(crate)`.
+pub(crate) mod ecc;
 mod flac;
 mod huff;
 mod lzma;
@@ -38,6 +40,19 @@ pub mod codecs {
     pub use crate::compression::zlib::ZlibEncoder;
     #[cfg(feature = "write-zstd")]
     pub use crate::compression::zstd::ZstdEncoder;
+
+    // CD wrapper encoders (encode mirror of CdLzmaCodec/CdZlibCodec/CdZstdCodec).
+    #[cfg(feature = "write")]
+    pub use crate::compression::cdrom::CdEncoder;
+    /// CD Deflate (`cdzl`) compression codec: zlib sectors + zlib subcode.
+    #[cfg(feature = "write")]
+    pub type CdZlibEncoder = CdEncoder<ZlibEncoder, ZlibEncoder>;
+    /// CD LZMA (`cdlz`) compression codec: LZMA sectors + zlib subcode.
+    #[cfg(feature = "write")]
+    pub type CdLzmaEncoder = CdEncoder<LzmaEncoder, ZlibEncoder>;
+    /// CD Zstandard (`cdzs`) compression codec: zstd sectors + zstd subcode.
+    #[cfg(feature = "write-zstd")]
+    pub type CdZstdEncoder = CdEncoder<ZstdEncoder, ZstdEncoder>;
 }
 
 // unstable(trait_alias)

--- a/chd-rs/src/compression/mod.rs
+++ b/chd-rs/src/compression/mod.rs
@@ -24,6 +24,20 @@ pub mod codecs {
     pub use crate::compression::none::NoneCodec;
     pub use crate::compression::zlib::ZlibCodec;
     pub use crate::compression::zstd::ZstdCodec;
+
+    // Encoders (write feature). Added per-codec as milestones land.
+    #[cfg(feature = "write")]
+    pub use crate::compression::flac::RawFlacEncoder;
+    #[cfg(feature = "write")]
+    pub use crate::compression::huff::HuffmanEncoder;
+    #[cfg(feature = "write")]
+    pub use crate::compression::lzma::LzmaEncoder;
+    #[cfg(feature = "write")]
+    pub use crate::compression::none::NoneEncoder;
+    #[cfg(feature = "write")]
+    pub use crate::compression::zlib::ZlibEncoder;
+    #[cfg(feature = "write-zstd")]
+    pub use crate::compression::zstd::ZstdEncoder;
 }
 
 // unstable(trait_alias)
@@ -53,6 +67,35 @@ pub trait CodecImplementation {
     /// length as `hunk_size`, but this may be dependent on the codec
     /// implementation.
     fn decompress(&mut self, input: &[u8], output: &mut [u8]) -> Result<DecompressResult>;
+}
+
+/// Marker trait for a codec that can be used to compress (encode) a hunk.
+///
+/// The encode mirror of [`CompressionCodec`]. Available with the `write` feature.
+#[cfg(feature = "write")]
+pub trait CompressionEncoder: CodecEncodeImplementation + Send + Sync {}
+
+/// Trait for a CHD compression (encode) codec implementation.
+///
+/// The encode mirror of [`CodecImplementation`]. Available with the `write` feature.
+#[cfg(feature = "write")]
+pub trait CodecEncodeImplementation {
+    /// Creates a new encoder for the provided hunk size.
+    fn new(hunk_size: u32) -> Result<Self>
+    where
+        Self: Sized;
+
+    /// Compress `input` (one hunk) into `output`, returning the number of compressed
+    /// bytes written.
+    ///
+    /// `output` is sized to at least `hunk_size`. A codec that cannot produce output
+    /// that fits within `output` (i.e. it would expand the hunk) returns
+    /// [`Error::CompressionError`](crate::error::Error::CompressionError) so the
+    /// writer can fall back to a smaller codec or store the hunk uncompressed.
+    ///
+    /// Implementations must be **deterministic**: identical input must yield identical
+    /// output (the bit-for-bit parity goal depends on it).
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize>;
 }
 
 /// The result of a chunk decompression operation.

--- a/chd-rs/src/compression/mod.rs
+++ b/chd-rs/src/compression/mod.rs
@@ -29,6 +29,8 @@ pub mod codecs {
 
     // Encoders (write feature). Added per-codec as milestones land.
     #[cfg(feature = "write")]
+    pub use crate::compression::flac::CdFlacEncoder;
+    #[cfg(feature = "write")]
     pub use crate::compression::flac::RawFlacEncoder;
     #[cfg(feature = "write")]
     pub use crate::compression::huff::HuffmanEncoder;

--- a/chd-rs/src/compression/none.rs
+++ b/chd-rs/src/compression/none.rs
@@ -28,3 +28,28 @@ impl CompressionCodecType for NoneCodec {
 }
 
 impl CompressionCodec for NoneCodec {}
+
+/// None/copy encoder: a byte-for-byte copy of the input.
+///
+/// "None" never shrinks a hunk, so the writer normally records uncompressed hunks at the
+/// map level rather than through this encoder; it exists for symmetry with [`NoneCodec`].
+#[cfg(feature = "write")]
+pub struct NoneEncoder;
+
+#[cfg(feature = "write")]
+impl crate::compression::CodecEncodeImplementation for NoneEncoder {
+    fn new(_: u32) -> Result<Self> {
+        Ok(NoneEncoder)
+    }
+
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize> {
+        if input.len() > output.len() {
+            return Err(crate::error::Error::CompressionError);
+        }
+        output[..input.len()].copy_from_slice(input);
+        Ok(input.len())
+    }
+}
+
+#[cfg(feature = "write")]
+impl crate::compression::CompressionEncoder for NoneEncoder {}

--- a/chd-rs/src/compression/zlib.rs
+++ b/chd-rs/src/compression/zlib.rs
@@ -55,3 +55,78 @@ impl CompressionCodecType for ZlibCodec {
 }
 
 impl CompressionCodec for ZlibCodec {}
+
+/// Deflate (zlib) compression codec.
+///
+/// Backed by [`zlib-bitexact-rs`](https://crates.io/crates/zlib-bitexact-rs), a bit-exact
+/// pure-Rust port of stock **zlib 1.3.1**'s deflate. Produces a raw DEFLATE stream (no zlib
+/// header/trailer) byte-identical to MAME's
+/// `deflateInit2(Z_BEST_COMPRESSION, Z_DEFLATED, -MAX_WBITS, 8, Z_DEFAULT_STRATEGY)` +
+/// `deflate(Z_FINISH)`. The decoder ([`ZlibCodec`]) keeps using `flate2` — inflate is
+/// unambiguous, so only the encoder needs byte-exactness.
+#[cfg(feature = "write")]
+pub struct ZlibEncoder;
+
+#[cfg(feature = "write")]
+impl crate::compression::CodecEncodeImplementation for ZlibEncoder {
+    fn new(_: u32) -> Result<Self> {
+        Ok(ZlibEncoder)
+    }
+
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize> {
+        let compressed = zlib_bitexact_rs::deflate_raw(input);
+        // `deflate_raw` always consumes the whole input; the only failure mode is that the raw
+        // DEFLATE stream doesn't fit the hunk-sized output buffer (it would expand), in which
+        // case the codec "loses" and the writer stores the hunk uncompressed (NONE).
+        if compressed.len() > output.len() {
+            return Err(Error::CompressionError);
+        }
+        output[..compressed.len()].copy_from_slice(&compressed);
+        Ok(compressed.len())
+    }
+}
+
+#[cfg(feature = "write")]
+impl crate::compression::CompressionEncoder for ZlibEncoder {}
+
+#[cfg(all(test, feature = "write"))]
+mod tests {
+    use super::*;
+    use crate::compression::{CodecEncodeImplementation, CodecImplementation};
+
+    #[test]
+    fn zlib_encode_roundtrips_through_decoder() {
+        // A compressible pattern so the encoder produces something smaller than the hunk.
+        let hunk: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+
+        let mut enc = ZlibEncoder::new(4096).unwrap();
+        let mut comp = vec![0u8; 4096];
+        let n = enc.compress(&hunk, &mut comp).unwrap();
+        assert!(n < hunk.len(), "expected compression to shrink the hunk");
+
+        let mut dec = ZlibCodec::new(4096).unwrap();
+        let mut out = vec![0u8; 4096];
+        let res = dec.decompress(&comp[..n], &mut out).unwrap();
+        assert_eq!(res.total_out(), 4096);
+        assert_eq!(out, hunk);
+    }
+
+    #[test]
+    fn zlib_encode_rejects_incompressible_into_tight_buffer() {
+        // Pseudo-random (incompressible) data; deflate will need >= input bytes, so a
+        // hunk-sized output buffer can't hold it and the encoder must reject.
+        let mut x = 0x1234_5678u32;
+        let hunk: Vec<u8> = (0..4096)
+            .map(|_| {
+                x ^= x << 13;
+                x ^= x >> 17;
+                x ^= x << 5;
+                (x & 0xff) as u8
+            })
+            .collect();
+
+        let mut enc = ZlibEncoder::new(4096).unwrap();
+        let mut comp = vec![0u8; 4096];
+        assert!(enc.compress(&hunk, &mut comp).is_err());
+    }
+}

--- a/chd-rs/src/compression/zstd.rs
+++ b/chd-rs/src/compression/zstd.rs
@@ -113,3 +113,63 @@ impl CompressionCodecType for ZstdCodec {
 }
 
 impl CompressionCodec for ZstdCodec {}
+
+/// Zstandard (zstd) compression codec.
+///
+/// Backed by [`libzstd-bitexact-rs`](https://crates.io/crates/libzstd-bitexact-rs) `=0.155`, a
+/// bit-exact pure-Rust port of libzstd **1.5.5** (chdman's version). Reproduces chdman's
+/// per-hunk path exactly: level 22 (`ZSTD_maxCLevel`), **unknown pledged size** (so the frame
+/// keeps `windowLog` 27 and long-distance matching), no dictionary — i.e.
+/// `ZSTD_initCStream(22)` + `ZSTD_compressStream2(.., ZSTD_e_end)`.
+#[cfg(feature = "write-zstd")]
+pub struct ZstdEncoder;
+
+#[cfg(feature = "write-zstd")]
+impl crate::compression::CodecEncodeImplementation for ZstdEncoder {
+    fn new(_: u32) -> crate::Result<Self> {
+        Ok(ZstdEncoder)
+    }
+
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> crate::Result<usize> {
+        // `StreamEncoder::new(22)` = unknown pledged size (do NOT pledge the hunk size — that
+        // downsizes windowLog and changes the bytes); `finish` = ZSTD_e_end.
+        let mut out = Vec::new();
+        libzstd_bitexact_rs::StreamEncoder::new(22)
+            .finish(input, &mut out)
+            .map_err(|_| Error::CompressionError)?;
+        if out.len() > output.len() {
+            return Err(Error::CompressionError);
+        }
+        output[..out.len()].copy_from_slice(&out);
+        Ok(out.len())
+    }
+}
+
+#[cfg(feature = "write-zstd")]
+impl crate::compression::CompressionEncoder for ZstdEncoder {}
+
+#[cfg(all(test, feature = "write-zstd"))]
+mod tests {
+    use super::*;
+    use crate::compression::{CodecEncodeImplementation, CodecImplementation};
+
+    /// Round-trip proves the integration is **valid**; byte-exactness vs zstd 1.5.5 is
+    /// guaranteed by libzstd-bitexact-rs's own differential suite. Because zstd decode is
+    /// format-stable, a round-trip cannot catch encoder drift — to guard byte-identity,
+    /// compare *compressed* bytes against a 1.5.5 golden (a chd-rs-side differential test).
+    #[test]
+    fn zstd_encode_roundtrips_through_decoder() {
+        let hunk: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+
+        let mut enc = ZstdEncoder::new(4096).unwrap();
+        let mut comp = vec![0u8; 4096];
+        let n = enc.compress(&hunk, &mut comp).unwrap();
+        assert!(n < hunk.len(), "expected compression to shrink the hunk");
+
+        let mut dec = ZstdCodec::new(4096).unwrap();
+        let mut out = vec![0u8; 4096];
+        let res = dec.decompress(&comp[..n], &mut out).unwrap();
+        assert_eq!(res.total_out(), 4096);
+        assert_eq!(out, hunk);
+    }
+}

--- a/chd-rs/src/copy.rs
+++ b/chd-rs/src/copy.rs
@@ -86,31 +86,7 @@ fn copy_inner(
         .collect();
 
     let mut out = File::create(dest).map_err(Error::from)?;
-    if codecs.is_empty() {
-        if cancel() {
-            return Err(Error::Cancelled);
-        }
-        write::write_uncompressed_inner(&mut out, &data, hunk, unit, &entries)?;
-        progress(CompressionProgress {
-            bytes_done: logical,
-            bytes_total: logical,
-            ratio: 1.0,
-        });
-        return Ok(());
-    }
-
-    let mut prog = |done: u64, total: u64, comp: u64| {
-        progress(CompressionProgress {
-            bytes_done: done,
-            bytes_total: total,
-            ratio: if done == 0 {
-                1.0
-            } else {
-                comp as f64 / done as f64
-            },
-        });
-    };
-    write::write_raw_inner(
-        &mut out, &data, hunk, unit, &codecs, &entries, &mut prog, cancel,
+    write::write_create(
+        &mut out, &data, hunk, unit, &codecs, &entries, progress, cancel,
     )
 }

--- a/chd-rs/src/copy.rs
+++ b/chd-rs/src/copy.rs
@@ -1,0 +1,116 @@
+//! Re-compress a CHD into a different codec set or hunk size — chdman `copy`.
+//!
+//! [`copy`] reads a source CHD's logical bytes, re-compresses them with a new codec list (and,
+//! optionally, a new hunk size), and clones every metadata record verbatim — byte-identical to
+//! `chdman copy` for the same options. The **unit size is preserved** from the source (chdman does
+//! the same), so the output's logical bytes, unit bytes, and `raw_sha1` match the source's.
+//!
+//! Matches libchdman-rs's `copy` module. Like the `hd` create functions, the whole logical image
+//! is held in memory while writing (a streaming writer is future work).
+//!
+//! ⚠️ CD/GD CHDs: chdman *re-does* the legacy CD metadata on copy. chd-rs clones all metadata
+//! verbatim, which is correct for HD/DVD/raw CHDs and modern CD metadata; the legacy-CD re-do
+//! lands with the `cd` module (Phase E).
+
+use crate::error::{Error, Result};
+use crate::metadata::Metadata;
+use crate::read::ChdReader;
+use crate::{write, Chd, CompressionProgress};
+use std::convert::TryInto;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+/// Options for [`copy`]. Matches libchdman-rs's `CopyOptions`.
+#[derive(Debug, Clone, Default)]
+pub struct CopyOptions {
+    /// New hunk size in bytes. `None` keeps the source's hunk size. Must be a multiple of the
+    /// source's unit size.
+    pub hunk_size: Option<u32>,
+    /// New codec slots (FourCCs from [`crate::codec`]). `[0; 4]` produces an uncompressed copy. A
+    /// `0` ends the list; codecs must be contiguous from slot 0.
+    pub codecs: [u32; 4],
+}
+
+/// Re-compress the CHD at `source` into `dest` with `opts.codecs` and (optionally) a new hunk size,
+/// cloning all metadata — chdman `copy`. On any error (including cancellation) the partial `dest`
+/// is removed.
+///
+/// `progress` is invoked per hunk; `cancel` is polled before each hunk and, if it returns true,
+/// the copy aborts with [`Error::Cancelled`].
+pub fn copy(
+    source: &Path,
+    dest: &Path,
+    opts: CopyOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let res = copy_inner(source, dest, opts, progress, cancel);
+    if res.is_err() {
+        let _ = std::fs::remove_file(dest);
+    }
+    res
+}
+
+fn copy_inner(
+    source: &Path,
+    dest: &Path,
+    opts: CopyOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let f = BufReader::new(File::open(source).map_err(Error::from)?);
+    let mut chd = Chd::open(f, None)?;
+    let logical = chd.header().logical_bytes();
+    let unit = chd.header().unit_bytes();
+    let hunk = opts.hunk_size.unwrap_or_else(|| chd.header().hunk_size());
+
+    // Snapshot every metadata record in file (linked-list) order, preserving tag/flags/payload —
+    // chdman's copy clones them in the same order via `write_metadata(..., APPEND, ...)`.
+    let metas: Vec<Metadata> = chd.metadata_refs().try_into()?;
+
+    // Read the full logical image (the in-memory writer needs it; ChdReader yields full hunks, so
+    // read exactly `logical` bytes — past that is last-hunk padding).
+    let mut data = vec![0u8; logical as usize];
+    let mut reader = ChdReader::new(chd);
+    reader.read_exact(&mut data).map_err(Error::from)?;
+
+    let codecs = write::resolve_codecs(&opts.codecs)?;
+    let entries: Vec<write::MetaEntry> = metas
+        .iter()
+        .map(|m| write::MetaEntry {
+            tag: m.metatag,
+            flags: m.flags,
+            payload: &m.value,
+        })
+        .collect();
+
+    let mut out = File::create(dest).map_err(Error::from)?;
+    if codecs.is_empty() {
+        if cancel() {
+            return Err(Error::Cancelled);
+        }
+        write::write_uncompressed_inner(&mut out, &data, hunk, unit, &entries)?;
+        progress(CompressionProgress {
+            bytes_done: logical,
+            bytes_total: logical,
+            ratio: 1.0,
+        });
+        return Ok(());
+    }
+
+    let mut prog = |done: u64, total: u64, comp: u64| {
+        progress(CompressionProgress {
+            bytes_done: done,
+            bytes_total: total,
+            ratio: if done == 0 {
+                1.0
+            } else {
+                comp as f64 / done as f64
+            },
+        });
+    };
+    write::write_raw_inner(
+        &mut out, &data, hunk, unit, &codecs, &entries, &mut prog, cancel,
+    )
+}

--- a/chd-rs/src/dvd.rs
+++ b/chd-rs/src/dvd.rs
@@ -1,0 +1,166 @@
+//! DVD CHDs — chdman `createdvd` / `extractdvd` parity.
+//!
+//! Simpler than CDs: flat 2048-byte sectors, no ECC, no tracks — just compressed sectors plus a
+//! single (effectively empty) `DVD ` metadata record so MAME recognises the file as a DVD. The
+//! create path is [`hd::create_from_reader`](crate::hd::create_from_reader) with a `DVD ` record
+//! instead of `GDDD`; output is **byte-identical to `chdman createdvd`**.
+//!
+//! Matches libchdman-rs's `dvd` module.
+
+use crate::error::{Error, Result};
+use crate::metadata::Metadata;
+use crate::read::ChdReader;
+use crate::{
+    write, Chd, CompressionProgress, CHD_CODEC_FLAC, CHD_CODEC_HUFF, CHD_CODEC_LZMA, CHD_CODEC_ZLIB,
+};
+use std::convert::TryInto;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::Path;
+
+/// DVD logical sector size in bytes.
+pub const DVD_SECTOR_SIZE: u32 = 2048;
+/// chdman's default DVD hunk size (`2 * 2048 = 4096`).
+pub const DEFAULT_HUNK_SIZE: u32 = 2 * DVD_SECTOR_SIZE;
+
+/// Options for DVD CHD creation. Matches libchdman-rs's `DvdCreateOptions`.
+#[derive(Debug, Clone)]
+pub struct DvdCreateOptions {
+    /// Logical size in bytes. Must be a multiple of 2048. `0` in [`create_from_iso`] means "use the
+    /// input file's size". The input is zero-padded to this size if it ends earlier.
+    pub logical_size: u64,
+    /// Hunk size in bytes. Default `4096`. Must be a multiple of 2048.
+    pub hunk_size: u32,
+    /// Codec slots. Default `[lzma, zlib, huff, flac]` (chdman's `do_create_dvd` reuses the HD
+    /// default codec set). `[0; 4]` produces an uncompressed DVD CHD.
+    pub codecs: [u32; 4],
+}
+
+impl Default for DvdCreateOptions {
+    fn default() -> Self {
+        Self {
+            logical_size: 0,
+            hunk_size: DEFAULT_HUNK_SIZE,
+            codecs: [
+                CHD_CODEC_LZMA,
+                CHD_CODEC_ZLIB,
+                CHD_CODEC_HUFF,
+                CHD_CODEC_FLAC,
+            ],
+        }
+    }
+}
+
+/// Stream `reader` into a DVD CHD at `out`, **byte-identical to `chdman createdvd`**.
+///
+/// Writes the flat 2048-byte sectors plus the `DVD ` metadata record (a single NUL byte — chdman's
+/// `write_metadata(DVD_METADATA_TAG, 0, "")` stores the string's NUL terminator). Same I/O model as
+/// [`hd::create_from_reader`](crate::hd::create_from_reader): whole input in memory, zero-padded to
+/// `logical_size`, `progress`/`cancel` callbacks (cancel → [`Error::Cancelled`] before any bytes
+/// hit `out`).
+pub fn create_from_reader<R: Read, W: Write + std::io::Seek>(
+    reader: R,
+    out: &mut W,
+    opts: DvdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    if opts.hunk_size == 0 || opts.hunk_size % DVD_SECTOR_SIZE != 0 {
+        return Err(Error::InvalidParameter);
+    }
+    let data = write::read_and_pad(reader, opts.logical_size, DVD_SECTOR_SIZE, opts.hunk_size)?;
+
+    // The `DVD ` tag (trailing space) with a 1-byte NUL payload — chdman writes an empty C string,
+    // whose stored length includes the terminator. CHECKSUM flag, like all of chdman's records.
+    let dvd_payload = [0u8; 1];
+    let entries = [write::MetaEntry {
+        tag: crate::make_tag(b"DVD "),
+        flags: write::CHD_MDFLAGS_CHECKSUM,
+        payload: &dvd_payload,
+    }];
+
+    let codecs = write::resolve_codecs(&opts.codecs)?;
+    write::write_create(
+        out,
+        &data,
+        opts.hunk_size,
+        DVD_SECTOR_SIZE,
+        &codecs,
+        &entries,
+        progress,
+        cancel,
+    )
+}
+
+/// File-input convenience over [`create_from_reader`]. If `opts.logical_size` is `0`, the input
+/// file's size is used. On any error (including cancellation) the partial `out_path` is removed.
+pub fn create_from_iso(
+    iso_path: &Path,
+    out_path: &Path,
+    opts: DvdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let mut effective = opts;
+    if effective.logical_size == 0 {
+        effective.logical_size = std::fs::metadata(iso_path).map_err(Error::from)?.len();
+    }
+    let reader = BufReader::new(File::open(iso_path).map_err(Error::from)?);
+    let mut out = File::create(out_path).map_err(Error::from)?;
+    let res = create_from_reader(reader, &mut out, effective, progress, cancel);
+    if res.is_err() {
+        drop(out);
+        let _ = std::fs::remove_file(out_path);
+    }
+    res
+}
+
+/// Returns whether the CHD at `chd_path` carries the `DVD ` metadata record.
+fn is_dvd<F: Read + std::io::Seek>(chd: &mut Chd<F>) -> Result<bool> {
+    let dvd_tag = crate::make_tag(b"DVD ");
+    let metas: Vec<Metadata> = chd.metadata_refs().try_into()?;
+    Ok(metas.iter().any(|m| m.metatag == dvd_tag))
+}
+
+/// Stream a DVD CHD's logical bytes to `writer` (chdman `extractdvd`). Rejects CHDs without the
+/// `DVD ` metadata tag with [`Error::UnsupportedFormat`] (use [`crate::hd::extract_to_writer`] for
+/// HD/raw CHDs).
+pub fn extract_to_writer<W: Write>(
+    chd_path: &Path,
+    mut writer: W,
+    progress: &mut dyn FnMut(u64),
+) -> Result<()> {
+    let f = BufReader::new(File::open(chd_path).map_err(Error::from)?);
+    let mut chd = Chd::open(f, None)?;
+    if !is_dvd(&mut chd)? {
+        return Err(Error::UnsupportedFormat);
+    }
+    let logical = chd.header().logical_bytes();
+    let hunk_size = chd.header().hunk_size() as usize;
+
+    let mut reader = ChdReader::new(chd);
+    let mut buf = vec![0u8; hunk_size.max(1)];
+    let mut remaining = logical;
+    let mut done = 0u64;
+    while remaining > 0 {
+        let want = remaining.min(hunk_size as u64) as usize;
+        reader.read_exact(&mut buf[..want]).map_err(Error::from)?;
+        writer.write_all(&buf[..want]).map_err(Error::from)?;
+        remaining -= want as u64;
+        done += want as u64;
+        progress(done);
+    }
+    Ok(())
+}
+
+/// File-output convenience over [`extract_to_writer`].
+pub fn extract_to_iso(
+    chd_path: &Path,
+    iso_path: &Path,
+    progress: &mut dyn FnMut(u64),
+) -> Result<()> {
+    let mut out = BufWriter::new(File::create(iso_path).map_err(Error::from)?);
+    extract_to_writer(chd_path, &mut out, progress)?;
+    out.flush().map_err(Error::from)?;
+    Ok(())
+}

--- a/chd-rs/src/error.rs
+++ b/chd-rs/src/error.rs
@@ -85,6 +85,11 @@ pub enum Error {
     UnsupportedFormat,
     /// Unknown error.
     Unknown,
+    /// A create/compress operation was cancelled via its `cancel` callback.
+    ///
+    /// chd-rs-specific (no libchdr equivalent); appended after [`Error::Unknown`] so the
+    /// existing libchdr-ABI discriminants are unchanged. Used by the write/create API.
+    Cancelled,
 }
 
 impl std::error::Error for Error {}
@@ -121,6 +126,7 @@ impl Display for Error {
             Error::NoAsyncOperation => f.write_str("no async operation in progress"),
             Error::UnsupportedFormat => f.write_str("unsupported format"),
             Error::Unknown => f.write_str("undocumented error"),
+            Error::Cancelled => f.write_str("operation cancelled"),
         }
     }
 }

--- a/chd-rs/src/hd.rs
+++ b/chd-rs/src/hd.rs
@@ -1,0 +1,476 @@
+//! Hard-disk CHDs — chdman `createraw`/`extractraw` parity, plus the geometry helpers used by
+//! `createhd`/`extracthd`.
+//!
+//! ## What's here
+//! - [`create_from_reader`] / [`create_from_path`] — full **`createhd`**: write an HD CHD with a
+//!   `GDDD` geometry record (+ optional `IDNT` ident), **byte-identical to `chdman createhd`**.
+//! - [`create_raw_from_reader`] / [`create_raw_from_path`] — write a raw CHD with no metadata
+//!   (chdman `createraw`), **byte-identical**, with `progress`/`cancel` callbacks.
+//! - [`extract_to_writer`] / [`extract_to_path`] — stream a CHD's logical bytes out (chdman
+//!   `extractraw`/`extracthd`), via the existing decoder.
+//! - [`HdGeometry`], [`compute_chs`], [`format_gddd`], [`read_geometry`], [`HdCreateOptions`] —
+//!   geometry helpers.
+//!
+//! ## Coming from libchdman-rs?
+//! chd-rs keeps its generic borrowed [`Chd<F>`](crate::Chd) reader and exposes creation as free
+//! functions (not methods on an owned, writeable handle). See `docs/libchdman-differences.md`.
+
+use crate::error::{Error, Result};
+use crate::header::CodecType;
+use crate::metadata::Metadata;
+use crate::read::ChdReader;
+use crate::{write, Chd, CompressionProgress};
+use std::convert::TryInto;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Seek, Write};
+use std::path::Path;
+
+/// Cylinder/head/sector geometry plus bytes-per-sector — the data behind a `GDDD` record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HdGeometry {
+    /// Number of cylinders.
+    pub cylinders: u32,
+    /// Number of heads.
+    pub heads: u32,
+    /// Sectors per track.
+    pub sectors: u32,
+    /// Bytes per sector (the CHD unit size).
+    pub sector_bytes: u32,
+}
+
+impl HdGeometry {
+    /// Total logical bytes implied by this geometry (`cylinders * heads * sectors * sector_bytes`).
+    pub fn logical_bytes(&self) -> u64 {
+        u64::from(self.cylinders)
+            * u64::from(self.heads)
+            * u64::from(self.sectors)
+            * u64::from(self.sector_bytes)
+    }
+}
+
+/// Options for [`create_raw_from_reader`] / [`create_raw_from_path`].
+///
+/// Matches libchdman-rs's `HdCreateOptions`. [`Default`] is hunk 4096, unit 512, codec
+/// `[zlib, 0, 0, 0]`. The `geometry`/`ident` fields drive `createhd`
+/// ([`create_from_reader`]/[`create_from_path`]); the `create_raw_*` functions reject them.
+#[derive(Debug, Clone)]
+pub struct HdCreateOptions {
+    /// Logical size of the destination CHD, in bytes. Must be a multiple of `unit_size`. `0` in
+    /// [`create_raw_from_path`] means "use the input file's size". The input is zero-padded to
+    /// this size if it ends earlier.
+    pub logical_size: u64,
+    /// Hunk size in bytes (chdman default 4096). Must be a multiple of `unit_size`.
+    pub hunk_size: u32,
+    /// Unit (sector) size in bytes (chdman default 512).
+    pub unit_size: u32,
+    /// Codec slots (FourCCs from [`crate::codec`]). Default `[zlib, 0, 0, 0]`. A `0` ends the
+    /// list; codecs must be contiguous from slot 0. All-zero means "uncompressed".
+    pub codecs: [u32; 4],
+    /// Geometry for the `GDDD` record (used by [`create_from_reader`]/[`create_from_path`]). `None`
+    /// derives it from `logical_size / unit_size` via [`compute_chs`]. Ignored by `create_raw_*`
+    /// (which writes no metadata — passing it there is an error).
+    pub geometry: Option<HdGeometry>,
+    /// Identification blob written as an `IDNT` record by [`create_from_reader`]/[`create_from_path`].
+    /// Ignored by `create_raw_*` (an error there).
+    pub ident: Option<Vec<u8>>,
+}
+
+impl Default for HdCreateOptions {
+    fn default() -> Self {
+        Self {
+            logical_size: 0,
+            hunk_size: 4096,
+            unit_size: 512,
+            codecs: [crate::CHD_CODEC_ZLIB, 0, 0, 0],
+            geometry: None,
+            ident: None,
+        }
+    }
+}
+
+/// Heuristic from chdman's `guess_chs` (`chdman.cpp:1115`): find CHS values whose product is
+/// `logical_bytes / sector_size`, preferring large sectors-per-track (≤63) then large head counts
+/// (≤16). If no factorization exists at the current total, the total is incremented and retried —
+/// allowing a tiny round-up to a factorable shape, exactly as chdman does.
+///
+/// Always terminates for any positive, sector-aligned input (`(total, 1, 1)`-style shapes are
+/// reached eventually). `sector_bytes` in the result is `sector_size`.
+///
+/// ```
+/// # use chd::hd::compute_chs;
+/// // 256 KiB at 512-byte sectors → 512 total sectors → 1 cyl / 16 heads / 32 sectors.
+/// let g = compute_chs(256 * 1024, 512).unwrap();
+/// assert_eq!((g.cylinders, g.heads, g.sectors, g.sector_bytes), (1, 16, 32, 512));
+/// ```
+pub fn compute_chs(logical_bytes: u64, sector_size: u32) -> Result<HdGeometry> {
+    if logical_bytes == 0 || sector_size == 0 {
+        return Err(Error::InvalidParameter);
+    }
+    if logical_bytes % u64::from(sector_size) != 0 {
+        return Err(Error::InvalidParameter);
+    }
+
+    let mut total: u64 = logical_bytes / u64::from(sector_size);
+    loop {
+        for cur_sectors in (2u32..=63).rev() {
+            if total % u64::from(cur_sectors) == 0 {
+                let total_heads = total / u64::from(cur_sectors);
+                for cur_heads in (2u32..=16).rev() {
+                    if total_heads % u64::from(cur_heads) == 0 {
+                        return Ok(HdGeometry {
+                            cylinders: (total_heads / u64::from(cur_heads)) as u32,
+                            heads: cur_heads,
+                            sectors: cur_sectors,
+                            sector_bytes: sector_size,
+                        });
+                    }
+                }
+            }
+        }
+        total = total.checked_add(1).ok_or(Error::InvalidParameter)?;
+    }
+}
+
+/// Format a geometry record exactly as chdman writes it: `"CYLS:%d,HEADS:%d,SECS:%d,BPS:%d"`
+/// followed by a NUL terminator (matching MAME's `write_metadata` convention).
+pub fn format_gddd(g: HdGeometry) -> Vec<u8> {
+    let mut s = format!(
+        "CYLS:{},HEADS:{},SECS:{},BPS:{}",
+        g.cylinders, g.heads, g.sectors, g.sector_bytes
+    )
+    .into_bytes();
+    s.push(0);
+    s
+}
+
+/// Parse a `GDDD` payload (tolerant of a trailing NUL) back into [`HdGeometry`].
+fn parse_gddd(raw: &[u8]) -> Result<HdGeometry> {
+    let s = std::str::from_utf8(raw)
+        .map_err(|_| Error::InvalidMetadata)?
+        .trim_end_matches('\0');
+    let parts: Vec<&str> = s.split(',').collect();
+    if parts.len() != 4 {
+        return Err(Error::InvalidMetadata);
+    }
+    fn parse_kv(s: &str, prefix: &str) -> Result<u32> {
+        s.strip_prefix(prefix)
+            .ok_or(Error::InvalidMetadata)?
+            .parse::<u32>()
+            .map_err(|_| Error::InvalidMetadata)
+    }
+    Ok(HdGeometry {
+        cylinders: parse_kv(parts[0], "CYLS:")?,
+        heads: parse_kv(parts[1], "HEADS:")?,
+        sectors: parse_kv(parts[2], "SECS:")?,
+        sector_bytes: parse_kv(parts[3], "BPS:")?,
+    })
+}
+
+/// Read the `GDDD` geometry record from an opened HD CHD.
+///
+/// Returns [`Error::MetadataNotFound`] if there is no `GDDD` record (e.g. a `createraw` CHD).
+pub fn read_geometry<F: Read + Seek>(chd: &mut Chd<F>) -> Result<HdGeometry> {
+    let gddd_tag = crate::make_tag(b"GDDD");
+    let metas: Vec<Metadata> = chd.metadata_refs().try_into()?;
+    let entry = metas
+        .iter()
+        .find(|m| m.metatag == gddd_tag)
+        .ok_or(Error::MetadataNotFound)?;
+    parse_gddd(&entry.value)
+}
+
+/// Write `reader`'s contents into a **raw** CHD (chdman `createraw`) at `out`, byte-identical to
+/// chdman for the same input and options.
+///
+/// The whole input is read into memory (the in-memory writer requires it; a streaming writer is
+/// future work). If the input is shorter than `opts.logical_size` it is zero-padded; if longer,
+/// [`Error::InvalidParameter`] is returned. `progress` is invoked per hunk; `cancel` is polled
+/// before each hunk and, if it returns true, [`Error::Cancelled`] is returned **before anything is
+/// written to `out`** (the output is assembled in memory and flushed only on success).
+///
+/// `opts.geometry` / `opts.ident` are for `createhd` — pass them to [`create_from_reader`]
+/// instead; setting either here returns [`Error::UnsupportedFormat`] (the raw path writes no
+/// metadata).
+pub fn create_raw_from_reader<R: Read, W: Write + Seek>(
+    reader: R,
+    out: &mut W,
+    opts: HdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    if opts.geometry.is_some() || opts.ident.is_some() {
+        return Err(Error::UnsupportedFormat);
+    }
+    let data = read_and_pad(reader, opts.logical_size, opts.unit_size, opts.hunk_size)?;
+    let codecs = write::resolve_codecs(&opts.codecs)?;
+    write_create(
+        out,
+        &data,
+        opts.hunk_size,
+        opts.unit_size,
+        &codecs,
+        &[],
+        progress,
+        cancel,
+    )
+}
+
+/// File convenience over [`create_raw_from_reader`]. If `opts.logical_size` is `0`, the input
+/// file's size is used. On any error (including cancellation) the partial `out_path` is removed.
+pub fn create_raw_from_path(
+    in_path: &Path,
+    out_path: &Path,
+    opts: HdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    create_from_path_impl(in_path, out_path, opts, false, progress, cancel)
+}
+
+/// Full **`createhd`**: stream `reader` into a hard-disk CHD with a `GDDD` geometry record (+ an
+/// optional `IDNT` ident from `opts.ident`), **byte-identical to `chdman createhd`** for the same
+/// input/options. Geometry is `opts.geometry` or, if `None`, derived via [`compute_chs`].
+///
+/// Same I/O model as [`create_raw_from_reader`] (whole input in memory, zero-padded to
+/// `logical_size`, `progress`/`cancel` callbacks; cancel returns [`Error::Cancelled`] before any
+/// bytes hit `out`). The compressed form computes the metadata-inclusive overall SHA-1; the
+/// uncompressed form leaves the SHA-1 fields zero, exactly as chdman does.
+pub fn create_from_reader<R: Read, W: Write + Seek>(
+    reader: R,
+    out: &mut W,
+    opts: HdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let data = read_and_pad(reader, opts.logical_size, opts.unit_size, opts.hunk_size)?;
+    let logical = data.len() as u64;
+
+    // geometry: explicit, else derived from the logical size + sector (unit) size.
+    let geom = match opts.geometry {
+        Some(g) => g,
+        None => compute_chs(logical, opts.unit_size)?,
+    };
+    let gddd = format_gddd(geom);
+
+    // chdman writes GDDD first, then (if present) IDNT; both with the CHECKSUM flag.
+    let mut entries = vec![write::MetaEntry {
+        tag: crate::make_tag(b"GDDD"),
+        flags: write::CHD_MDFLAGS_CHECKSUM,
+        payload: &gddd,
+    }];
+    if let Some(ident) = &opts.ident {
+        entries.push(write::MetaEntry {
+            tag: crate::make_tag(b"IDNT"),
+            flags: write::CHD_MDFLAGS_CHECKSUM,
+            payload: ident,
+        });
+    }
+
+    let codecs = write::resolve_codecs(&opts.codecs)?;
+    write_create(
+        out,
+        &data,
+        opts.hunk_size,
+        opts.unit_size,
+        &codecs,
+        &entries,
+        progress,
+        cancel,
+    )
+}
+
+/// File convenience over [`create_from_reader`] (chdman `createhd`). If `opts.logical_size` is `0`,
+/// the input file's size is used. On any error (including cancellation) the partial `out_path` is
+/// removed.
+pub fn create_from_path(
+    in_path: &Path,
+    out_path: &Path,
+    opts: HdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    create_from_path_impl(in_path, out_path, opts, true, progress, cancel)
+}
+
+/// Shared file-create body for [`create_raw_from_path`] (`with_metadata = false`) and
+/// [`create_from_path`] (`with_metadata = true`): default the logical size to the input file's
+/// size, run the matching reader-based create, and remove the partial output on error.
+fn create_from_path_impl(
+    in_path: &Path,
+    out_path: &Path,
+    opts: HdCreateOptions,
+    with_metadata: bool,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let mut effective = opts;
+    if effective.logical_size == 0 {
+        effective.logical_size = std::fs::metadata(in_path).map_err(Error::from)?.len();
+    }
+    let reader = BufReader::new(File::open(in_path).map_err(Error::from)?);
+    let mut out = File::create(out_path).map_err(Error::from)?;
+    let res = if with_metadata {
+        create_from_reader(reader, &mut out, effective, progress, cancel)
+    } else {
+        create_raw_from_reader(reader, &mut out, effective, progress, cancel)
+    };
+    if res.is_err() {
+        drop(out);
+        let _ = std::fs::remove_file(out_path);
+    }
+    res
+}
+
+/// Read all of `reader` into memory and zero-pad to `logical_size` (or the read length if 0).
+/// Validates `hunk_size`/`unit_size` and that the logical size is unit-aligned and ≥ the input.
+fn read_and_pad<R: Read>(
+    mut reader: R,
+    logical_size: u64,
+    unit_size: u32,
+    hunk_size: u32,
+) -> Result<Vec<u8>> {
+    if unit_size == 0 || hunk_size == 0 || hunk_size % unit_size != 0 {
+        return Err(Error::InvalidParameter);
+    }
+    let mut data = Vec::new();
+    reader.read_to_end(&mut data).map_err(Error::from)?;
+    let logical = if logical_size != 0 {
+        logical_size
+    } else {
+        data.len() as u64
+    };
+    if logical % u64::from(unit_size) != 0 || data.len() as u64 > logical {
+        return Err(Error::InvalidParameter);
+    }
+    data.resize(logical as usize, 0);
+    Ok(data)
+}
+
+/// Write `data` (already padded to the logical size) to `out` with the given codec list and
+/// metadata, dispatching to the uncompressed or compressed writer and adapting `progress`/`cancel`.
+fn write_create<W: Write + Seek>(
+    out: &mut W,
+    data: &[u8],
+    hunk_size: u32,
+    unit_size: u32,
+    codecs: &[CodecType],
+    metadata: &[write::MetaEntry],
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let logical = data.len() as u64;
+    if codecs.is_empty() {
+        // all-zero codec list → uncompressed (no per-hunk progress hook).
+        if cancel() {
+            return Err(Error::Cancelled);
+        }
+        write::write_uncompressed_inner(out, data, hunk_size, unit_size, metadata)?;
+        progress(CompressionProgress {
+            bytes_done: logical,
+            bytes_total: logical,
+            ratio: 1.0,
+        });
+        return Ok(());
+    }
+
+    let mut prog = |done: u64, total: u64, comp: u64| {
+        progress(CompressionProgress {
+            bytes_done: done,
+            bytes_total: total,
+            ratio: if done == 0 {
+                1.0
+            } else {
+                comp as f64 / done as f64
+            },
+        });
+    };
+    write::write_raw_inner(
+        out, data, hunk_size, unit_size, codecs, metadata, &mut prog, cancel,
+    )
+}
+
+/// Stream the logical contents of the CHD at `chd_path` to `writer` (chdman `extractraw` /
+/// `extracthd`). `progress` reports cumulative logical bytes written. Works for any readable CHD
+/// (any codec/version chd-rs decodes); the output is the exact logical image.
+pub fn extract_to_writer<W: Write>(
+    chd_path: &Path,
+    mut writer: W,
+    progress: &mut dyn FnMut(u64),
+) -> Result<()> {
+    let f = BufReader::new(File::open(chd_path).map_err(Error::from)?);
+    let chd = Chd::open(f, None)?;
+    let logical = chd.header().logical_bytes();
+    let hunk_size = chd.header().hunk_size() as usize;
+
+    let mut reader = ChdReader::new(chd);
+    let mut buf = vec![0u8; hunk_size.max(1)];
+    let mut remaining = logical;
+    let mut done = 0u64;
+    while remaining > 0 {
+        let want = remaining.min(hunk_size as u64) as usize;
+        reader.read_exact(&mut buf[..want]).map_err(Error::from)?;
+        writer.write_all(&buf[..want]).map_err(Error::from)?;
+        remaining -= want as u64;
+        done += want as u64;
+        progress(done);
+    }
+    Ok(())
+}
+
+/// File convenience over [`extract_to_writer`].
+pub fn extract_to_path(
+    chd_path: &Path,
+    out_path: &Path,
+    progress: &mut dyn FnMut(u64),
+) -> Result<()> {
+    let mut out = BufWriter::new(File::create(out_path).map_err(Error::from)?);
+    extract_to_writer(chd_path, &mut out, progress)?;
+    out.flush().map_err(Error::from)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_chs_matches_chdman_examples() {
+        // 256 KiB @ 512 → 512 sectors → 1/16/32 (verified against chdman createhd).
+        let g = compute_chs(256 * 1024, 512).unwrap();
+        assert_eq!(
+            (g.cylinders, g.heads, g.sectors, g.sector_bytes),
+            (1, 16, 32, 512)
+        );
+        assert_eq!(g.logical_bytes(), 256 * 1024);
+
+        // odd/prime-ish totals still terminate and factor.
+        let g2 = compute_chs(1024 * 512, 512).unwrap(); // 1024 sectors
+        assert_eq!(g2.logical_bytes(), 1024 * 512);
+    }
+
+    #[test]
+    fn compute_chs_rejects_bad_input() {
+        assert!(compute_chs(0, 512).is_err());
+        assert!(compute_chs(1000, 0).is_err());
+        assert!(compute_chs(513, 512).is_err()); // not sector-aligned
+    }
+
+    #[test]
+    fn gddd_format_parse_roundtrip() {
+        let g = HdGeometry {
+            cylinders: 1,
+            heads: 16,
+            sectors: 32,
+            sector_bytes: 512,
+        };
+        let raw = format_gddd(g);
+        assert_eq!(raw.last(), Some(&0u8), "GDDD must be NUL-terminated");
+        assert_eq!(
+            &raw[..raw.len() - 1],
+            b"CYLS:1,HEADS:16,SECS:32,BPS:512".as_slice()
+        );
+        assert_eq!(parse_gddd(&raw).unwrap(), g);
+        // also parse without the trailing NUL
+        assert_eq!(parse_gddd(&raw[..raw.len() - 1]).unwrap(), g);
+    }
+}

--- a/chd-rs/src/hd.rs
+++ b/chd-rs/src/hd.rs
@@ -16,7 +16,6 @@
 //! functions (not methods on an owned, writeable handle). See `docs/libchdman-differences.md`.
 
 use crate::error::{Error, Result};
-use crate::header::CodecType;
 use crate::metadata::Metadata;
 use crate::read::ChdReader;
 use crate::{write, Chd, CompressionProgress};
@@ -201,9 +200,9 @@ pub fn create_raw_from_reader<R: Read, W: Write + Seek>(
     if opts.geometry.is_some() || opts.ident.is_some() {
         return Err(Error::UnsupportedFormat);
     }
-    let data = read_and_pad(reader, opts.logical_size, opts.unit_size, opts.hunk_size)?;
+    let data = write::read_and_pad(reader, opts.logical_size, opts.unit_size, opts.hunk_size)?;
     let codecs = write::resolve_codecs(&opts.codecs)?;
-    write_create(
+    write::write_create(
         out,
         &data,
         opts.hunk_size,
@@ -242,7 +241,7 @@ pub fn create_from_reader<R: Read, W: Write + Seek>(
     progress: &mut dyn FnMut(CompressionProgress),
     cancel: &dyn Fn() -> bool,
 ) -> Result<()> {
-    let data = read_and_pad(reader, opts.logical_size, opts.unit_size, opts.hunk_size)?;
+    let data = write::read_and_pad(reader, opts.logical_size, opts.unit_size, opts.hunk_size)?;
     let logical = data.len() as u64;
 
     // geometry: explicit, else derived from the logical size + sector (unit) size.
@@ -267,7 +266,7 @@ pub fn create_from_reader<R: Read, W: Write + Seek>(
     }
 
     let codecs = write::resolve_codecs(&opts.codecs)?;
-    write_create(
+    write::write_create(
         out,
         &data,
         opts.hunk_size,
@@ -319,74 +318,6 @@ fn create_from_path_impl(
         let _ = std::fs::remove_file(out_path);
     }
     res
-}
-
-/// Read all of `reader` into memory and zero-pad to `logical_size` (or the read length if 0).
-/// Validates `hunk_size`/`unit_size` and that the logical size is unit-aligned and ≥ the input.
-fn read_and_pad<R: Read>(
-    mut reader: R,
-    logical_size: u64,
-    unit_size: u32,
-    hunk_size: u32,
-) -> Result<Vec<u8>> {
-    if unit_size == 0 || hunk_size == 0 || hunk_size % unit_size != 0 {
-        return Err(Error::InvalidParameter);
-    }
-    let mut data = Vec::new();
-    reader.read_to_end(&mut data).map_err(Error::from)?;
-    let logical = if logical_size != 0 {
-        logical_size
-    } else {
-        data.len() as u64
-    };
-    if logical % u64::from(unit_size) != 0 || data.len() as u64 > logical {
-        return Err(Error::InvalidParameter);
-    }
-    data.resize(logical as usize, 0);
-    Ok(data)
-}
-
-/// Write `data` (already padded to the logical size) to `out` with the given codec list and
-/// metadata, dispatching to the uncompressed or compressed writer and adapting `progress`/`cancel`.
-fn write_create<W: Write + Seek>(
-    out: &mut W,
-    data: &[u8],
-    hunk_size: u32,
-    unit_size: u32,
-    codecs: &[CodecType],
-    metadata: &[write::MetaEntry],
-    progress: &mut dyn FnMut(CompressionProgress),
-    cancel: &dyn Fn() -> bool,
-) -> Result<()> {
-    let logical = data.len() as u64;
-    if codecs.is_empty() {
-        // all-zero codec list → uncompressed (no per-hunk progress hook).
-        if cancel() {
-            return Err(Error::Cancelled);
-        }
-        write::write_uncompressed_inner(out, data, hunk_size, unit_size, metadata)?;
-        progress(CompressionProgress {
-            bytes_done: logical,
-            bytes_total: logical,
-            ratio: 1.0,
-        });
-        return Ok(());
-    }
-
-    let mut prog = |done: u64, total: u64, comp: u64| {
-        progress(CompressionProgress {
-            bytes_done: done,
-            bytes_total: total,
-            ratio: if done == 0 {
-                1.0
-            } else {
-                comp as f64 / done as f64
-            },
-        });
-    };
-    write::write_raw_inner(
-        out, data, hunk_size, unit_size, codecs, metadata, &mut prog, cancel,
-    )
 }
 
 /// Stream the logical contents of the CHD at `chd_path` to `writer` (chdman `extractraw` /

--- a/chd-rs/src/hd.rs
+++ b/chd-rs/src/hd.rs
@@ -20,8 +20,8 @@ use crate::metadata::Metadata;
 use crate::read::ChdReader;
 use crate::{write, Chd, CompressionProgress};
 use std::convert::TryInto;
-use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Seek, Write};
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 /// Cylinder/head/sector geometry plus bytes-per-sector — the data behind a `GDDD` record.
@@ -360,6 +360,289 @@ pub fn extract_to_path(
     Ok(())
 }
 
+/// Read a 4-byte big-endian field from a header buffer.
+fn be32(b: &[u8], off: usize) -> u32 {
+    u32::from_be_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]])
+}
+
+/// A read/write **block-device view** over an uncompressed hard-disk CHD — the surface MAME's
+/// `harddisk_image_device` exposes to a running machine. Backs per-sector [`read_sector`]/
+/// [`write_sector`] (and whole-hunk reads) onto an uncompressed V5 CHD, optionally with a
+/// (compressed) **parent**: unwritten hunks fall through to the parent, and writes materialise the
+/// affected hunk into the diff and rewrite its map entry.
+///
+/// Matches libchdman-rs's `HdImage`. chd-rs's [`Chd`] is read-only, so `HdImage` holds the diff/child
+/// as a raw read-write file plus an in-memory copy of the 4-byte map, and keeps the parent open as a
+/// read-only [`Chd`] for fall-through reads.
+///
+/// [`read_sector`]: HdImage::read_sector
+/// [`write_sector`]: HdImage::write_sector
+pub struct HdImage {
+    file: File,
+    parent: Option<Box<Chd<BufReader<File>>>>,
+    /// 4-byte map entries (`offset / hunk_bytes`; `0` = read from parent / zero-fill).
+    map: Vec<u32>,
+    geometry: HdGeometry,
+    hunk_bytes: u32,
+    logical_bytes: u64,
+    comp_buf: Vec<u8>,
+    hunk_buf: Vec<u8>,
+}
+
+const V5_HEADER_LEN: usize = 124;
+
+impl HdImage {
+    /// Open an **uncompressed** HD CHD read-write for in-place sector edits. Fails with
+    /// [`Error::UnsupportedFormat`] if the CHD is compressed (MAME also rejects compressed write
+    /// targets) or [`Error::MetadataNotFound`] if it has no `GDDD` geometry record.
+    pub fn open(path: &Path) -> Result<Self> {
+        // Probe read-only for header fields + geometry.
+        let mut probe = Chd::open(BufReader::new(File::open(path).map_err(Error::from)?), None)?;
+        if probe.header().compression()[0] != 0 {
+            return Err(Error::UnsupportedFormat);
+        }
+        let geometry = read_geometry(&mut probe)?;
+        let logical_bytes = probe.header().logical_bytes();
+        let hunk_bytes = probe.header().hunk_size();
+        let hunk_count = probe.header().hunk_count();
+        drop(probe);
+
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .map_err(Error::from)?;
+        let map = Self::read_map(&mut file, hunk_count)?;
+        Ok(Self::assemble(
+            file,
+            None,
+            map,
+            geometry,
+            hunk_bytes,
+            logical_bytes,
+        ))
+    }
+
+    /// Open `parent_path` read-only and create a fresh **uncompressed diff** at `diff_path` whose
+    /// every hunk initially falls through to the parent; subsequent writes land in the diff. This is
+    /// MAME's runtime strategy for writing to a compressed image. The parent's metadata is cloned
+    /// into the diff (so geometry is available), and `diff_path` is created fresh (overwritten).
+    pub fn open_with_diff(parent_path: &Path, diff_path: &Path) -> Result<Self> {
+        {
+            let mut parent = Chd::open(
+                BufReader::new(File::open(parent_path).map_err(Error::from)?),
+                None,
+            )?;
+            let logical = parent.header().logical_bytes();
+            let hunk = parent.header().hunk_size();
+            let unit = parent.header().unit_bytes();
+            let parent_sha1 = parent.header().sha1().unwrap_or([0u8; 20]);
+            if parent_sha1 == [0u8; 20] {
+                // A V5 child keys its parent by the parent's overall SHA-1; an uncompressed parent
+                // has none, so it can't be referenced as a diff parent.
+                return Err(Error::UnsupportedFormat);
+            }
+            let metas: Vec<Metadata> = parent.metadata_refs().try_into()?;
+            let entries: Vec<write::MetaEntry> = metas
+                .iter()
+                .map(|m| write::MetaEntry {
+                    tag: m.metatag,
+                    flags: m.flags,
+                    payload: &m.value,
+                })
+                .collect();
+            let mut out = File::create(diff_path).map_err(Error::from)?;
+            write::write_empty_diff(&mut out, logical, hunk, unit, &parent_sha1, &entries)?;
+        }
+        Self::reopen_diff(parent_path, diff_path)
+    }
+
+    /// Re-open a previously-created diff against its parent. The returned `HdImage` keeps the parent
+    /// open for its whole lifetime (unwritten hunks read through it).
+    pub fn reopen_diff(parent_path: &Path, diff_path: &Path) -> Result<Self> {
+        // Probe the diff with its parent (validates `parent_sha1`) for header fields + geometry.
+        let geometry;
+        let logical_bytes;
+        let hunk_bytes;
+        let hunk_count;
+        {
+            let parent = Chd::open(
+                BufReader::new(File::open(parent_path).map_err(Error::from)?),
+                None,
+            )?;
+            let mut probe = Chd::open(
+                BufReader::new(File::open(diff_path).map_err(Error::from)?),
+                Some(Box::new(parent)),
+            )?;
+            if probe.header().compression()[0] != 0 {
+                return Err(Error::UnsupportedFormat);
+            }
+            logical_bytes = probe.header().logical_bytes();
+            hunk_bytes = probe.header().hunk_size();
+            hunk_count = probe.header().hunk_count();
+            geometry = read_geometry(&mut probe)?;
+        }
+
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(diff_path)
+            .map_err(Error::from)?;
+        let map = Self::read_map(&mut file, hunk_count)?;
+        let parent = Chd::open(
+            BufReader::new(File::open(parent_path).map_err(Error::from)?),
+            None,
+        )?;
+        Ok(Self::assemble(
+            file,
+            Some(Box::new(parent)),
+            map,
+            geometry,
+            hunk_bytes,
+            logical_bytes,
+        ))
+    }
+
+    fn read_map(file: &mut File, hunk_count: u32) -> Result<Vec<u32>> {
+        let mut raw = vec![0u8; hunk_count as usize * 4];
+        file.seek(SeekFrom::Start(V5_HEADER_LEN as u64))
+            .map_err(Error::from)?;
+        file.read_exact(&mut raw).map_err(Error::from)?;
+        Ok(raw.chunks_exact(4).map(|c| be32(c, 0)).collect())
+    }
+
+    fn assemble(
+        file: File,
+        parent: Option<Box<Chd<BufReader<File>>>>,
+        map: Vec<u32>,
+        geometry: HdGeometry,
+        hunk_bytes: u32,
+        logical_bytes: u64,
+    ) -> Self {
+        HdImage {
+            file,
+            parent,
+            map,
+            geometry,
+            hunk_bytes,
+            logical_bytes,
+            comp_buf: Vec::new(),
+            hunk_buf: vec![0u8; hunk_bytes as usize],
+        }
+    }
+
+    /// Parsed `GDDD` geometry (cylinders / heads / sectors / bytes-per-sector).
+    pub fn geometry(&self) -> HdGeometry {
+        self.geometry
+    }
+
+    /// Bytes per sector.
+    pub fn sector_size(&self) -> u32 {
+        self.geometry.sector_bytes
+    }
+
+    /// Total addressable sectors (`logical_bytes / sector_size`). Valid LBAs are `0..sector_count()`.
+    pub fn sector_count(&self) -> u64 {
+        self.logical_bytes / u64::from(self.geometry.sector_bytes)
+    }
+
+    /// Read one sector at logical block address `lba` into `buf` (must be exactly
+    /// [`sector_size`](Self::sector_size) bytes).
+    pub fn read_sector(&mut self, lba: u64, buf: &mut [u8]) -> Result<()> {
+        let ss = self.geometry.sector_bytes as usize;
+        if buf.len() != ss || lba >= self.sector_count() {
+            return Err(Error::InvalidParameter);
+        }
+        let byte = lba * ss as u64;
+        let hunk = (byte / self.hunk_bytes as u64) as u32;
+        let off = (byte % self.hunk_bytes as u64) as usize;
+        let mut hunk_buf = std::mem::take(&mut self.hunk_buf);
+        let res = self.read_hunk(hunk, &mut hunk_buf);
+        if res.is_ok() {
+            buf.copy_from_slice(&hunk_buf[off..off + ss]);
+        }
+        self.hunk_buf = hunk_buf;
+        res
+    }
+
+    /// Write one sector at `lba` from `buf` (must be exactly [`sector_size`](Self::sector_size)
+    /// bytes). Materialises the affected hunk into the diff if it was a parent reference.
+    pub fn write_sector(&mut self, lba: u64, buf: &[u8]) -> Result<()> {
+        let ss = self.geometry.sector_bytes as usize;
+        if buf.len() != ss || lba >= self.sector_count() {
+            return Err(Error::InvalidParameter);
+        }
+        let byte = lba * ss as u64;
+        let hunk = (byte / self.hunk_bytes as u64) as u32;
+        let off = (byte % self.hunk_bytes as u64) as usize;
+
+        let mut hunk_buf = std::mem::take(&mut self.hunk_buf);
+        let res = match self.read_hunk(hunk, &mut hunk_buf) {
+            Ok(()) => {
+                hunk_buf[off..off + ss].copy_from_slice(buf);
+                self.write_hunk(hunk, &hunk_buf)
+            }
+            Err(e) => Err(e),
+        };
+        self.hunk_buf = hunk_buf;
+        res
+    }
+
+    /// Read whole hunk `hunk` into `dest` (`hunk_bytes` long): from the diff if materialised, else
+    /// the parent, else zeros.
+    fn read_hunk(&mut self, hunk: u32, dest: &mut [u8]) -> Result<()> {
+        let entry = self.map[hunk as usize];
+        if entry != 0 {
+            self.file
+                .seek(SeekFrom::Start(entry as u64 * self.hunk_bytes as u64))
+                .map_err(Error::from)?;
+            self.file.read_exact(dest).map_err(Error::from)?;
+        } else if let Some(parent) = self.parent.as_deref_mut() {
+            let mut comp = std::mem::take(&mut self.comp_buf);
+            let res = parent
+                .hunk(hunk)
+                .and_then(|mut h| h.read_hunk_in(&mut comp, dest));
+            self.comp_buf = comp;
+            res?;
+        } else {
+            dest.fill(0);
+        }
+        Ok(())
+    }
+
+    /// Write whole hunk `hunk` (`hunk_bytes` long), materialising it (appending a fresh hunk-aligned
+    /// block + updating the map entry) if it was a parent reference, else overwriting in place.
+    fn write_hunk(&mut self, hunk: u32, data: &[u8]) -> Result<()> {
+        let entry = self.map[hunk as usize];
+        let offset = if entry != 0 {
+            entry as u64 * self.hunk_bytes as u64
+        } else {
+            // Append at EOF (which stays hunk-aligned: the data region starts aligned and every
+            // appended hunk is exactly hunk_bytes), then record the new map entry on disk.
+            let eof = self.file.seek(SeekFrom::End(0)).map_err(Error::from)?;
+            let new_entry = (eof / self.hunk_bytes as u64) as u32;
+            self.map[hunk as usize] = new_entry;
+            self.file
+                .seek(SeekFrom::Start(V5_HEADER_LEN as u64 + hunk as u64 * 4))
+                .map_err(Error::from)?;
+            self.file
+                .write_all(&new_entry.to_be_bytes())
+                .map_err(Error::from)?;
+            eof
+        };
+        self.file
+            .seek(SeekFrom::Start(offset))
+            .map_err(Error::from)?;
+        self.file.write_all(data).map_err(Error::from)?;
+        Ok(())
+    }
+
+    /// Flush buffered writes to disk.
+    pub fn flush(&mut self) -> Result<()> {
+        self.file.flush().map_err(Error::from)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -384,6 +667,74 @@ mod tests {
         assert!(compute_chs(0, 512).is_err());
         assert!(compute_chs(1000, 0).is_err());
         assert!(compute_chs(513, 512).is_err()); // not sector-aligned
+    }
+
+    /// `HdImage` diff round-trip: against a compressed parent, written sectors persist in the diff,
+    /// unwritten sectors fall through to the parent, and a reopen sees the same image.
+    #[test]
+    fn hd_image_diff_roundtrip() {
+        let dir = std::env::temp_dir();
+        let parent_in = dir.join("chdrs_hdimg_parent.bin");
+        let parent_chd = dir.join("chdrs_hdimg_parent.chd");
+        let diff_chd = dir.join("chdrs_hdimg_diff.chd");
+
+        // 256 KiB deterministic image → compressed (zlib) parent with a GDDD record.
+        let img: Vec<u8> = (0..256 * 1024).map(|i| (i * 7 + 3) as u8).collect();
+        std::fs::write(&parent_in, &img).unwrap();
+        create_from_path(
+            &parent_in,
+            &parent_chd,
+            HdCreateOptions {
+                codecs: [crate::CHD_CODEC_ZLIB, 0, 0, 0],
+                ..Default::default()
+            },
+            &mut |_| {},
+            &|| false,
+        )
+        .unwrap();
+
+        // Expected merged image: parent with the written sectors overlaid.
+        let mut expected = img.clone();
+        let written: [u64; 4] = [5, 100, 200, 511];
+
+        {
+            let mut hd = HdImage::open_with_diff(&parent_chd, &diff_chd).unwrap();
+            let ss = hd.sector_size() as usize;
+            assert_eq!(ss, 512);
+            assert_eq!(hd.sector_count(), 512);
+            for &lba in &written {
+                let pat = vec![(lba as u8).wrapping_mul(3).wrapping_add(1); ss];
+                hd.write_sector(lba, &pat).unwrap();
+                expected[lba as usize * ss..][..ss].copy_from_slice(&pat);
+            }
+            hd.flush().unwrap();
+
+            // written sector reads back; an unwritten one falls through to the parent.
+            let mut buf = vec![0u8; ss];
+            hd.read_sector(5, &mut buf).unwrap();
+            assert_eq!(buf, expected[5 * ss..6 * ss]);
+            hd.read_sector(50, &mut buf).unwrap();
+            assert_eq!(
+                buf,
+                img[50 * ss..51 * ss],
+                "unwritten sector should read the parent"
+            );
+        }
+
+        // reopen and verify the whole image (written persisted + parent fall-through).
+        {
+            let mut hd = HdImage::reopen_diff(&parent_chd, &diff_chd).unwrap();
+            let ss = hd.sector_size() as usize;
+            let mut buf = vec![0u8; ss];
+            for lba in 0..hd.sector_count() {
+                hd.read_sector(lba, &mut buf).unwrap();
+                assert_eq!(buf, expected[lba as usize * ss..][..ss], "sector {lba}");
+            }
+        }
+
+        for p in [&parent_in, &parent_chd, &diff_chd] {
+            let _ = std::fs::remove_file(p);
+        }
     }
 
     #[test]

--- a/chd-rs/src/hd.rs
+++ b/chd-rs/src/hd.rs
@@ -226,6 +226,88 @@ pub fn create_raw_from_path(
     create_from_path_impl(in_path, out_path, opts, false, progress, cancel)
 }
 
+/// Create a **compressed child** CHD of `parent_path` (chdman `createraw -op`), **byte-identical to
+/// chdman**. Hunks of `in_path` identical to a (unit-aligned window of the) parent become
+/// `COMPRESSION_PARENT` references instead of being stored; the rest are compressed normally, and
+/// the header links the parent via `parent_sha1`.
+///
+/// The child inherits the parent's hunk/unit sizes and logical size (the input is zero-padded to
+/// it); only `opts.codecs` is used (`geometry`/`ident` are ignored — this writes no metadata, like
+/// `createraw`). The parent must be **compressed** (an uncompressed parent has no SHA-1 to link).
+pub fn create_raw_from_path_with_parent(
+    in_path: &Path,
+    out_path: &Path,
+    parent_path: &Path,
+    opts: HdCreateOptions,
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let codecs = write::resolve_codecs(&opts.codecs)?;
+    if codecs.is_empty() {
+        // A parent diff is inherently a compressed format (the map needs the 12-byte entries).
+        return Err(Error::InvalidParameter);
+    }
+
+    // Open the parent; inherit its geometry and decode its full (padded) image for the hash map.
+    let mut parent = Chd::open(
+        BufReader::new(File::open(parent_path).map_err(Error::from)?),
+        None,
+    )?;
+    let hunk_bytes = parent.header().hunk_size();
+    let unit_bytes = parent.header().unit_bytes();
+    let logical = parent.header().logical_bytes();
+    let hunk_count = parent.header().hunk_count();
+    let parent_sha1 = parent.header().sha1().unwrap_or([0u8; 20]);
+    if parent_sha1 == [0u8; 20] {
+        return Err(Error::UnsupportedFormat);
+    }
+
+    let mut img = vec![0u8; hunk_count as usize * hunk_bytes as usize];
+    let mut comp = Vec::new();
+    for h in 0..hunk_count {
+        let dst = &mut img[h as usize * hunk_bytes as usize..][..hunk_bytes as usize];
+        parent.hunk(h)?.read_hunk_in(&mut comp, dst)?;
+    }
+    let pref = write::build_parent_ref(&img, hunk_bytes, unit_bytes, hunk_count, parent_sha1);
+    drop(parent);
+
+    let data = write::read_and_pad(
+        BufReader::new(File::open(in_path).map_err(Error::from)?),
+        logical,
+        unit_bytes,
+        hunk_bytes,
+    )?;
+
+    let mut out = File::create(out_path).map_err(Error::from)?;
+    let mut prog = |done: u64, total: u64, c: u64| {
+        progress(CompressionProgress {
+            bytes_done: done,
+            bytes_total: total,
+            ratio: if done == 0 {
+                1.0
+            } else {
+                c as f64 / done as f64
+            },
+        });
+    };
+    let res = write::write_raw_inner(
+        &mut out,
+        &data,
+        hunk_bytes,
+        unit_bytes,
+        &codecs,
+        &[],
+        Some(&pref),
+        &mut prog,
+        cancel,
+    );
+    if res.is_err() {
+        drop(out);
+        let _ = std::fs::remove_file(out_path);
+    }
+    res
+}
+
 /// Full **`createhd`**: stream `reader` into a hard-disk CHD with a `GDDD` geometry record (+ an
 /// optional `IDNT` ident from `opts.ident`), **byte-identical to `chdman createhd`** for the same
 /// input/options. Geometry is `opts.geometry` or, if `None`, derived via [`compute_chs`].

--- a/chd-rs/src/header.rs
+++ b/chd-rs/src/header.rs
@@ -506,6 +506,21 @@ impl Header {
         }
     }
 
+    /// Returns the compression codecs as a 4-slot array of FourCCs.
+    ///
+    /// V5 CHDs store up to four codec FourCCs (slot 0 the primary; `0` = unused). Legacy (V1-4)
+    /// CHDs have a single codec, returned in slot 0 with the rest zero. A slot-0 value of `0`
+    /// (`CHD_CODEC_NONE`) means the CHD is uncompressed.
+    pub fn compression(&self) -> [u32; 4] {
+        match self {
+            Header::V1Header(c) => [c.compression, 0, 0, 0],
+            Header::V2Header(c) => [c.compression, 0, 0, 0],
+            Header::V3Header(c) => [c.compression, 0, 0, 0],
+            Header::V4Header(c) => [c.compression, 0, 0, 0],
+            Header::V5Header(c) => c.compression,
+        }
+    }
+
     /// Returns the MD5 of the CHD file if available.
     pub fn md5(&self) -> Option<[u8; MD5_BYTES]> {
         match self {

--- a/chd-rs/src/header.rs
+++ b/chd-rs/src/header.rs
@@ -140,6 +140,8 @@ impl CodecType {
             CodecType::FlacV5 => {
                 RawFlacEncoder::new(hunk_size).map(|x| Box::new(x) as Box<dyn CompressionEncoder>)
             }
+            CodecType::FlacCdV5 => crate::compression::codecs::CdFlacEncoder::new(hunk_size)
+                .map(|x| Box::new(x) as Box<dyn CompressionEncoder>),
             CodecType::ZLibCdV5 => crate::compression::codecs::CdZlibEncoder::new(hunk_size)
                 .map(|x| Box::new(x) as Box<dyn CompressionEncoder>),
             CodecType::LzmaCdV5 => crate::compression::codecs::CdLzmaEncoder::new(hunk_size)

--- a/chd-rs/src/header.rs
+++ b/chd-rs/src/header.rs
@@ -140,8 +140,15 @@ impl CodecType {
             CodecType::FlacV5 => {
                 RawFlacEncoder::new(hunk_size).map(|x| Box::new(x) as Box<dyn CompressionEncoder>)
             }
+            CodecType::ZLibCdV5 => crate::compression::codecs::CdZlibEncoder::new(hunk_size)
+                .map(|x| Box::new(x) as Box<dyn CompressionEncoder>),
+            CodecType::LzmaCdV5 => crate::compression::codecs::CdLzmaEncoder::new(hunk_size)
+                .map(|x| Box::new(x) as Box<dyn CompressionEncoder>),
             #[cfg(feature = "write-zstd")]
             CodecType::ZstdV5 => crate::compression::codecs::ZstdEncoder::new(hunk_size)
+                .map(|x| Box::new(x) as Box<dyn CompressionEncoder>),
+            #[cfg(feature = "write-zstd")]
+            CodecType::ZstdCdV5 => crate::compression::codecs::CdZstdEncoder::new(hunk_size)
                 .map(|x| Box::new(x) as Box<dyn CompressionEncoder>),
             _ => Err(Error::UnsupportedFormat),
         }

--- a/chd-rs/src/header.rs
+++ b/chd-rs/src/header.rs
@@ -26,7 +26,7 @@ use text_io::try_scan;
 
 /// The types of compression codecs supported in a CHD file.
 #[repr(u32)]
-#[derive(FromPrimitive, Debug)]
+#[derive(FromPrimitive, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodecType {
     /// No compression.
     None = 0,
@@ -105,6 +105,44 @@ impl CodecType {
                 CdZstdCodec::new(hunk_size).map(|x| Box::new(x) as Box<dyn CompressionCodec>)
             }
             #[allow(unreachable_patterns)]
+            _ => Err(Error::UnsupportedFormat),
+        }
+    }
+
+    /// Initializes the encoder for this codec type and the provided hunk size.
+    ///
+    /// The encode mirror of [`CodecType::init`]. Codecs are added per milestone; types
+    /// without an encoder yet return [`Error::UnsupportedFormat`]. Available with the
+    /// `write` feature.
+    #[cfg(feature = "write")]
+    pub(crate) fn init_encoder(
+        &self,
+        hunk_size: u32,
+    ) -> Result<Box<dyn crate::compression::CompressionEncoder>> {
+        use crate::compression::codecs::{
+            HuffmanEncoder, LzmaEncoder, NoneEncoder, RawFlacEncoder, ZlibEncoder,
+        };
+        use crate::compression::CodecEncodeImplementation;
+        use crate::compression::CompressionEncoder;
+        match self {
+            CodecType::None => {
+                NoneEncoder::new(hunk_size).map(|x| Box::new(x) as Box<dyn CompressionEncoder>)
+            }
+            CodecType::Zlib | CodecType::ZlibPlus | CodecType::ZLibV5 => {
+                ZlibEncoder::new(hunk_size).map(|x| Box::new(x) as Box<dyn CompressionEncoder>)
+            }
+            CodecType::LzmaV5 => {
+                LzmaEncoder::new(hunk_size).map(|x| Box::new(x) as Box<dyn CompressionEncoder>)
+            }
+            CodecType::HuffV5 => {
+                HuffmanEncoder::new(hunk_size).map(|x| Box::new(x) as Box<dyn CompressionEncoder>)
+            }
+            CodecType::FlacV5 => {
+                RawFlacEncoder::new(hunk_size).map(|x| Box::new(x) as Box<dyn CompressionEncoder>)
+            }
+            #[cfg(feature = "write-zstd")]
+            CodecType::ZstdV5 => crate::compression::codecs::ZstdEncoder::new(hunk_size)
+                .map(|x| Box::new(x) as Box<dyn CompressionEncoder>),
             _ => Err(Error::UnsupportedFormat),
         }
     }

--- a/chd-rs/src/huffman_encode.rs
+++ b/chd-rs/src/huffman_encode.rs
@@ -1,0 +1,438 @@
+//! MAME CHD static Huffman **encoder** — a faithful port of the encode path in
+//! [huffman.cpp](https://github.com/mamedev/mame/blob/master/src/lib/util/huffman.cpp)
+//! (`huffman_context_base` / `huffman_encoder`). Produces output byte-identical to MAME for a
+//! given histogram, so the `huff` codec and the V5 compressed-map writer match chdman.
+//!
+//! Algorithm ported from MAME `src/lib/util/huffman.cpp` and `bitstream.h`
+//! (BSD-3-Clause, © Aaron Giles).
+//!
+//! The decode side ([`crate::huffman`]) reads the tree via `from_huffman_tree`, which
+//! corresponds exactly to [`HuffEncoder::export_tree_huffman`] here.
+
+/// MSB-first bit writer, a port of MAME's `bitstream_out` (`bitstream.h`). Writes into a
+/// growable `Vec<u8>`; `flush` pads the final byte with zero bits and returns the bytes.
+pub(crate) struct BitWriter {
+    buffer: u32,
+    bits: i32,
+    out: Vec<u8>,
+}
+
+impl BitWriter {
+    pub(crate) fn new() -> Self {
+        BitWriter {
+            buffer: 0,
+            bits: 0,
+            out: Vec::new(),
+        }
+    }
+
+    /// Port of `bitstream_out::write`.
+    pub(crate) fn write(&mut self, newbits: u32, numbits: i32) {
+        if numbits <= 0 {
+            return;
+        }
+        let mut newbits = newbits << (32 - numbits);
+        let mut numbits = numbits;
+
+        while self.bits + numbits >= 32 && numbits > 0 {
+            while self.bits >= 8 {
+                self.out.push((self.buffer >> 24) as u8);
+                self.buffer <<= 8;
+                self.bits -= 8;
+            }
+            if self.bits + numbits >= 32 {
+                let rem = core::cmp::min(32 - self.bits, numbits);
+                self.buffer |= newbits >> self.bits;
+                self.bits += rem;
+                // `rem` is in 1..=31 here, so the shift is always in range.
+                newbits = newbits.wrapping_shl(rem as u32);
+                numbits -= rem;
+            }
+        }
+
+        if numbits <= 0 {
+            return;
+        }
+        self.buffer |= newbits >> self.bits;
+        self.bits += numbits;
+    }
+
+    /// Port of `bitstream_out::flush` — emit remaining bits (zero-padded), return the bytes.
+    pub(crate) fn flush(mut self) -> Vec<u8> {
+        while self.bits > 0 {
+            self.out.push((self.buffer >> 24) as u8);
+            self.buffer <<= 8;
+            self.bits -= 8;
+        }
+        self.out
+    }
+}
+
+const NULL_PARENT: u32 = u32::MAX;
+
+#[derive(Clone, Copy)]
+struct Node {
+    parent: u32,
+    weight: u32,
+    bits: u32,
+    numbits: u8,
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Node {
+            parent: NULL_PARENT,
+            weight: 0,
+            bits: 0,
+            numbits: 0,
+        }
+    }
+}
+
+/// Static Huffman encoder parameterized over the symbol count and max code length, mirroring
+/// MAME's `huffman_encoder<NumCodes, MaxBits>`.
+pub(crate) struct HuffEncoder {
+    num_codes: usize,
+    max_bits: u8,
+    histo: Vec<u32>,
+    nodes: Vec<Node>,
+}
+
+impl HuffEncoder {
+    pub(crate) fn new(num_codes: usize, max_bits: u8) -> Self {
+        HuffEncoder {
+            num_codes,
+            max_bits,
+            histo: vec![0; num_codes],
+            nodes: vec![Node::default(); num_codes * 2],
+        }
+    }
+
+    pub(crate) fn histo_reset(&mut self) {
+        self.histo.iter_mut().for_each(|h| *h = 0);
+    }
+
+    #[inline]
+    pub(crate) fn histo_one(&mut self, data: u32) {
+        self.histo[data as usize] += 1;
+    }
+
+    /// Port of `encode_one`: write the symbol's canonical code.
+    #[inline]
+    pub(crate) fn encode_one(&self, bitbuf: &mut BitWriter, data: u32) {
+        let node = &self.nodes[data as usize];
+        bitbuf.write(node.bits, node.numbits as i32);
+    }
+
+    /// Port of `compute_tree_from_histo`: binary-search the weight scaling so the resulting
+    /// tree's max code length is `<= max_bits`, then assign canonical codes.
+    pub(crate) fn compute_tree_from_histo(&mut self) -> Result<(), ()> {
+        let sdatacount: u32 = self
+            .histo
+            .iter()
+            .copied()
+            .fold(0u32, |a, b| a.wrapping_add(b));
+
+        let mut lowerweight: u32 = 0;
+        let mut upperweight: u32 = sdatacount.wrapping_mul(2);
+        loop {
+            let curweight = (upperweight.wrapping_add(lowerweight)) / 2;
+            let curmaxbits = self.build_tree(sdatacount, curweight);
+
+            if curmaxbits <= self.max_bits {
+                lowerweight = curweight;
+                if curweight == sdatacount || upperweight.wrapping_sub(lowerweight) <= 1 {
+                    break;
+                }
+            } else {
+                upperweight = curweight;
+            }
+        }
+
+        self.assign_canonical_codes()
+    }
+
+    /// Port of `build_tree`. Returns the maximum code length of the resulting tree.
+    fn build_tree(&mut self, totaldata: u32, totalweight: u32) -> u8 {
+        // reset all nodes (MAME memsets the leaves; internal nodes are written before read —
+        // resetting both is equivalent and simpler).
+        for n in self.nodes.iter_mut() {
+            *n = Node::default();
+        }
+
+        // list of active node indices
+        let mut list = vec![0u32; self.num_codes * 2];
+        let mut listitems = 0usize;
+        for curcode in 0..self.num_codes {
+            if self.histo[curcode] != 0 {
+                list[listitems] = curcode as u32;
+                listitems += 1;
+                self.nodes[curcode].bits = curcode as u32;
+                let w = (self.histo[curcode] as u64 * totalweight as u64 / totaldata as u64) as u32;
+                self.nodes[curcode].weight = if w == 0 { 1 } else { w };
+            }
+        }
+
+        // sort by weight descending, tie-break by bits ascending (== MAME's qsort comparator;
+        // `bits` is the unique code index for leaves, so this is a total order).
+        let nodes = &self.nodes;
+        list[..listitems].sort_by(|&a, &b| {
+            let na = &nodes[a as usize];
+            let nb = &nodes[b as usize];
+            if nb.weight != na.weight {
+                nb.weight.cmp(&na.weight)
+            } else {
+                na.bits.cmp(&nb.bits)
+            }
+        });
+
+        // build the tree by repeatedly combining the two lowest-weight nodes
+        let mut nextalloc = self.num_codes;
+        while listitems > 1 {
+            listitems -= 1;
+            let n1 = list[listitems] as usize;
+            listitems -= 1;
+            let n0 = list[listitems] as usize;
+
+            let newidx = nextalloc;
+            nextalloc += 1;
+            let newweight = self.nodes[n0].weight + self.nodes[n1].weight;
+            self.nodes[newidx].parent = NULL_PARENT;
+            self.nodes[newidx].weight = newweight;
+            self.nodes[n0].parent = newidx as u32;
+            self.nodes[n1].parent = newidx as u32;
+
+            // insert newnode into list[0..listitems] keeping descending weight order
+            let mut curitem = 0usize;
+            while curitem < listitems {
+                if newweight > self.nodes[list[curitem] as usize].weight {
+                    break;
+                }
+                curitem += 1;
+            }
+            list.copy_within(curitem..listitems, curitem + 1);
+            list[curitem] = newidx as u32;
+            listitems += 1;
+        }
+
+        // compute the number of bits per leaf code (depth in the tree), track the max
+        let mut maxbits = 0u8;
+        for curcode in 0..self.num_codes {
+            self.nodes[curcode].numbits = 0;
+            self.nodes[curcode].bits = 0;
+            if self.nodes[curcode].weight > 0 {
+                let mut nb: u8 = 0;
+                let mut cur = curcode;
+                while self.nodes[cur].parent != NULL_PARENT {
+                    cur = self.nodes[cur].parent as usize;
+                    nb += 1;
+                }
+                if nb == 0 {
+                    nb = 1;
+                }
+                self.nodes[curcode].numbits = nb;
+                if nb > maxbits {
+                    maxbits = nb;
+                }
+            }
+        }
+        maxbits
+    }
+
+    /// Port of `assign_canonical_codes`.
+    fn assign_canonical_codes(&mut self) -> Result<(), ()> {
+        let mut bithisto = [0u32; 33];
+        for curcode in 0..self.num_codes {
+            let nb = self.nodes[curcode].numbits;
+            if nb > self.max_bits {
+                return Err(());
+            }
+            if nb <= 32 {
+                bithisto[nb as usize] += 1;
+            }
+        }
+
+        let mut curstart = 0u32;
+        for codelen in (1..=32usize).rev() {
+            let nextstart = (curstart + bithisto[codelen]) >> 1;
+            if codelen != 1 && nextstart * 2 != (curstart + bithisto[codelen]) {
+                return Err(());
+            }
+            bithisto[codelen] = curstart;
+            curstart = nextstart;
+        }
+
+        for curcode in 0..self.num_codes {
+            let nb = self.nodes[curcode].numbits;
+            if nb > 0 {
+                self.nodes[curcode].bits = bithisto[nb as usize];
+                bithisto[nb as usize] += 1;
+            }
+        }
+        Ok(())
+    }
+
+    /// Port of `export_tree_huffman`: write the tree as a small-tree-coded RLE of code lengths,
+    /// matching the decode side's `from_huffman_tree`.
+    pub(crate) fn export_tree_huffman(&self, bitbuf: &mut BitWriter) -> Result<(), ()> {
+        let mut rle_data: Vec<u8> = Vec::with_capacity(self.num_codes);
+        let mut rle_lengths: Vec<u16> = Vec::new();
+        let mut smallhuff = HuffEncoder::new(24, 6);
+
+        let mut last: i32 = !0;
+        let mut repcount: i32 = 0;
+
+        for curcode in 0..self.num_codes {
+            let newval = self.nodes[curcode].numbits as i32;
+            if newval != last && repcount > 0 {
+                if repcount == 1 {
+                    let d = (last + 1) as u8;
+                    smallhuff.histo_one(d as u32);
+                    rle_data.push(d);
+                } else {
+                    smallhuff.histo_one(0);
+                    rle_data.push(0);
+                    rle_lengths.push((repcount - 2) as u16);
+                }
+            }
+            if newval == last {
+                repcount += 1;
+            } else {
+                let d = (newval + 1) as u8;
+                smallhuff.histo_one(d as u32);
+                rle_data.push(d);
+                last = newval;
+                repcount = 0;
+            }
+        }
+        if repcount > 0 {
+            if repcount == 1 {
+                let d = (last + 1) as u8;
+                smallhuff.histo_one(d as u32);
+                rle_data.push(d);
+            } else {
+                smallhuff.histo_one(0);
+                rle_data.push(0);
+                rle_lengths.push((repcount - 2) as u16);
+            }
+        }
+
+        smallhuff.compute_tree_from_histo()?;
+
+        // first/last non-zero small-tree nodes
+        let mut first_non_zero: i32 = 31;
+        let mut last_non_zero: i32 = 0;
+        for index in 1..smallhuff.num_codes {
+            if smallhuff.nodes[index].numbits != 0 {
+                if first_non_zero == 31 {
+                    first_non_zero = index as i32;
+                }
+                last_non_zero = index as i32;
+            }
+        }
+        first_non_zero = first_non_zero.min(8);
+
+        bitbuf.write(smallhuff.nodes[0].numbits as u32, 3);
+        bitbuf.write((first_non_zero - 1) as u32, 3);
+        for index in first_non_zero..=last_non_zero {
+            bitbuf.write(smallhuff.nodes[index as usize].numbits as u32, 3);
+        }
+        bitbuf.write(7, 3);
+
+        // bits needed for an extended RLE count
+        let mut temp = (self.num_codes - 9) as u32;
+        let mut rlefullbits = 0u8;
+        while temp != 0 {
+            temp >>= 1;
+            rlefullbits += 1;
+        }
+
+        // encode the RLE token stream
+        let mut li = 0usize;
+        for &data in &rle_data {
+            smallhuff.encode_one(bitbuf, data as u32);
+            if data == 0 {
+                let count = rle_lengths[li];
+                li += 1;
+                if count < 7 {
+                    bitbuf.write(count as u32, 3);
+                } else {
+                    bitbuf.write(7, 3);
+                    bitbuf.write((count - 7) as u32, rlefullbits as i32);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl HuffEncoder {
+    /// Port of `write_rle_tree_bits` (`huffman.cpp:468`) — write a run of `value` using the
+    /// 1-escape RLE the tree export uses.
+    fn write_rle_tree_bits(bitbuf: &mut BitWriter, value: i32, mut repcount: i32, numbits: i32) {
+        while repcount > 0 {
+            if value == 1 {
+                // 1 is the escape code, so write it twice
+                bitbuf.write(1, numbits);
+                bitbuf.write(1, numbits);
+                repcount -= 1;
+            } else if repcount <= 2 {
+                bitbuf.write(value as u32, numbits);
+                repcount -= 1;
+            } else {
+                let cur_reps = (repcount - 3).min((1 << numbits) - 1);
+                bitbuf.write(1, numbits);
+                bitbuf.write(value as u32, numbits);
+                bitbuf.write(cur_reps as u32, numbits);
+                repcount -= cur_reps + 3;
+            }
+        }
+    }
+
+    /// Port of `export_tree_rle` (`huffman.cpp:204`): write the code lengths as a simple RLE
+    /// bitstream (the inverse of the decoder's `from_tree_rle`). Used by the V5 map writer.
+    pub(crate) fn export_tree_rle(&self, bitbuf: &mut BitWriter) {
+        let numbits: i32 = if self.max_bits >= 16 {
+            5
+        } else if self.max_bits >= 8 {
+            4
+        } else {
+            3
+        };
+
+        let mut lastval: i32 = !0;
+        let mut repcount: i32 = 0;
+        for curcode in 0..self.num_codes {
+            let newval = self.nodes[curcode].numbits as i32;
+            if newval == lastval {
+                repcount += 1;
+            } else {
+                if repcount != 0 {
+                    Self::write_rle_tree_bits(bitbuf, lastval, repcount, numbits);
+                }
+                lastval = newval;
+                repcount = 1;
+            }
+        }
+        Self::write_rle_tree_bits(bitbuf, lastval, repcount, numbits);
+    }
+}
+
+/// Encode `source` with a 256-symbol / 16-bit-max static Huffman tree (the `huff` codec):
+/// histogram → optimal tree → exported tree → symbols. Byte-identical to MAME's
+/// `huffman_8bit_encoder::encode`.
+pub(crate) fn encode_8bit(source: &[u8]) -> Result<Vec<u8>, ()> {
+    let mut enc = HuffEncoder::new(256, 16);
+    enc.histo_reset();
+    for &b in source {
+        enc.histo_one(b as u32);
+    }
+    enc.compute_tree_from_histo()?;
+
+    let mut bitbuf = BitWriter::new();
+    enc.export_tree_huffman(&mut bitbuf)?;
+    for &b in source {
+        enc.encode_one(&mut bitbuf, b as u32);
+    }
+    Ok(bitbuf.flush())
+}

--- a/chd-rs/src/lib.rs
+++ b/chd-rs/src/lib.rs
@@ -202,6 +202,12 @@ pub mod hd;
 #[cfg_attr(docsrs, doc(cfg(feature = "write")))]
 pub mod copy;
 
+/// DVD CHD creation/extraction (chdman `createdvd`/`extractdvd`). Available with the `write`
+/// feature.
+#[cfg(feature = "write")]
+#[cfg_attr(docsrs, doc(cfg(feature = "write")))]
+pub mod dvd;
+
 #[cfg(feature = "unstable_lending_iterators")]
 #[cfg_attr(docsrs, doc(cfg(unstable_lending_iterators)))]
 pub mod iter;

--- a/chd-rs/src/lib.rs
+++ b/chd-rs/src/lib.rs
@@ -251,7 +251,8 @@ pub mod copy;
 #[cfg_attr(docsrs, doc(cfg(feature = "write")))]
 pub mod dvd;
 
-/// CD-ROM CHD creation (chdman `createcd`). Available with the `write` feature.
+/// CD-ROM CHD creation + extraction (chdman `createcd`/`extractcd`). Available with the `write`
+/// feature.
 #[cfg(feature = "write")]
 #[cfg_attr(docsrs, doc(cfg(feature = "write")))]
 pub mod cd;

--- a/chd-rs/src/lib.rs
+++ b/chd-rs/src/lib.rs
@@ -251,6 +251,11 @@ pub mod copy;
 #[cfg_attr(docsrs, doc(cfg(feature = "write")))]
 pub mod dvd;
 
+/// CD-ROM CHD creation (chdman `createcd`). Available with the `write` feature.
+#[cfg(feature = "write")]
+#[cfg_attr(docsrs, doc(cfg(feature = "write")))]
+pub mod cd;
+
 #[cfg(feature = "unstable_lending_iterators")]
 #[cfg_attr(docsrs, doc(cfg(unstable_lending_iterators)))]
 pub mod iter;

--- a/chd-rs/src/lib.rs
+++ b/chd-rs/src/lib.rs
@@ -23,7 +23,8 @@
 //! [`Chd`](crate::Chd), direct iteration of hunks is not possible without
 //! Generic Associated Types. Instead, the hunk indices should be iterated over.
 //!
-//!```rust
+//!```rust,no_run
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use std::fs::File;
 //! use std::io::BufReader;
 //! use chd::Chd;
@@ -42,28 +43,36 @@
 //!     let mut hunk = chd.hunk(hunk_num)?;
 //!     hunk.read_hunk_in(&mut cmp_buf, &mut hunk_buf)?;
 //! }
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Iterating over metadata
 //! Metadata in a CHD file consists of a list of entries that contain offsets to the
-//! byte data of the metadata contents in the CHD file. The individual metadata entries
-//! can be iterated directly, but a reference to the source stream has to be provided to
-//! read the data.
-//! ```rust
+//! byte data of the metadata contents in the CHD file. The metadata entry references can be
+//! collected, then a reference to the source stream has to be provided to read each entry's data.
+//! ```rust,no_run
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use std::fs::File;
 //! use std::io::BufReader;
 //! use chd::Chd;
 //!
 //! let mut f = BufReader::new(File::open("file.chd")?);
-//! let mut chd = Chd::open(&mut f, None)?;
-//! let entries = chd.metadata_refs()?;
+//! // Collect the metadata entry references, dropping the `Chd` to release the borrow on `f`.
+//! let entries: Vec<_> = {
+//!     let mut chd = Chd::open(&mut f, None)?;
+//!     chd.metadata_refs().collect()
+//! };
 //! for entry in entries {
 //!     let metadata = entry.read(&mut f)?;
 //! }
+//! # Ok(())
+//! # }
 //!```
 //! `Vec<Metadata>` implements `TryFrom<MetadataRefs>` so all metadata entries
 //! can be collected at once without requiring a reference to the file.
-//! ```rust
+//! ```rust,no_run
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use std::fs::File;
 //! use std::io::BufReader;
 //! use chd::Chd;
@@ -73,7 +82,9 @@
 //! // chd takes ownership of f here
 //! let mut chd = Chd::open(f, None)?;
 //!
-//! let metadatas: Vec<Metadata> = chd.metadata_refs()?.try_into()?;
+//! let metadatas: Vec<Metadata> = chd.metadata_refs().try_into()?;
+//! # Ok(())
+//! # }
 //!```
 //!
 
@@ -97,6 +108,15 @@ pub mod huffman;
 
 #[cfg(not(feature = "huffman_api"))]
 mod huffman;
+
+#[cfg(feature = "write")]
+mod huffman_encode;
+
+#[cfg(feature = "write")]
+mod write;
+
+#[cfg(all(test, feature = "chdman_compat_tests", feature = "write"))]
+mod chdman_compat;
 
 #[cfg(feature = "codec_api")]
 /// Implementations of decompression codecs used in MAME CHD.
@@ -139,10 +159,48 @@ pub(crate) use const_assert;
 
 pub use chdfile::{Chd, Hunk};
 pub use error::{Error, Result};
+pub mod codec;
 pub mod header;
 pub mod map;
 pub mod metadata;
 pub mod read;
+
+// Re-export the codec FourCC constants + helpers at the crate root, matching libchdman-rs's
+// surface so code written against it ports unchanged.
+pub use codec::{
+    codec_exists, codec_name, parse_codec_spec, CHD_CODEC_AVHUFF, CHD_CODEC_CD_FLAC,
+    CHD_CODEC_CD_LZMA, CHD_CODEC_CD_ZLIB, CHD_CODEC_CD_ZSTD, CHD_CODEC_FLAC, CHD_CODEC_HUFF,
+    CHD_CODEC_LZMA, CHD_CODEC_NONE, CHD_CODEC_ZLIB, CHD_CODEC_ZSTD,
+};
+
+/// Progress of a create/compress operation, passed to the `progress` callback that the create
+/// functions in [`hd`](crate::hd) (and, later, `cd`/`dvd`/`copy`) take. Matches libchdman-rs's
+/// `CompressionProgress` field-for-field.
+///
+/// Available with the `write` feature.
+#[cfg(feature = "write")]
+#[cfg_attr(docsrs, doc(cfg(feature = "write")))]
+#[derive(Debug, Clone, Copy)]
+pub struct CompressionProgress {
+    /// Logical bytes processed so far (`0..=bytes_total`).
+    pub bytes_done: u64,
+    /// Total logical bytes to process.
+    pub bytes_total: u64,
+    /// Running compressed/logical size ratio (`0.0..=1.0+`); `1.0` before any data is processed.
+    pub ratio: f64,
+}
+
+/// Hard-disk CHD creation/extraction (chdman `createraw`/`extractraw`; `createhd`/`extracthd`
+/// geometry helpers). Available with the `write` feature.
+#[cfg(feature = "write")]
+#[cfg_attr(docsrs, doc(cfg(feature = "write")))]
+pub mod hd;
+
+/// Re-compress a CHD into a different codec set or hunk size (chdman `copy`). Available with the
+/// `write` feature.
+#[cfg(feature = "write")]
+#[cfg_attr(docsrs, doc(cfg(feature = "write")))]
+pub mod copy;
 
 #[cfg(feature = "unstable_lending_iterators")]
 #[cfg_attr(docsrs, doc(cfg(unstable_lending_iterators)))]

--- a/chd-rs/src/lib.rs
+++ b/chd-rs/src/lib.rs
@@ -173,6 +173,49 @@ pub use codec::{
     CHD_CODEC_LZMA, CHD_CODEC_NONE, CHD_CODEC_ZLIB, CHD_CODEC_ZSTD,
 };
 
+/// Aggregate snapshot of a CHD's header + metadata, returned by [`Chd::info`]. Mirrors the data
+/// chdman's `info` subcommand reports (and libchdman-rs's `ChdInfo`).
+#[derive(Debug, Clone)]
+pub struct ChdInfo {
+    /// CHD format version (1–5).
+    pub version: u32,
+    /// Hunk size in bytes.
+    pub hunk_bytes: u32,
+    /// Unit (sector) size in bytes.
+    pub unit_bytes: u32,
+    /// Total hunk count.
+    pub hunk_count: u32,
+    /// Logical (uncompressed) size in bytes.
+    pub logical_bytes: u64,
+    /// Per-slot codec FourCCs (slot 0..=3); `0` means an unused slot / no compression.
+    pub codecs: [u32; 4],
+    /// Overall SHA-1 (zero if the header has none, e.g. an uncompressed CHD).
+    pub sha1: [u8; 20],
+    /// Raw (hunk-data) SHA-1 (zero if the header has none).
+    pub raw_sha1: [u8; 20],
+    /// Parent SHA-1 (zero if the CHD has no parent).
+    pub parent_sha1: [u8; 20],
+    /// Every metadata entry in stored order, paired with its per-tag index (so `(CHT2, 0)`,
+    /// `(CHT2, 1)`, … are distinguishable).
+    pub metadata_tags: Vec<(u32, u32)>,
+    /// Count of CD/GD track records (`CHT2` + `CHTR` + `CHGD`).
+    pub track_count: u32,
+    /// Whether the CHD is compressed (codec slot 0 is not `CHD_CODEC_NONE`).
+    pub compressed: bool,
+    /// Whether the CHD references a parent.
+    pub has_parent: bool,
+    /// Carries a `GDDD` hard-disk record.
+    pub is_hd: bool,
+    /// Carries CD-ROM records (`CHCD`/`CHTR`/`CHT2`).
+    pub is_cd: bool,
+    /// Carries GD-ROM records (`CHGT`/`CHGD`).
+    pub is_gd: bool,
+    /// Carries a `DVD ` record.
+    pub is_dvd: bool,
+    /// Carries A/V records (`AVAV`).
+    pub is_av: bool,
+}
+
 /// Progress of a create/compress operation, passed to the `progress` callback that the create
 /// functions in [`hd`](crate::hd) (and, later, `cd`/`dvd`/`copy`) take. Matches libchdman-rs's
 /// `CompressionProgress` field-for-field.

--- a/chd-rs/src/lib.rs
+++ b/chd-rs/src/lib.rs
@@ -216,6 +216,40 @@ pub struct ChdInfo {
     pub is_av: bool,
 }
 
+/// Result of [`Chd::verify`]: the SHA-1 checksums recomputed from the data, alongside the values
+/// stored in the header. Available with the `verify` feature.
+#[cfg(feature = "verify")]
+#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+#[derive(Debug, Clone)]
+pub struct VerifyResult {
+    /// Raw SHA-1 recomputed over the logical (decompressed, unpadded) data.
+    pub computed_raw_sha1: [u8; 20],
+    /// Overall SHA-1 recomputed from the raw SHA-1 + the checksummed metadata.
+    pub computed_sha1: [u8; 20],
+    /// Raw-data SHA-1 stored in the header.
+    pub expected_raw_sha1: [u8; 20],
+    /// Overall (metadata-inclusive) SHA-1 stored in the header.
+    pub expected_sha1: [u8; 20],
+}
+
+#[cfg(feature = "verify")]
+impl VerifyResult {
+    /// Whether the recomputed raw-data SHA-1 matches the header.
+    pub fn raw_sha1_valid(&self) -> bool {
+        self.computed_raw_sha1 == self.expected_raw_sha1
+    }
+
+    /// Whether the recomputed overall (metadata-inclusive) SHA-1 matches the header.
+    pub fn overall_sha1_valid(&self) -> bool {
+        self.computed_sha1 == self.expected_sha1
+    }
+
+    /// Whether both the raw-data and overall SHA-1 checksums match the header.
+    pub fn is_valid(&self) -> bool {
+        self.raw_sha1_valid() && self.overall_sha1_valid()
+    }
+}
+
 /// Progress of a create/compress operation, passed to the `progress` callback that the create
 /// functions in [`hd`](crate::hd) (and, later, `cd`/`dvd`/`copy`) take. Matches libchdman-rs's
 /// `CompressionProgress` field-for-field.

--- a/chd-rs/src/metadata.rs
+++ b/chd-rs/src/metadata.rs
@@ -227,3 +227,289 @@ impl<'a, F: Read + Seek + 'a> Iterator for MetadataRefs<'a, F> {
         next_inner(self).ok()
     }
 }
+
+/// Metadata flag: this entry's payload is included in the overall SHA-1 (MAME's
+/// `CHD_MDFLAGS_CHECKSUM`). chdman writes this on every metadata record by default.
+#[cfg(feature = "write")]
+pub const METADATA_FLAG_CHECKSUM: u8 = 0x01;
+
+// In-place metadata writer for existing V5 CHDs (chdman `addmeta`/`delmeta`). These mutate the
+// file's metadata linked list, so they take a `Read + Write + Seek` handle (e.g. a `File` opened
+// read-write) rather than chd-rs's read-only [`Chd`]. Ports of `chd_file::write_metadata` /
+// `delete_metadata` (chd.cpp:1542/1641); byte-identical to chdman.
+#[cfg(feature = "write")]
+mod edit {
+    use super::{Error, Result, METADATA_HEADER_SIZE};
+    use sha1::{Digest, Sha1};
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    // V5 header field offsets.
+    const VERSION_OFF: u64 = 12;
+    const COMPRESSION_OFF: u64 = 16;
+    const META_OFFSET_FIELD: u64 = 48;
+    const RAW_SHA1_OFF: u64 = 64;
+    const SHA1_OFF: u64 = 84;
+    const CHD_MDFLAGS_CHECKSUM: u8 = 0x01;
+
+    struct Found {
+        found: bool,
+        offset: u64,
+        prev: u64,
+        next: u64,
+        length: u32,
+    }
+
+    fn read_u32be<F: Read + Seek>(file: &mut F, off: u64) -> Result<u32> {
+        let mut b = [0u8; 4];
+        file.seek(SeekFrom::Start(off))?;
+        file.read_exact(&mut b)?;
+        Ok(u32::from_be_bytes(b))
+    }
+
+    fn read_u64be<F: Read + Seek>(file: &mut F, off: u64) -> Result<u64> {
+        let mut b = [0u8; 8];
+        file.seek(SeekFrom::Start(off))?;
+        file.read_exact(&mut b)?;
+        Ok(u64::from_be_bytes(b))
+    }
+
+    /// Verify the handle is a V5 CHD (the only version chd-rs writes/edits).
+    fn check_v5<F: Read + Seek>(file: &mut F) -> Result<()> {
+        let mut magic = [0u8; 8];
+        file.seek(SeekFrom::Start(0))?;
+        file.read_exact(&mut magic)?;
+        if &magic != b"MComprHD" {
+            return Err(Error::InvalidFile);
+        }
+        if read_u32be(file, VERSION_OFF)? != 5 {
+            return Err(Error::UnsupportedVersion);
+        }
+        Ok(())
+    }
+
+    fn sha1_20(data: &[u8]) -> [u8; 20] {
+        let mut h = Sha1::new();
+        h.update(data);
+        h.finalize().into()
+    }
+
+    /// Port of `metadata_find` (chd.cpp:2804): walk the linked list from `meta_offset`, returning
+    /// the `index`-th entry whose tag matches (or `found=false` with `prev` = the last entry, so a
+    /// caller can append). `index == u32::MAX` never matches (chdman's `CHDMETAINDEX_APPEND`).
+    fn metadata_find<F: Read + Seek>(
+        file: &mut F,
+        meta_offset: u64,
+        tag: u32,
+        index: u32,
+    ) -> Result<Found> {
+        let mut offset = meta_offset;
+        let mut prev = 0u64;
+        let mut idx = index as i32;
+        while offset != 0 {
+            let mut hdr = [0u8; METADATA_HEADER_SIZE];
+            file.seek(SeekFrom::Start(offset))?;
+            file.read_exact(&mut hdr)?;
+            let etag = u32::from_be_bytes([hdr[0], hdr[1], hdr[2], hdr[3]]);
+            let elen = ((hdr[5] as u32) << 16) | ((hdr[6] as u32) << 8) | hdr[7] as u32;
+            let enext = u64::from_be_bytes([
+                hdr[8], hdr[9], hdr[10], hdr[11], hdr[12], hdr[13], hdr[14], hdr[15],
+            ]);
+            if etag == tag {
+                if idx == 0 {
+                    return Ok(Found {
+                        found: true,
+                        offset,
+                        prev,
+                        next: enext,
+                        length: elen,
+                    });
+                }
+                idx -= 1;
+            }
+            prev = offset;
+            offset = enext;
+        }
+        Ok(Found {
+            found: false,
+            offset: 0,
+            prev,
+            next: 0,
+            length: 0,
+        })
+    }
+
+    /// Port of `metadata_set_previous_next` (chd.cpp:2858): point the previous entry (or, if
+    /// `prev == 0`, the header's `meta_offset` field) at `next`.
+    fn set_previous_next<F: Write + Seek>(file: &mut F, prev: u64, next: u64) -> Result<()> {
+        let off = if prev == 0 {
+            META_OFFSET_FIELD
+        } else {
+            prev + 8
+        };
+        file.seek(SeekFrom::Start(off))?;
+        file.write_all(&next.to_be_bytes())?;
+        Ok(())
+    }
+
+    /// Port of `compute_overall_sha1` (chd.cpp:1709) reading the on-disk metadata list:
+    /// `SHA1(raw_sha1 ‖ sorted[tag(4 BE) ‖ SHA1(payload)])` over CHECKSUM-flagged entries.
+    fn overall_sha1<F: Read + Seek>(
+        file: &mut F,
+        raw_sha1: &[u8; 20],
+        meta_offset: u64,
+    ) -> Result<[u8; 20]> {
+        let mut hashes: Vec<[u8; 24]> = Vec::new();
+        let mut offset = meta_offset;
+        while offset != 0 {
+            let mut hdr = [0u8; METADATA_HEADER_SIZE];
+            file.seek(SeekFrom::Start(offset))?;
+            file.read_exact(&mut hdr)?;
+            let etag = u32::from_be_bytes([hdr[0], hdr[1], hdr[2], hdr[3]]);
+            let eflags = hdr[4];
+            let elen = ((hdr[5] as u32) << 16) | ((hdr[6] as u32) << 8) | hdr[7] as u32;
+            let enext = u64::from_be_bytes([
+                hdr[8], hdr[9], hdr[10], hdr[11], hdr[12], hdr[13], hdr[14], hdr[15],
+            ]);
+            if eflags & CHD_MDFLAGS_CHECKSUM != 0 {
+                let mut payload = vec![0u8; elen as usize];
+                file.read_exact(&mut payload)?; // positioned at offset + 16 after the header read
+                let mut h = [0u8; 24];
+                h[0..4].copy_from_slice(&etag.to_be_bytes());
+                h[4..24].copy_from_slice(&sha1_20(&payload));
+                hashes.push(h);
+            }
+            offset = enext;
+        }
+        hashes.sort_unstable();
+        let mut hasher = Sha1::new();
+        hasher.update(raw_sha1);
+        for h in &hashes {
+            hasher.update(h);
+        }
+        Ok(hasher.finalize().into())
+    }
+
+    /// Port of `metadata_update_hash` (chd.cpp:2890): for a **compressed** V5 CHD, recompute the
+    /// overall SHA-1 from the current metadata and write it to the header. Uncompressed CHDs keep
+    /// zero SHA-1 (chdman computes none), so this is a no-op for them.
+    fn update_hash<F: Read + Write + Seek>(file: &mut F) -> Result<()> {
+        if read_u32be(file, COMPRESSION_OFF)? == 0 {
+            return Ok(());
+        }
+        let mut raw = [0u8; 20];
+        file.seek(SeekFrom::Start(RAW_SHA1_OFF))?;
+        file.read_exact(&mut raw)?;
+        let meta_offset = read_u64be(file, META_OFFSET_FIELD)?;
+        let overall = overall_sha1(file, &raw, meta_offset)?;
+        file.seek(SeekFrom::Start(SHA1_OFF))?;
+        file.write_all(&overall)?;
+        Ok(())
+    }
+
+    pub fn write_metadata<F: Read + Write + Seek>(
+        file: &mut F,
+        tag: u32,
+        index: u32,
+        data: &[u8],
+        flags: u8,
+    ) -> Result<()> {
+        if data.is_empty() || data.len() >= 16 * 1024 * 1024 {
+            return Err(Error::InvalidParameter);
+        }
+        check_v5(file)?;
+        let meta_offset = read_u64be(file, META_OFFSET_FIELD)?;
+        let found = metadata_find(file, meta_offset, tag, index)?;
+
+        let mut finished = false;
+        if found.found {
+            if data.len() as u32 <= found.length {
+                // overwrite in place; update the length field if it shrank
+                file.seek(SeekFrom::Start(found.offset + METADATA_HEADER_SIZE as u64))?;
+                file.write_all(data)?;
+                if data.len() as u32 != found.length {
+                    let l = data.len() as u32;
+                    file.seek(SeekFrom::Start(found.offset + 5))?;
+                    file.write_all(&[(l >> 16) as u8, (l >> 8) as u8, l as u8])?;
+                }
+                finished = true;
+            } else {
+                // doesn't fit — unlink the old entry, then append below
+                set_previous_next(file, found.prev, found.next)?;
+            }
+        }
+
+        if !finished {
+            // append a fresh entry at EOF and link the previous entry (or header) to it
+            let new_offset = file.seek(SeekFrom::End(0))?;
+            let l = data.len() as u32;
+            let mut hdr = [0u8; METADATA_HEADER_SIZE];
+            hdr[0..4].copy_from_slice(&tag.to_be_bytes());
+            hdr[4] = flags;
+            hdr[5] = (l >> 16) as u8;
+            hdr[6] = (l >> 8) as u8;
+            hdr[7] = l as u8;
+            // next (8..16) = 0
+            file.write_all(&hdr)?;
+            file.write_all(data)?;
+            set_previous_next(file, found.prev, new_offset)?;
+        }
+
+        update_hash(file)?;
+        Ok(())
+    }
+
+    pub fn delete_metadata<F: Read + Write + Seek>(
+        file: &mut F,
+        tag: u32,
+        index: u32,
+    ) -> Result<()> {
+        check_v5(file)?;
+        let meta_offset = read_u64be(file, META_OFFSET_FIELD)?;
+        let found = metadata_find(file, meta_offset, tag, index)?;
+        if !found.found {
+            return Err(Error::MetadataNotFound);
+        }
+        // unlink only — chdman's delete_metadata does NOT recompute the overall SHA-1.
+        set_previous_next(file, found.prev, found.next)
+    }
+}
+
+/// Write (add or overwrite) a metadata record in an existing **V5** CHD, byte-identical to
+/// `chdman addmeta`. Mutates the on-disk metadata linked list, so it takes a `Read + Write + Seek`
+/// handle (e.g. `OpenOptions::new().read(true).write(true).open(path)`), not chd-rs's read-only
+/// [`Chd`](crate::Chd).
+///
+/// If a record with `(tag, index)` exists and the new `data` fits in its slot it is overwritten in
+/// place; otherwise a new entry is appended at end-of-file and linked in. `index == u32::MAX`
+/// always appends (chdman's `CHDMETAINDEX_APPEND`). `flags` is usually [`METADATA_FLAG_CHECKSUM`].
+/// For a **compressed** CHD the overall SHA-1 is recomputed; uncompressed CHDs keep zero SHA-1.
+///
+/// `data` is written verbatim — chdman's *text* form stores a trailing NUL (`"abc"` → 4 bytes),
+/// while its *file* form stores the raw bytes; replicate whichever you need in `data`.
+#[cfg(feature = "write")]
+#[cfg_attr(docsrs, doc(cfg(feature = "write")))]
+pub fn write_metadata<F: Read + std::io::Write + Seek>(
+    file: &mut F,
+    tag: u32,
+    index: u32,
+    data: &[u8],
+    flags: u8,
+) -> Result<()> {
+    edit::write_metadata(file, tag, index, data, flags)
+}
+
+/// Delete a metadata record from an existing **V5** CHD, byte-identical to `chdman delmeta`.
+/// Unlinks the `(tag, index)` entry from the on-disk list (its bytes remain as dead space, exactly
+/// as chdman leaves them). Like chdman, this does **not** recompute the overall SHA-1.
+///
+/// Takes a `Read + Write + Seek` handle (see [`write_metadata`]). Returns
+/// [`Error::MetadataNotFound`](crate::Error::MetadataNotFound) if no matching record exists.
+#[cfg(feature = "write")]
+#[cfg_attr(docsrs, doc(cfg(feature = "write")))]
+pub fn delete_metadata<F: Read + std::io::Write + Seek>(
+    file: &mut F,
+    tag: u32,
+    index: u32,
+) -> Result<()> {
+    edit::delete_metadata(file, tag, index)
+}

--- a/chd-rs/src/write.rs
+++ b/chd-rs/src/write.rs
@@ -170,6 +170,45 @@ fn sha1_digest(data: &[u8]) -> [u8; 20] {
     h.finalize().into()
 }
 
+/// Precomputed parent-hunk hashes for parent dedup when writing a child CHD. Keyed by the
+/// `(crc16, sha1)` of a `hunk_bytes`-sized window at each unit-aligned offset in the parent's
+/// (padded) logical image; the value is that **unit offset** (the `COMPRESSION_PARENT` reference).
+pub(crate) struct ParentRef {
+    map: HashMap<(u16, [u8; 20]), u64>,
+    sha1: [u8; 20],
+}
+
+/// Build a [`ParentRef`] from the parent's padded logical image (`hunk_count * hunk_bytes` bytes,
+/// last hunk zero-padded). Port of `chd_file_compressor::async_walk_parent` (`chd.cpp:3208`) + the
+/// hashmap insert in `compress_continue` (`chd.cpp:3084`): for parent hunk `h` it hashes `units`
+/// windows (`units = hunk_bytes/unit_bytes`, or **1** for the last hunk) at unit offsets
+/// `h*uph + unit`, each a `hunk_bytes` window starting at that unit — so a child hunk can match the
+/// parent at any unit-aligned position, not just hunk boundaries. First occurrence of a hash wins.
+pub(crate) fn build_parent_ref(
+    padded_img: &[u8],
+    hunk_bytes: u32,
+    unit_bytes: u32,
+    hunk_count: u32,
+    sha1: [u8; 20],
+) -> ParentRef {
+    let uph = (hunk_bytes / unit_bytes) as u64;
+    let hb = hunk_bytes as usize;
+    let ub = unit_bytes as usize;
+    let mut map: HashMap<(u16, [u8; 20]), u64> = HashMap::new();
+    for h in 0..hunk_count as u64 {
+        let units = if h == hunk_count as u64 - 1 { 1 } else { uph };
+        for unit in 0..units {
+            let pos = h * uph + unit;
+            let start = pos as usize * ub;
+            let window = &padded_img[start..start + hb];
+            let crc = crate::block_hash::CRC16.checksum(window);
+            let key = (crc, sha1_digest(window));
+            map.entry(key).or_insert(pos);
+        }
+    }
+    ParentRef { map, sha1 }
+}
+
 /// Write a complete **compressed** V5 CHD containing `data`, using a single codec, intended to
 /// be byte-identical to `chdman createraw -c <codec> -hs <hunk_bytes> -us <unit_bytes>`.
 ///
@@ -221,6 +260,7 @@ pub fn write_raw<W: Write + Seek>(
         unit_bytes,
         codecs,
         &[],
+        None,
         &mut |_, _, _| {},
         &|| false,
     )
@@ -246,6 +286,7 @@ pub(crate) fn write_raw_inner<W: Write + Seek>(
     unit_bytes: u32,
     codecs: &[CodecType],
     metadata: &[MetaEntry],
+    parent: Option<&ParentRef>,
     progress: &mut dyn FnMut(u64, u64, u64),
     cancel: &dyn Fn() -> bool,
 ) -> Result<()> {
@@ -312,6 +353,17 @@ pub(crate) fn write_raw_inner<W: Write + Seek>(
             continue;
         }
 
+        // PARENT: identical to a (unit-aligned window of the) parent -> reference it. Checked after
+        // SELF, matching chdman's `compress_continue` priority. Not added to the self map (chdman
+        // only adds hunks it actually writes).
+        if let Some(p) = parent {
+            if let Some(&refunit) = p.map.get(&(crc, sha1)) {
+                rawmap[base] = COMPRESSION_PARENT;
+                put_u48be(&mut rawmap[base + 4..base + 10], refunit);
+                continue;
+            }
+        }
+
         // find_best_compressor: baseline is "store NONE" at hunk_bytes; a codec wins only if it
         // is strictly smaller than the current best, earliest slot first.
         let mut best_type = COMPRESSION_NONE;
@@ -371,7 +423,9 @@ pub(crate) fn write_raw_inner<W: Write + Seek>(
     hdr[60..64].copy_from_slice(&unit_bytes.to_be_bytes());
     hdr[64..84].copy_from_slice(&raw_sha1);
     hdr[84..104].copy_from_slice(&overall_sha1);
-    // parent_sha1 (104..124) = 0
+    if let Some(p) = parent {
+        hdr[104..124].copy_from_slice(&p.sha1);
+    }
 
     out.write_all(&hdr)?;
     out.write_all(&meta_blob)?;
@@ -759,6 +813,6 @@ pub(crate) fn write_create<W: Write + Seek>(
         });
     };
     write_raw_inner(
-        out, data, hunk_size, unit_size, codecs, metadata, &mut prog, cancel,
+        out, data, hunk_size, unit_size, codecs, metadata, None, &mut prog, cancel,
     )
 }

--- a/chd-rs/src/write.rs
+++ b/chd-rs/src/write.rs
@@ -8,9 +8,10 @@ use crate::compression::CompressionEncoder;
 use crate::error::{Error, Result};
 use crate::header::CodecType;
 use crate::huffman_encode::{BitWriter, HuffEncoder};
+use crate::CompressionProgress;
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
-use std::io::{Seek, Write};
+use std::io::{Read, Seek, Write};
 
 const CHD_MAGIC: &[u8; 8] = b"MComprHD";
 const V5_HEADER_SIZE: u32 = 124;
@@ -638,4 +639,74 @@ pub(crate) fn write_uncompressed_inner<W: Write + Seek>(
     }
 
     Ok(())
+}
+
+/// Read all of `reader` into memory and zero-pad to `logical_size` (or the read length if 0),
+/// validating `hunk_size`/`unit_size` and that the logical size is unit-aligned and ≥ the input.
+/// Shared by the `hd`/`dvd`/`copy` create paths (the in-memory writer needs the whole image).
+pub(crate) fn read_and_pad<R: Read>(
+    mut reader: R,
+    logical_size: u64,
+    unit_size: u32,
+    hunk_size: u32,
+) -> Result<Vec<u8>> {
+    if unit_size == 0 || hunk_size == 0 || hunk_size % unit_size != 0 {
+        return Err(Error::InvalidParameter);
+    }
+    let mut data = Vec::new();
+    reader.read_to_end(&mut data)?;
+    let logical = if logical_size != 0 {
+        logical_size
+    } else {
+        data.len() as u64
+    };
+    if logical % u64::from(unit_size) != 0 || data.len() as u64 > logical {
+        return Err(Error::InvalidParameter);
+    }
+    data.resize(logical as usize, 0);
+    Ok(data)
+}
+
+/// Create dispatch for the `hd`/`dvd`/`copy` modules: write `data` (already padded to the logical
+/// size) with the given codec list + metadata, choosing the uncompressed or compressed writer and
+/// adapting the numeric per-hunk callback to a [`CompressionProgress`]. An empty `codecs` writes an
+/// uncompressed CHD (no per-hunk progress hook; `cancel` checked once up front).
+pub(crate) fn write_create<W: Write + Seek>(
+    out: &mut W,
+    data: &[u8],
+    hunk_size: u32,
+    unit_size: u32,
+    codecs: &[CodecType],
+    metadata: &[MetaEntry],
+    progress: &mut dyn FnMut(CompressionProgress),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    let logical = data.len() as u64;
+    if codecs.is_empty() {
+        if cancel() {
+            return Err(Error::Cancelled);
+        }
+        write_uncompressed_inner(out, data, hunk_size, unit_size, metadata)?;
+        progress(CompressionProgress {
+            bytes_done: logical,
+            bytes_total: logical,
+            ratio: 1.0,
+        });
+        return Ok(());
+    }
+
+    let mut prog = |done: u64, total: u64, comp: u64| {
+        progress(CompressionProgress {
+            bytes_done: done,
+            bytes_total: total,
+            ratio: if done == 0 {
+                1.0
+            } else {
+                comp as f64 / done as f64
+            },
+        });
+    };
+    write_raw_inner(
+        out, data, hunk_size, unit_size, codecs, metadata, &mut prog, cancel,
+    )
 }

--- a/chd-rs/src/write.rs
+++ b/chd-rs/src/write.rs
@@ -641,6 +641,58 @@ pub(crate) fn write_uncompressed_inner<W: Write + Seek>(
     Ok(())
 }
 
+/// Write an **empty uncompressed diff** CHD: a V5 `compression = none` file whose 4-byte map is
+/// all zeros (every hunk reads from the parent) with `parent_sha1` set, plus the (cloned) metadata.
+/// No data hunks are written; the file ends padded to the first hunk-aligned offset so the runtime
+/// writer ([`crate::hd::HdImage`]) can append materialised hunks there. Layout matches an
+/// uncompressed CHD (`header → map → metadata → pad`), exactly what MAME's `create(.., parent)`
+/// produces for a diff and what its (and chd-rs's) reader expects.
+pub(crate) fn write_empty_diff<W: Write + Seek>(
+    out: &mut W,
+    logical_bytes: u64,
+    hunk_bytes: u32,
+    unit_bytes: u32,
+    parent_sha1: &[u8; 20],
+    metadata: &[MetaEntry],
+) -> Result<()> {
+    if hunk_bytes == 0 || unit_bytes == 0 || hunk_bytes % unit_bytes != 0 {
+        return Err(Error::InvalidParameter);
+    }
+    let hunk_bytes_u64 = hunk_bytes as u64;
+    let hunk_count = round_up(logical_bytes, hunk_bytes_u64) / hunk_bytes_u64;
+    let map_offset = V5_HEADER_SIZE as u64;
+    let map_size = hunk_count * 4;
+
+    let meta_start = map_offset + map_size;
+    let meta_blob = build_metadata_blob(metadata, meta_start);
+    let meta_offset = if meta_blob.is_empty() { 0 } else { meta_start };
+    let data_start = round_up(meta_start + meta_blob.len() as u64, hunk_bytes_u64);
+
+    let mut hdr = [0u8; V5_HEADER_SIZE as usize];
+    hdr[0..8].copy_from_slice(CHD_MAGIC);
+    hdr[8..12].copy_from_slice(&V5_HEADER_SIZE.to_be_bytes());
+    hdr[12..16].copy_from_slice(&5u32.to_be_bytes());
+    // compression[0..4] = 0 (none) — already zero
+    hdr[32..40].copy_from_slice(&logical_bytes.to_be_bytes());
+    hdr[40..48].copy_from_slice(&map_offset.to_be_bytes());
+    hdr[48..56].copy_from_slice(&meta_offset.to_be_bytes());
+    hdr[56..60].copy_from_slice(&hunk_bytes.to_be_bytes());
+    hdr[60..64].copy_from_slice(&unit_bytes.to_be_bytes());
+    // raw_sha1 (64) + sha1 (84) stay zero (uncompressed); parent_sha1 (104) links the parent.
+    hdr[104..124].copy_from_slice(parent_sha1);
+    out.write_all(&hdr)?;
+
+    // all-zero map: every hunk falls through to the parent until written.
+    out.write_all(&vec![0u8; map_size as usize])?;
+
+    out.write_all(&meta_blob)?;
+    let pad = data_start - (meta_start + meta_blob.len() as u64);
+    if pad > 0 {
+        out.write_all(&vec![0u8; pad as usize])?;
+    }
+    Ok(())
+}
+
 /// Read all of `reader` into memory and zero-pad to `logical_size` (or the read length if 0),
 /// validating `hunk_size`/`unit_size` and that the logical size is unit-aligned and ≥ the input.
 /// Shared by the `hd`/`dvd`/`copy` create paths (the in-memory writer needs the whole image).

--- a/chd-rs/src/write.rs
+++ b/chd-rs/src/write.rs
@@ -1,0 +1,641 @@
+//! CHD writing (encode side). Gated behind the `write` feature.
+//!
+//! Start of the V5 writer core. The first target is an **uncompressed** raw CHD that is
+//! byte-identical to `chdman createraw -c none`. The compressed path (codec selection +
+//! `compress_v5_map` + SHA-1) builds on this.
+
+use crate::compression::CompressionEncoder;
+use crate::error::{Error, Result};
+use crate::header::CodecType;
+use crate::huffman_encode::{BitWriter, HuffEncoder};
+use sha1::{Digest, Sha1};
+use std::collections::HashMap;
+use std::io::{Seek, Write};
+
+const CHD_MAGIC: &[u8; 8] = b"MComprHD";
+const V5_HEADER_SIZE: u32 = 124;
+
+/// Size of an on-disk metadata entry header: `tag(4) + flags(1) + length(3) + next(8)`.
+const METADATA_HEADER_SIZE: u64 = 16;
+/// Metadata flag: this entry's payload is included in the overall SHA-1 (`CHD_MDFLAGS_CHECKSUM`).
+pub(crate) const CHD_MDFLAGS_CHECKSUM: u8 = 0x01;
+
+/// A metadata record to write into a freshly-created CHD. `flags` is usually
+/// [`CHD_MDFLAGS_CHECKSUM`] (chdman's `write_metadata` default).
+pub(crate) struct MetaEntry<'a> {
+    pub tag: u32,
+    pub flags: u8,
+    pub payload: &'a [u8],
+}
+
+/// Build the on-disk metadata linked-list blob for a freshly-created CHD: entries are laid out in
+/// order starting at file offset `meta_start`, each `tag(4) + flags(1) + len(3) + next(8) +
+/// payload`, with `next` pointing at the following entry's offset (0 for the last). This is the
+/// inverse of [`crate::metadata`]'s reader and reproduces chdman's sequential `write_metadata`
+/// appends (the header's `meta_offset` then points at `meta_start`).
+fn build_metadata_blob(entries: &[MetaEntry], meta_start: u64) -> Vec<u8> {
+    // entry i's file offset (header start)
+    let mut offsets = Vec::with_capacity(entries.len());
+    let mut off = meta_start;
+    for e in entries {
+        offsets.push(off);
+        off += METADATA_HEADER_SIZE + e.payload.len() as u64;
+    }
+
+    let mut blob = Vec::new();
+    for (i, e) in entries.iter().enumerate() {
+        let next = if i + 1 < entries.len() {
+            offsets[i + 1]
+        } else {
+            0
+        };
+        let len = e.payload.len() as u32;
+        blob.extend_from_slice(&e.tag.to_be_bytes());
+        blob.push(e.flags);
+        blob.push((len >> 16) as u8);
+        blob.push((len >> 8) as u8);
+        blob.push(len as u8);
+        blob.extend_from_slice(&next.to_be_bytes());
+        blob.extend_from_slice(e.payload);
+    }
+    blob
+}
+
+/// Port of `chd_file::compute_overall_sha1` (`chd.cpp:1709`): the overall SHA-1 is
+/// `SHA1(raw_sha1 ‖ sorted[ tag(4 BE) ‖ SHA1(payload) ])`, over only the metadata entries with the
+/// `CHECKSUM` flag, sorted by the 24-byte `(tag, sha1)` tuple (a `memcmp`, i.e. lexicographic).
+/// With no checksummed metadata this is just `SHA1(raw_sha1)`.
+fn compute_overall_sha1(raw_sha1: &[u8; 20], entries: &[MetaEntry]) -> [u8; 20] {
+    let mut hashes: Vec<[u8; 24]> = Vec::new();
+    for e in entries {
+        if e.flags & CHD_MDFLAGS_CHECKSUM == 0 {
+            continue;
+        }
+        let mut h = [0u8; 24];
+        h[0..4].copy_from_slice(&e.tag.to_be_bytes());
+        h[4..24].copy_from_slice(&sha1_digest(e.payload));
+        hashes.push(h);
+    }
+    hashes.sort_unstable(); // [u8; 24] Ord == memcmp == chdman's metadata_hash_compare
+
+    let mut hasher = Sha1::new();
+    hasher.update(raw_sha1);
+    for h in &hashes {
+        hasher.update(h);
+    }
+    hasher.finalize().into()
+}
+
+// V5 map compression-type codes (== MAME's COMPRESSION_* and chd-rs's CompressionTypeV5).
+const COMPRESSION_NONE: u8 = 4;
+const COMPRESSION_SELF: u8 = 5;
+const COMPRESSION_PARENT: u8 = 6;
+const COMPRESSION_RLE_SMALL: u8 = 7;
+const COMPRESSION_RLE_LARGE: u8 = 8;
+const COMPRESSION_SELF_0: u8 = 9;
+const COMPRESSION_SELF_1: u8 = 10;
+const COMPRESSION_PARENT_SELF: u8 = 11;
+const COMPRESSION_PARENT_0: u8 = 12;
+const COMPRESSION_PARENT_1: u8 = 13;
+
+#[inline]
+fn round_up(x: u64, align: u64) -> u64 {
+    ((x + align - 1) / align) * align
+}
+
+#[inline]
+fn get_u16be(b: &[u8]) -> u16 {
+    u16::from_be_bytes([b[0], b[1]])
+}
+#[inline]
+fn get_u24be(b: &[u8]) -> u32 {
+    ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32
+}
+#[inline]
+fn get_u48be(b: &[u8]) -> u64 {
+    ((b[0] as u64) << 40)
+        | ((b[1] as u64) << 32)
+        | ((b[2] as u64) << 24)
+        | ((b[3] as u64) << 16)
+        | ((b[4] as u64) << 8)
+        | b[5] as u64
+}
+#[inline]
+fn put_u48be(b: &mut [u8], v: u64) {
+    b[0] = (v >> 40) as u8;
+    b[1] = (v >> 32) as u8;
+    b[2] = (v >> 24) as u8;
+    b[3] = (v >> 16) as u8;
+    b[4] = (v >> 8) as u8;
+    b[5] = v as u8;
+}
+
+/// Resolve a `[u32; 4]` codec-FourCC list (as in [`crate::codec`] / `HdCreateOptions`) into the
+/// ordered, contiguous [`CodecType`] list the writers expect. A `0` ends the list; a non-zero slot
+/// after a `0` (a gap) is rejected, since the slot index is significant (it becomes the map's
+/// `COMPRESSION_TYPE_<slot>`). An all-zero list yields an empty vec (= uncompressed).
+pub(crate) fn resolve_codecs(codecs: &[u32; 4]) -> Result<Vec<CodecType>> {
+    use num_traits::FromPrimitive;
+    let mut out = Vec::new();
+    let mut ended = false;
+    for &c in codecs {
+        if c == 0 {
+            ended = true;
+            continue;
+        }
+        if ended {
+            return Err(Error::InvalidParameter); // gapped codec lists are unsupported
+        }
+        out.push(CodecType::from_u32(c).ok_or(Error::UnsupportedFormat)?);
+    }
+    Ok(out)
+}
+
+/// Port of MAME's `chd_file::bits_for_value`: number of bits needed to hold `value`.
+#[inline]
+fn bits_for_value(mut value: u64) -> u8 {
+    let mut result = 0u8;
+    while value != 0 {
+        value >>= 1;
+        result += 1;
+    }
+    result
+}
+
+#[inline]
+fn sha1_digest(data: &[u8]) -> [u8; 20] {
+    let mut h = Sha1::new();
+    h.update(data);
+    h.finalize().into()
+}
+
+/// Write a complete **compressed** V5 CHD containing `data`, using a single codec, intended to
+/// be byte-identical to `chdman createraw -c <codec> -hs <hunk_bytes> -us <unit_bytes>`.
+///
+/// Layout (verified against chdman 0.288): 124-byte header, then the compressed hunks
+/// byte-packed starting at offset 124, then the compressed map (`compress_v5_map`) at the end.
+/// Each hunk uses the codec if it shrinks below `hunk_bytes`, else is stored uncompressed
+/// (`COMPRESSION_NONE`). `raw_sha1 = SHA1(logical data)`, `sha1 = SHA1(raw_sha1)` (no metadata).
+///
+/// Self-hunk dedup matches chdman: a hunk byte-identical to an **earlier written** hunk is stored
+/// as a `COMPRESSION_SELF` reference (keyed by the whole-hunk crc16 + sha1, first occurrence wins)
+/// instead of being re-compressed. Parent-hunk refs are not yet supported (no-parent only). The
+/// codec must have an encoder (`init_encoder`).
+///
+/// This is the single-codec convenience over [`write_raw`]; it is exactly `write_raw(.., &[codec])`.
+pub fn write_raw_compressed<W: Write + Seek>(
+    out: &mut W,
+    data: &[u8],
+    hunk_bytes: u32,
+    unit_bytes: u32,
+    codec: CodecType,
+) -> Result<()> {
+    write_raw(out, data, hunk_bytes, unit_bytes, &[codec])
+}
+
+/// Write a complete **compressed** V5 CHD using a codec **list** (1..=4 codecs), intended to be
+/// byte-identical to `chdman createraw -c <c0[,c1[,c2[,c3]]]>`.
+///
+/// Per hunk it reproduces MAME's `chd_compressor_group::find_best_compressor` (`chdcodec.cpp:737`):
+/// it tries every codec in `codecs` **in slot order**, keeping the result that is **strictly
+/// smaller** than the current best (so ties go to the earlier slot), with the baseline being
+/// "store uncompressed" at `hunk_bytes`. The winning slot index becomes the map's
+/// `COMPRESSION_TYPE_<slot>` (0..3); if no codec beats `hunk_bytes` the hunk is `COMPRESSION_NONE`.
+/// Self-hunk dedup is applied first (see [`write_raw_compressed`]). The header's `compression[0..4]`
+/// records the FourCCs in slot order (unused slots zero).
+///
+/// `codecs` must be non-empty and at most 4 entries. For the uncompressed (no-codec) format use
+/// [`write_raw_uncompressed`]. Every codec must have an encoder (`init_encoder`).
+pub fn write_raw<W: Write + Seek>(
+    out: &mut W,
+    data: &[u8],
+    hunk_bytes: u32,
+    unit_bytes: u32,
+    codecs: &[CodecType],
+) -> Result<()> {
+    write_raw_inner(
+        out,
+        data,
+        hunk_bytes,
+        unit_bytes,
+        codecs,
+        &[],
+        &mut |_, _, _| {},
+        &|| false,
+    )
+}
+
+/// Core of [`write_raw`] with metadata + progress/cancel hooks (used by the public `hd` create
+/// surface, including `createhd`).
+///
+/// `metadata` (possibly empty) is written **between the header and the compressed hunks** (so the
+/// header's `meta_offset` is `V5_HEADER_SIZE` and the hunks start after the metadata blob), exactly
+/// as chdman lays out a compressed `createhd`. The overall SHA-1 then includes the checksummed
+/// metadata ([`compute_overall_sha1`]).
+///
+/// `progress(bytes_done, bytes_total, compressed_bytes_so_far)` is invoked once per hunk (before
+/// processing it) and once more at the end; `cancel()` is polled before each hunk and, if it
+/// returns true, the function returns [`Error::Cancelled`] **before any bytes are written to
+/// `out`** — the output is assembled in memory and only flushed after the hunk loop, so a
+/// cancelled `out` is left untouched. The byte output is independent of the callbacks.
+pub(crate) fn write_raw_inner<W: Write + Seek>(
+    out: &mut W,
+    data: &[u8],
+    hunk_bytes: u32,
+    unit_bytes: u32,
+    codecs: &[CodecType],
+    metadata: &[MetaEntry],
+    progress: &mut dyn FnMut(u64, u64, u64),
+    cancel: &dyn Fn() -> bool,
+) -> Result<()> {
+    if hunk_bytes == 0 || unit_bytes == 0 || hunk_bytes % unit_bytes != 0 {
+        return Err(Error::InvalidParameter);
+    }
+    if codecs.is_empty() || codecs.len() > 4 {
+        return Err(Error::InvalidParameter);
+    }
+
+    // metadata (if any) sits right after the header; hunks start after it.
+    let meta_blob = build_metadata_blob(metadata, V5_HEADER_SIZE as u64);
+    let meta_offset = if meta_blob.is_empty() {
+        0u64
+    } else {
+        V5_HEADER_SIZE as u64
+    };
+    let data_start = V5_HEADER_SIZE as u64 + meta_blob.len() as u64;
+
+    let logical_bytes = data.len() as u64;
+    let hunk_bytes_u64 = hunk_bytes as u64;
+    let hunk_count = round_up(logical_bytes, hunk_bytes_u64) / hunk_bytes_u64;
+
+    let mut encoders: Vec<Box<dyn CompressionEncoder>> = Vec::with_capacity(codecs.len());
+    for &c in codecs {
+        encoders.push(c.init_encoder(hunk_bytes)?);
+    }
+
+    let mut data_stream: Vec<u8> = Vec::new();
+    let mut rawmap = vec![0u8; hunk_count as usize * 12];
+    let mut hunk_buf = vec![0u8; hunk_bytes as usize];
+    let mut comp_buf = vec![0u8; hunk_bytes as usize];
+    let mut best_buf = vec![0u8; hunk_bytes as usize];
+    // self-hunk map: (whole-hunk crc16, sha1) -> the first hunk number with that data.
+    let mut self_map: HashMap<(u16, [u8; 20]), u32> = HashMap::new();
+
+    for i in 0..hunk_count {
+        if cancel() {
+            return Err(Error::Cancelled);
+        }
+        progress(
+            (i * hunk_bytes_u64).min(logical_bytes),
+            logical_bytes,
+            data_stream.len() as u64,
+        );
+
+        // assemble the hunk (zero-padded past the logical end)
+        let start = (i * hunk_bytes_u64) as usize;
+        let end = ((i + 1) * hunk_bytes_u64).min(logical_bytes) as usize;
+        hunk_buf[..end - start].copy_from_slice(&data[start..end]);
+        for b in &mut hunk_buf[end - start..] {
+            *b = 0;
+        }
+
+        let crc = crate::block_hash::CRC16.checksum(&hunk_buf);
+        let sha1 = sha1_digest(&hunk_buf);
+        let base = i as usize * 12;
+
+        // SELF: identical to an earlier written hunk -> reference it, store nothing.
+        if let Some(&refhunk) = self_map.get(&(crc, sha1)) {
+            rawmap[base] = COMPRESSION_SELF;
+            // complen (1..4) = 0, crc (10..12) = 0 (rawmap is zero-initialized).
+            put_u48be(&mut rawmap[base + 4..base + 10], refhunk as u64);
+            continue;
+        }
+
+        // find_best_compressor: baseline is "store NONE" at hunk_bytes; a codec wins only if it
+        // is strictly smaller than the current best, earliest slot first.
+        let mut best_type = COMPRESSION_NONE;
+        let mut best_len = hunk_bytes;
+        for (slot, enc) in encoders.iter_mut().enumerate() {
+            if let Ok(n) = enc.compress(&hunk_buf, &mut comp_buf) {
+                let n = n as u32;
+                if n < best_len {
+                    best_len = n;
+                    best_type = slot as u8; // COMPRESSION_TYPE_<slot> (0..3)
+                    best_buf[..n as usize].copy_from_slice(&comp_buf[..n as usize]);
+                }
+            }
+        }
+
+        let offset = data_start + data_stream.len() as u64;
+        let (type_byte, complen): (u8, u32) = if best_type == COMPRESSION_NONE {
+            data_stream.extend_from_slice(&hunk_buf);
+            (COMPRESSION_NONE, hunk_bytes)
+        } else {
+            data_stream.extend_from_slice(&best_buf[..best_len as usize]);
+            (best_type, best_len)
+        };
+
+        rawmap[base] = type_byte;
+        rawmap[base + 1] = (complen >> 16) as u8;
+        rawmap[base + 2] = (complen >> 8) as u8;
+        rawmap[base + 3] = complen as u8;
+        put_u48be(&mut rawmap[base + 4..base + 10], offset);
+        rawmap[base + 10] = (crc >> 8) as u8;
+        rawmap[base + 11] = crc as u8;
+
+        self_map.insert((crc, sha1), i as u32);
+    }
+
+    progress(logical_bytes, logical_bytes, data_stream.len() as u64);
+
+    let map_offset = data_start + data_stream.len() as u64;
+    let stored_map = compress_v5_map(&rawmap, hunk_count as u32, hunk_bytes, unit_bytes);
+
+    let raw_sha1 = sha1_digest(data);
+    let overall_sha1 = compute_overall_sha1(&raw_sha1, metadata);
+
+    // --- header ---
+    let mut hdr = [0u8; V5_HEADER_SIZE as usize];
+    hdr[0..8].copy_from_slice(CHD_MAGIC);
+    hdr[8..12].copy_from_slice(&V5_HEADER_SIZE.to_be_bytes());
+    hdr[12..16].copy_from_slice(&5u32.to_be_bytes());
+    // compression[0..4]: one u32 FourCC per slot, in order; unused slots stay zero.
+    for (slot, &c) in codecs.iter().enumerate() {
+        hdr[16 + slot * 4..16 + slot * 4 + 4].copy_from_slice(&(c as u32).to_be_bytes());
+    }
+    hdr[32..40].copy_from_slice(&logical_bytes.to_be_bytes());
+    hdr[40..48].copy_from_slice(&map_offset.to_be_bytes());
+    hdr[48..56].copy_from_slice(&meta_offset.to_be_bytes());
+    hdr[56..60].copy_from_slice(&hunk_bytes.to_be_bytes());
+    hdr[60..64].copy_from_slice(&unit_bytes.to_be_bytes());
+    hdr[64..84].copy_from_slice(&raw_sha1);
+    hdr[84..104].copy_from_slice(&overall_sha1);
+    // parent_sha1 (104..124) = 0
+
+    out.write_all(&hdr)?;
+    out.write_all(&meta_blob)?;
+    out.write_all(&data_stream)?;
+    out.write_all(&stored_map)?;
+    Ok(())
+}
+
+/// Port of `chd_file::compress_v5_map` (`chd.cpp:2071`). Compresses the in-memory `rawmap`
+/// (`hunk_count × 12` bytes: `[type, complen:u24, offset:u48, crc16:u16]`) into the stored V5
+/// map: a 16-byte header followed by the RLE+Huffman bitstream. Byte-identical to chdman.
+pub(crate) fn compress_v5_map(
+    rawmap: &[u8],
+    hunk_count: u32,
+    hunk_bytes: u32,
+    unit_bytes: u32,
+) -> Vec<u8> {
+    let mapcrc = crate::block_hash::CRC16.checksum(&rawmap[..(hunk_count as usize) * 12]);
+
+    // --- RLE-compress the compression types, feeding a 16-code / 8-bit Huffman histogram ---
+    let mut compression_rle: Vec<u8> = Vec::with_capacity(hunk_count as usize);
+    let mut encoder = HuffEncoder::new(16, 8);
+    encoder.histo_reset();
+
+    let mut max_self: u32 = 0;
+    let mut last_self: u32 = 0;
+    let mut max_parent: u64 = 0;
+    let mut last_parent: u64 = 0;
+    let mut max_complen: u32 = 0;
+    let mut lastcomp: u8 = 0;
+    let mut count: i64 = 0;
+    let units_per_hunk = (hunk_bytes / unit_bytes) as u64;
+
+    for hunknum in 0..hunk_count {
+        let base = hunknum as usize * 12;
+        let mut curcomp = rawmap[base];
+
+        if curcomp == COMPRESSION_SELF {
+            let refhunk = get_u48be(&rawmap[base + 4..]) as u32;
+            if refhunk == last_self {
+                curcomp = COMPRESSION_SELF_0;
+            } else if refhunk == last_self + 1 {
+                curcomp = COMPRESSION_SELF_1;
+            } else {
+                max_self = max_self.max(refhunk);
+            }
+            last_self = refhunk;
+        } else if curcomp == COMPRESSION_PARENT {
+            let refunit = get_u48be(&rawmap[base + 4..]);
+            if refunit == (hunknum as u64 * hunk_bytes as u64) / unit_bytes as u64 {
+                curcomp = COMPRESSION_PARENT_SELF;
+            } else if refunit == last_parent {
+                curcomp = COMPRESSION_PARENT_0;
+            } else if refunit == last_parent + units_per_hunk {
+                curcomp = COMPRESSION_PARENT_1;
+            } else {
+                max_parent = max_parent.max(refunit);
+            }
+            last_parent = refunit;
+        } else {
+            max_complen = max_complen.max(get_u24be(&rawmap[base + 1..]));
+        }
+
+        if curcomp == lastcomp {
+            count += 1;
+        }
+        if curcomp != lastcomp || hunknum == hunk_count - 1 {
+            while count != 0 {
+                if count < 3 {
+                    encoder.histo_one(lastcomp as u32);
+                    compression_rle.push(lastcomp);
+                    count -= 1;
+                } else if count <= 3 + 15 {
+                    encoder.histo_one(COMPRESSION_RLE_SMALL as u32);
+                    compression_rle.push(COMPRESSION_RLE_SMALL);
+                    encoder.histo_one((count - 3) as u32);
+                    compression_rle.push((count - 3) as u8);
+                    count = 0;
+                } else {
+                    let this_count = count.min(3 + 16 + 255);
+                    encoder.histo_one(COMPRESSION_RLE_LARGE as u32);
+                    compression_rle.push(COMPRESSION_RLE_LARGE);
+                    encoder.histo_one(((this_count - 3 - 16) >> 4) as u32);
+                    compression_rle.push(((this_count - 3 - 16) >> 4) as u8);
+                    encoder.histo_one(((this_count - 3 - 16) & 15) as u32);
+                    compression_rle.push(((this_count - 3 - 16) & 15) as u8);
+                    count -= this_count;
+                }
+            }
+            if curcomp != lastcomp {
+                encoder.histo_one(curcomp as u32);
+                compression_rle.push(curcomp);
+                lastcomp = curcomp;
+            }
+        }
+    }
+
+    let lengthbits = bits_for_value(max_complen as u64);
+    let selfbits = bits_for_value(max_self as u64);
+    let parentbits = bits_for_value(max_parent);
+
+    // --- compute + export the tree, then encode the RLE token stream ---
+    let mut bitbuf = BitWriter::new();
+    encoder.compute_tree_from_histo().expect("map huffman tree");
+    encoder.export_tree_rle(&mut bitbuf);
+    for &b in &compression_rle {
+        encoder.encode_one(&mut bitbuf, b as u32);
+    }
+
+    // --- per-entry extra data (re-walking the RLE stream to recover each hunk's type) ---
+    let mut lastcomp2: u8 = 0;
+    let mut count2: i64 = 0;
+    let mut src = 0usize;
+    let mut firstoffs: u64 = 0;
+    for hunknum in 0..hunk_count {
+        let base = hunknum as usize * 12;
+        let length = get_u24be(&rawmap[base + 1..]);
+        let offset = get_u48be(&rawmap[base + 4..]);
+        let crc = get_u16be(&rawmap[base + 10..]);
+
+        if count2 == 0 {
+            let val = compression_rle[src];
+            src += 1;
+            if val == COMPRESSION_RLE_SMALL {
+                count2 = 2 + compression_rle[src] as i64;
+                src += 1;
+            } else if val == COMPRESSION_RLE_LARGE {
+                count2 = 2 + 16 + ((compression_rle[src] as i64) << 4);
+                src += 1;
+                count2 += compression_rle[src] as i64;
+                src += 1;
+            } else {
+                lastcomp2 = val;
+            }
+        } else {
+            count2 -= 1;
+        }
+
+        match lastcomp2 {
+            0..=3 => {
+                bitbuf.write(length, lengthbits as i32);
+                bitbuf.write(crc as u32, 16);
+                if firstoffs == 0 {
+                    firstoffs = offset;
+                }
+            }
+            COMPRESSION_NONE => {
+                bitbuf.write(crc as u32, 16);
+                if firstoffs == 0 {
+                    firstoffs = offset;
+                }
+            }
+            COMPRESSION_SELF => {
+                bitbuf.write(offset as u32, selfbits as i32);
+            }
+            COMPRESSION_PARENT => {
+                bitbuf.write(offset as u32, parentbits as i32);
+            }
+            // compact pseudo-codecs carry no extra data
+            COMPRESSION_SELF_0
+            | COMPRESSION_SELF_1
+            | COMPRESSION_PARENT_SELF
+            | COMPRESSION_PARENT_0
+            | COMPRESSION_PARENT_1 => {}
+            _ => {}
+        }
+    }
+
+    let bitstream = bitbuf.flush();
+    let complen = bitstream.len() as u32;
+
+    let mut out = vec![0u8; 16 + bitstream.len()];
+    out[0..4].copy_from_slice(&complen.to_be_bytes());
+    put_u48be(&mut out[4..10], firstoffs);
+    out[10..12].copy_from_slice(&mapcrc.to_be_bytes());
+    out[12] = lengthbits;
+    out[13] = selfbits;
+    out[14] = parentbits;
+    out[15] = 0;
+    out[16..].copy_from_slice(&bitstream);
+    out
+}
+
+/// Write a complete **uncompressed** (compression = none) V5 CHD containing `data`,
+/// byte-identical to `chdman createraw -c none -hs <hunk_bytes> -us <unit_bytes>`.
+///
+/// Layout (verified against chdman 0.288): 124-byte header, then a `hunk_count × 4`-byte map
+/// (each entry = the hunk's file offset divided by `hunk_bytes`), zero-padding up to the next
+/// `hunk_bytes` boundary, then the raw hunks (the final hunk zero-padded to `hunk_bytes`).
+/// chdman leaves the SHA-1 fields zero for uncompressed CHDs and does not verify them.
+pub fn write_raw_uncompressed<W: Write + Seek>(
+    out: &mut W,
+    data: &[u8],
+    hunk_bytes: u32,
+    unit_bytes: u32,
+) -> Result<()> {
+    write_uncompressed_inner(out, data, hunk_bytes, unit_bytes, &[])
+}
+
+/// Core of [`write_raw_uncompressed`] with metadata support (used by `createhd -c none`).
+///
+/// `metadata` (possibly empty) is written **after the map and before the data** (so the header's
+/// `meta_offset` is `V5_HEADER_SIZE + map_size`, and `data_start` rounds up past the metadata to
+/// the next hunk boundary), exactly as chdman lays out an uncompressed `createhd`. The SHA-1 fields
+/// stay zero (chdman computes no SHA-1 for uncompressed CHDs).
+pub(crate) fn write_uncompressed_inner<W: Write + Seek>(
+    out: &mut W,
+    data: &[u8],
+    hunk_bytes: u32,
+    unit_bytes: u32,
+    metadata: &[MetaEntry],
+) -> Result<()> {
+    if hunk_bytes == 0 || unit_bytes == 0 || hunk_bytes % unit_bytes != 0 {
+        return Err(Error::InvalidParameter);
+    }
+
+    let logical_bytes = data.len() as u64;
+    let hunk_bytes_u64 = hunk_bytes as u64;
+    let hunk_count = round_up(logical_bytes, hunk_bytes_u64) / hunk_bytes_u64;
+    let map_offset: u64 = V5_HEADER_SIZE as u64;
+    let map_size = hunk_count * 4;
+
+    // metadata sits right after the map; the data rounds up past it to a hunk boundary.
+    let meta_start = map_offset + map_size;
+    let meta_blob = build_metadata_blob(metadata, meta_start);
+    let meta_offset = if meta_blob.is_empty() { 0 } else { meta_start };
+    let data_start = round_up(meta_start + meta_blob.len() as u64, hunk_bytes_u64);
+
+    // --- header (124 bytes, big-endian) ---
+    let mut hdr = [0u8; V5_HEADER_SIZE as usize];
+    hdr[0..8].copy_from_slice(CHD_MAGIC);
+    hdr[8..12].copy_from_slice(&V5_HEADER_SIZE.to_be_bytes());
+    hdr[12..16].copy_from_slice(&5u32.to_be_bytes());
+    // compression[4] = 0 (none) — already zero
+    hdr[32..40].copy_from_slice(&logical_bytes.to_be_bytes());
+    hdr[40..48].copy_from_slice(&map_offset.to_be_bytes());
+    hdr[48..56].copy_from_slice(&meta_offset.to_be_bytes());
+    hdr[56..60].copy_from_slice(&hunk_bytes.to_be_bytes());
+    hdr[60..64].copy_from_slice(&unit_bytes.to_be_bytes());
+    // raw_sha1 (64), sha1 (84), parent_sha1 (104) = 0 for uncompressed CHDs
+    out.write_all(&hdr)?;
+
+    // --- map: each entry = (data_start + i*hunk_bytes) / hunk_bytes ---
+    let base = (data_start / hunk_bytes_u64) as u32;
+    for i in 0..hunk_count as u32 {
+        out.write_all(&(base + i).to_be_bytes())?;
+    }
+
+    // --- metadata blob, then pad up to the data start ---
+    out.write_all(&meta_blob)?;
+    let pad = data_start - (meta_start + meta_blob.len() as u64);
+    if pad > 0 {
+        out.write_all(&vec![0u8; pad as usize])?;
+    }
+
+    // --- raw hunks (zero-pad the final hunk) ---
+    for i in 0..hunk_count {
+        let start = (i * hunk_bytes_u64) as usize;
+        let end = ((i + 1) * hunk_bytes_u64).min(logical_bytes) as usize;
+        out.write_all(&data[start..end])?;
+        let short = hunk_bytes as usize - (end - start);
+        if short > 0 {
+            out.write_all(&vec![0u8; short])?;
+        }
+    }
+
+    Ok(())
+}

--- a/docs/chdman-mapping.md
+++ b/docs/chdman-mapping.md
@@ -1,0 +1,44 @@
+# chdman → chd-rs / rchdman command mapping
+
+How each `chdman` 0.288 sub-command maps onto chd-rs's library API and the `rchdman` CLI. Unless
+noted, the **created CHD is byte-for-byte identical to chdman** (the project's verification bar; see
+[libchdman-parity.md](libchdman-parity.md)). Library create/extract functions live in per-format
+modules and take `progress: &mut dyn FnMut(CompressionProgress)` + `cancel: &dyn Fn() -> bool`
+callbacks (extract takes `&mut dyn FnMut(u64)`); they need the `write` feature.
+
+| chdman | rchdman | chd-rs library | notes |
+| --- | --- | --- | --- |
+| `info` | `info` | `Chd::info() -> ChdInfo` | read-side; header + metadata tags + track/type detection. |
+| `verify` | `verify` | `Chd::verify() -> VerifyResult` | `verify` feature (also via `write`). Recomputes raw + overall SHA-1. Uncompressed CHDs carry no checksum → error. |
+| `dumpmeta` | `dumpmeta` | `Chd::metadata_refs()` / `metadata()` | read a metadata record by `(tag, index)`. |
+| `createraw` | `createraw` | `hd::create_raw_from_path` / `create_raw_from_reader` | no metadata. `-op <parent>` → `hd::create_raw_from_path_with_parent` (compressed child; `COMPRESSION_PARENT` refs). |
+| `extractraw` | `extractraw` | `hd::extract_to_path` / `extract_to_writer` | streams the logical bytes (last-hunk padding trimmed). |
+| `createhd` | `createhd` | `hd::create_from_path` / `create_from_reader` | writes a `GDDD` geometry record (auto via `compute_chs`, or `HdCreateOptions.geometry`) + optional `IDNT`. |
+| `extracthd` | `extractraw` | `hd::extract_to_path` | an HD CHD's logical bytes are extracted exactly like `extractraw`. |
+| `createcd` | `createcd` | `cd::create_from_cue` / `create_from_gdi` / `create_from_iso` | CUE (single/multi-file BIN), Sega `.gdi` (GD-ROM, `CHGD`), or a flat sector image. `CdCreateOptions.codecs` default `[cdlz, cdzl, cdfl, 0]`. |
+| `extractcd` | `extractcd` | `cd::extract_to_cue` / `extract_to_gdi` | cue/bin or `.gdi` + split track files. `cd::extract_to_iso` / `CdCookedReader` give a single MODE1 track's cooked 2048-byte data (no chdman equivalent → round-trip-verified). |
+| `createdvd` | `createdvd` | `dvd::create_from_iso` / `create_from_reader` | flat 2048-byte sectors + the empty `DVD ` record. |
+| `extractdvd` | `extractdvd` | `dvd::extract_to_iso` / `extract_to_writer` | |
+| `copy` | `copy` | `copy::copy` | recompress / re-hunk, cloning all metadata. |
+| `addmeta` | `addmeta` | `metadata::write_metadata` | in-place edit of an existing CHD's metadata list (`Read + Write + Seek`). chdman only edits *uncompressed* CHDs; chd-rs also handles compressed. |
+| `delmeta` | `delmeta` | `metadata::delete_metadata` | unlinks the record (does not recompute the overall SHA-1, matching chdman). |
+| `listtemplates` | — | — | not implemented (HD templates). |
+| `createld` / `extractld` | — | — | laserdisc / A/V not in scope. |
+
+## Codec mnemonics (`-c`)
+
+`codec::parse_codec_spec("lzma,zlib")` parses a chdman `-c` spec into a `[u32; 4]`. Mnemonics:
+`none`, `zlib`, `zstd`, `lzma`, `huff`, `flac`, `cdzl`, `cdzs`, `cdlz`, `cdfl`, `avhu`. `zstd`/`cdzs`
+need the `write-zstd` feature.
+
+⚠️ **FLAC byte-identity is libm-gated.** `flac`/`cdfl` (and the HD/DVD default sets that include
+`flac`) are byte-identical to a **glibc**-built chdman; against an MSVC/Windows chdman they are
+round-trip-correct but may differ by a few bytes. `cdlz`/`cdzl`/`cdzs`/`zlib`/`lzma`/`zstd`/`huff`
+are byte-identical on every platform.
+
+## Runtime block device
+
+`hd::HdImage` has no direct chdman command — it is the MAME `harddisk_image_device` surface:
+`open` (uncompressed in place), `open_with_diff` / `reopen_diff` (an uncompressed diff over a
+compressed parent), and `read_sector` / `write_sector`. The diff format is the one chdman's
+`extracthd -ip <parent>` reads back.

--- a/docs/codec-ports/README.md
+++ b/docs/codec-ports/README.md
@@ -1,0 +1,114 @@
+# CHD codec ports — bit-exact pure-Rust encoders
+
+This directory holds **handoff specs** for the standalone Rust crates needed to give
+[chd-rs](../../PARITY_PLAN.md) bit-for-bit CHD *write* support without any C toolchain.
+
+Each crate is **independently useful** — anyone wanting byte-identical 7-zip LZMA,
+libFLAC, or libzstd output in Rust can depend on it. chd-rs is just the first consumer.
+
+## Why these exist
+
+A CHD file's exact bytes are decided hunk-by-hunk by (1) each codec's exact compressed
+bitstream and (2) which codec "wins" each hunk (smallest output). So **bit-for-bit parity
+with `chdman` requires every encoder to emit output byte-identical to the exact C library
+MAME bundles, at the exact settings CHD uses.** No existing Rust crate does this for LZMA,
+FLAC, or zstd. These specs are the projects that close that gap. See
+[PARITY_PLAN.md §11](../../PARITY_PLAN.md) for the full rationale.
+
+## The projects — BUILT (sibling repos under `../`)
+
+All four crates now exist and are bit-exact-verified against their C oracle. Status as of
+2026-06-20:
+
+| Crate | Spec | Targets | libchdman-rs (MAME 0.288) bundles | Aligned? | State |
+| --- | --- | --- | --- | --- | --- |
+| `lzma-sdk-rs` v0.2301.0 | [lzma-sdk-rs.md](lzma-sdk-rs.md) | LZMA SDK **23.01** | 23.01 | ✅ | byte-exact vs `LzmaEnc_MemEncode` across corpus incl. CHD hunk sizes; encoder+decoder; zero-dep |
+| `libflac-rs` v0.143.0 | [libflac-rs.md](libflac-rs.md) | libFLAC **1.4.3** | 1.4.3 | ✅ | byte-exact for CHD config + all levels/depths + decoder + Ogg; has `encode_frames()`; zero-dep. ⚠️ float parity validated vs **glibc** libm |
+| `libzstd-bitexact-rs` **v0.155.0** | [zstd-bitexact.md](zstd-bitexact.md) | zstd **1.5.5** | **1.5.5** | ✅ | full bit-exact zstd (all 22 levels + dict + streaming + MT + LDM), now **aligned to the 1.5.5 chdman uses**; published to crates.io |
+| `zlib-bitexact-rs` **v0.131.0** | [zlib-bitexact.md](zlib-bitexact.md) · [integration](zlib-bitexact-integration.md) | stock zlib **1.3.1** | **1.3.1** | ✅ | byte-exact vs stock zlib 1.3.1 `deflate` at the CHD config (level 9, raw, memLevel 8); encode-only; zero-dep; **published to crates.io** |
+
+### ✅ zstd drift RESOLVED (2026-06-19)
+
+`libzstd-bitexact-rs` **0.155.0** is byte-exact with **zstd 1.5.5** (chdman's version, confirmed
+via `../libchdman-rs/deps/mame/3rdparty/zstd`) and published to crates.io. The 0.157.x line of
+the same crate stays on zstd 1.5.7 for consumers tracking current upstream.
+
+**chd-rs wiring:** pin `libzstd-bitexact-rs = "=0.155"` (a bare add resolves to 0.157.x). chdman
+compresses each hunk at level 22 with an **unknown pledged size**, so use
+`StreamEncoder::new(22).finish(input, &mut out)` — **not** `with_pledged_src_size`, which
+downsizes `windowLog` (27) and changes the bytes. `compress(input, 22)` is byte-identical for a
+single `e_end`. For `cdzs`, the same encoder applies per sub-stream. ⚠️ A round-trip test cannot
+catch encoder drift (zstd decode is format-stable) — guard byte-identity by comparing
+*compressed* bytes to a zstd-1.5.5 golden. Deferred edge cases in the crate (non-canonical
+`nbSeq==0` reject, large-dict suffix truncation, 4 GiB ceiling, ≤8-byte CDict, large-window LDM
+*with* a dict) **do not touch chdman's no-dict, hunk-sized, level-22 path**.
+
+> **Crate naming note:** the spec file is still `zstd-bitexact.md`; the shipped crate is
+> `libzstd-bitexact-rs` (matches the `lib*-rs` family + the libchdman-rs naming).
+
+### ✅ zlib DONE (2026-06-20)
+
+`zlib-bitexact-rs` **0.131.0** is a pure-Rust port of stock zlib 1.3.1 `deflate.c`/`trees.c`,
+byte-identical to the C `deflate()` at the CHD config (level 9, raw `-15`, memLevel 8,
+`Z_DEFAULT_STRATEGY`, one `Z_FINISH`), verified against the vendored zlib 1.3.1 C oracle and
+**published to crates.io**. This closes the last default-codec gap: `zlib-rs` 0.4.2 (the old
+backend) is a from-scratch, zlib-ng-quality deflate that is **~2 bytes smaller** than stock zlib
+1.3.1 (proven by `chdman_compat::zlib_bit_exact_vs_chdman`: 1523 vs 1525). zlib is the **HD
+default** *and* used by every **CD** codec (subcode + `cdzl`), so this was the highest-priority
+remaining port.
+
+**chd-rs wiring:** ✅ **done** (2026-06-20, per
+**[zlib-bitexact-integration.md](zlib-bitexact-integration.md)**) — `zlib-bitexact-rs` added under
+`write`, `compression/zlib.rs`'s `ZlibEncoder` swapped from `flate2::Compress` to
+`zlib_bitexact_rs::deflate_raw` (decoder stays flate2), and `chdman_compat::zlib_bit_exact_vs_chdman`
+un-ignored → **passes** against chdman 0.288, with a full `-c zlib` CHD byte-identical end-to-end.
+
+### In-tree (no separate crate)
+
+- **MAME static Huffman** (V5 map + `huff` codec) → small, CHD/MAME-specific, BSD-3. Lives
+  **in-tree** in chd-rs (`huffman_encode.rs`, alongside the decoder). ✅ **done & bit-exact vs
+  chdman 0.288.** Split into a `mame-huffman` crate only if another consumer appears.
+
+## Shared rules for all three ports
+
+1. **Success criterion = byte-identical to the C reference.** Not "valid output," not
+   "decompresses correctly" — the exact same bytes as the bundled C library at the exact
+   pinned version and settings. A single differing byte fails.
+
+2. **Pin the version.** Reproduce the *specific* version MAME 0.288 bundles (LZMA SDK
+   23.01 / libFLAC 1.4.3 / libzstd 1.5.5). These libraries change their output across
+   versions; the port targets one frozen version. State it in the crate's docs.
+
+3. **Differential testing is the whole game.** Each crate ships a dev-only harness that
+   builds the C reference (from `../mame/3rdparty/<lib>` or pinned upstream) into a tiny
+   "gold vector" generator, runs a corpus through both, and asserts `rust_out == c_out`
+   byte-for-byte. Corpus must include: all-zeros, highly-repetitive, random/incompressible,
+   real CHD hunk dumps, and the format's edge cases. CI gates on zero mismatches. The C
+   reference is dev-local (like libchdman-rs's `chdman_compat_tests`); downstream consumers
+   never need a C toolchain.
+
+4. **Portable path only.** Port the reference C scalar path, never the SIMD/intrinsic
+   variants (`*_intrin_*`, `*_asm_*`) — they can differ from the scalar path (esp. FLAC
+   float autocorrelation) and would break bit-exactness. Optimize *after* parity holds, and
+   only with SIMD proven bit-identical to the scalar path.
+
+5. **Permissive licensing.** All three upstreams are public-domain or BSD-3. Carry the
+   original copyright + a `// Ported from <lib> <version> (<license>)` note in each module,
+   and publish the crate BSD-3-Clause. Do **not** pull from any GPL/LGPL file (FLAC's CLI
+   tools, zstd's `COPYING`) — use only the library sources, which are BSD-3.
+
+6. **No dependency on chd-rs.** These are general-purpose codec crates. chd-rs depends on
+   them, not the reverse.
+
+## Recommended build order
+
+1. **`lzma-sdk-rs`** — cleanest (public domain, integer-only range coder, self-contained,
+   no float hazards). Best first port; proves the differential-testing methodology.
+2. **`libflac-rs`** — medium-high; the float arithmetic (windows, autocorrelation, LPC
+   quantization `lround`) is the main risk. Needed for DVD default + CD `cdfl`.
+3. **`zstd-bitexact`** — highest LOC; the level-22 optimal parser + FSE/Huffman table
+   determinism. Per-hunk usage removes dictionaries/LDM/MT/streaming, which helps.
+
+chd-rs's writer core (header, V5 map encoder, metadata, SHA-1, compressor driver) can be
+built **in parallel** using `none`/`zlib`/`huff` first (see PARITY_PLAN.md M0–M1), so the
+codec ports are not a hard blocker for early progress.

--- a/docs/codec-ports/libflac-rs.md
+++ b/docs/codec-ports/libflac-rs.md
@@ -1,0 +1,163 @@
+# Handoff: `libflac-rs` — bit-exact libFLAC encoder in Rust
+
+> Working name. `flacenc` (the existing pure-Rust encoder) is taken and is **NOT
+> byte-identical to libFLAC** — that's exactly why this project exists. Pick a name that
+> signals bit-exactness (e.g. `libflac-rs`, `flac-bitexact`).
+
+## 1. Goal & success criterion
+
+A pure-Rust port of the **libFLAC 1.4.3 encoder** whose frame output is **byte-identical**
+to libFLAC at the settings CHD uses. This is the **trickiest** of the three ports because
+the encoder makes decisions in **floating point** (windows, autocorrelation, LPC
+quantization) where rounding must match the C reference exactly.
+
+**Done =** for every PCM input in the corpus, the encoded FLAC frames (STREAMINFO/seektable
+stripped, as CHD does) are byte-identical to MAME's `flac_encoder` output.
+
+## 2. Provenance & license
+
+- Upstream: libFLAC **1.4.3** (Xiph.Org), vendored at `../mame/3rdparty/flac/src/libFLAC/`.
+- License: **BSD-3-Clause** — every `src/libFLAC/*.c` carries the Xiph BSD-3 header
+  (`stream_encoder.c:1`, © 2000-2009 Josh Coalson, © 2011-2023 Xiph.Org). The
+  `COPYING.GPL`/`COPYING.LGPL` files cover only the **CLI tools**, not the library — do not
+  read or port from those. Publish the port **BSD-3-Clause**, retaining the Xiph copyright.
+
+## 3. Source files to port (encoder, portable path only)
+
+| C file | LOC | Role |
+| --- | --- | --- |
+| `stream_encoder.c` | 4738 | Orchestrator: frame/subframe selection, level presets, partition search |
+| `lpc.c` | 1629 | Windowing, autocorrelation, Levinson-Durbin, quantization, residual |
+| `fixed.c` | 667 | Fixed predictors (orders 0–4), best-order selection |
+| `bitwriter.c` | 955 | Bit I/O, CRC-8/CRC-16 |
+| `stream_encoder_framing.c` | 594 | Frame header/footer + (stripped) STREAMINFO synthesis |
+| `window.c` | 308 | Apodization windows (Tukey, `subdivide_tukey`) |
+| `crc.c` | 436 | CRC-8 (header), CRC-16 (footer) |
+| `format.c` | 608 | Header/validation constants |
+| `memory.c` | 219 | Allocation — replace with Rust |
+| `md5.c` | 517 | **Skip** — CHD disables MD5 |
+
+**Omit every `*_intrin_*` / `*_asm_*` and the `deduplication/*_intrin_*` autocorrelation
+variants.** Port only the scalar reference paths (`lpc.c:133` autocorrelation loop, etc.).
+SIMD float paths use 24-bit intermediates and **diverge** from the scalar `double` path.
+
+## 4. Exact settings CHD uses (`flac.cpp:77`, `chdcodec.cpp`)
+
+```c
+set_verify(false); /* md5 off */ set_compression_level(8);
+set_channels(2); set_bits_per_sample(16); set_sample_rate(44100);
+set_total_samples_estimate(0); set_streamable_subset(false);
+set_blocksize(m_block_size);   // per-hunk, see below
+```
+
+**Level-8 preset** (`stream_encoder.c:124`, last row):
+```
+do_mid_side=true, loose_mid_side=false, max_lpc_order=12, qlp_coeff_precision=0(auto),
+do_qlp_coeff_prec_search=false, do_escape_coding=false, do_exhaustive_model_search=false,
+min_residual_partition_order=0, max_residual_partition_order=6,
+rice_parameter_search_dist=0, apodization="subdivide_tukey(3)"
+```
+
+**Block size** (`chdcodec.cpp:1520`): `blocksize(bytes) = bytes/4`, halved while `>2048`
+→ typically **2048** samples. Raw FLAC hunk: `bytes = hunk_bytes`. CD FLAC:
+`bytes = frames_in_hunk * 2048` (`chdcodec.cpp:1602`).
+
+**Raw framing**: CHD strips STREAMINFO/seektable (`flac.cpp:72,263` — `m_strip_metadata`,
+skip leading metadata via `m_ignore_bytes`). The CHD raw-FLAC codec also prepends a single
+**endian flag byte** `'L'`/`'B'` (`chdcodec.cpp:503`) and encodes both little- and
+big-endian framings, keeping the smaller (`chdcodec.cpp:1498`). For CD, audio → FLAC and the
+96-byte subcode → zlib deflate, split per `chdcodec.cpp:1634`.
+
+## 5. Suggested Rust module layout
+
+```
+libflac-rs/
+  src/
+    bitwriter.rs    // bit packing + CRC-8/CRC-16 (bitwriter.c, crc.c)
+    window.rs       // tukey + subdivide_tukey(3); EXACT float constants / cosf
+    lpc/
+      autocorr.rs   // double-precision dot products (scalar path only)
+      levinson.rs   // Levinson-Durbin (double); reflection-coeff division
+      quantize.rs   // qlp quantization with lround-equivalent + error feedback
+      residual.rs   // FIR residual filter (16-bit + wide overflow path)
+    fixed.rs        // fixed predictors 0..4, SSE-free
+    rice.rs         // partition-order search, parameter estimation, Golomb-Rice
+    subframe.rs     // CONSTANT/VERBATIM/FIXED/LPC selection
+    frame.rs        // frame header/footer, mid-side decorrelation
+    encoder.rs      // public API; level-8 preset wiring; per-block process
+  tests/
+    differential.rs // vs MAME flac_encoder gold vectors
+```
+
+## 6. Bit-exactness hazards — FLOAT is the enemy
+
+This is where a careless port silently diverges. Each item must match the C reference
+**bit-for-bit in IEEE-754**:
+
+1. **Apodization windows** (`window.c`): coefficients via `cosf`/`fabsf` (single precision).
+   `cosf` differs across libms by ±1 ULP → different windowed signal → different LPC.
+   **Mitigation:** reproduce the exact float expressions and evaluation order; if Rust's
+   `f32::cos` disagrees with the reference libm, precompute the window tables from the C
+   reference and embed them, or implement the same polynomial. Verify per-coefficient.
+2. **Autocorrelation** (`lpc.c:133`): accumulate in **`double`**, operands promoted from
+   `f32`. Keep the exact loop/accumulation order; never use the SIMD `f32` path.
+3. **Levinson-Durbin** (`lpc.c:176`): reflection coefficient `r /= err` in `double`. Early
+   `if(err == 0.0)` exit. FPU rounding mode (round-to-nearest-even) must hold.
+4. **LPC quantization** (`lpc.c:265`): `q = lround(error); error -= q;` with error feedback.
+   `lround` tie behavior differs: **MSVC = half-away-from-zero, glibc = half-to-even**.
+   Pick the semantics matching the libm the gold vectors are generated with, and implement
+   that explicitly in Rust (don't rely on `f64::round`, which is half-away-from-zero).
+5. **Auto qlp precision** (`lpc.c:~3983`): `min(15, 32 - subframe_bps - ilog2(order))`.
+   Integer, but feeds quantization — get `ilog2` and bps (17 after mid-side) right.
+6. **Rice partition search** (`stream_encoder.c:4089`): integer math, but tie-breaks in
+   choosing partition order and parameter must match (first-best wins). `do_escape_coding`
+   is **false** at level 8 → no raw-bit escape path.
+7. **Mid-side decision** (`stream_encoder.c:3265`): with `loose_mid_side=false`, the
+   per-frame channel-assignment choice (L/R vs M/S vs L/S vs R/S) is by estimated bits —
+   replicate the estimate exactly or the chosen assignment flips.
+8. **`f32` (`FLAC__real`) vs `f64`**: libFLAC stores LPC coeffs as `float` but computes
+   autocorrelation in `double`. Match each variable's type precisely; a stray `f64` where C
+   uses `f32` changes quantization.
+
+## 7. Differential testing
+
+Generate gold via MAME's `flac_encoder` (or libFLAC directly) at level 8, subset off,
+blocksize 2048, 2ch/16-bit/44100, verify off; strip the leading metadata exactly as
+`flac.cpp` does; compare frame bytes. Corpus: silence (→ CONSTANT subframes), full-scale
+±32767, sine sweeps 1 Hz–20 kHz, decorrelated noise (exercises mid-side), and **real 16-bit
+CD audio rips**. Compare in stages: frame header → subframe header → qlp_coeff integers →
+residual/rice → CRC-16. Diff at the first mismatching field to localize float drift.
+
+## 8. Public API
+
+```rust
+pub struct FlacEncoder { /* level-8 preset baked in */ }
+impl FlacEncoder {
+    /// 2ch/16-bit/44100, level 8, subset off, given block size — CHD's config.
+    pub fn new_chd(block_size: u32) -> Self;
+    /// Encode interleaved i16 stereo; returns raw frames (no STREAMINFO/seektable).
+    pub fn encode_interleaved(&mut self, samples: &[i16]) -> Vec<u8>;
+    pub fn finish(self) -> Vec<u8>;
+}
+```
+chd-rs wraps this for both the raw `flac` codec (with the `'L'/'B'` endian byte + both-endian
+trial) and the `cdfl` codec (audio→FLAC, subcode→deflate split).
+
+## 9. Milestones
+
+- **F0** Bitwriter + CRC-8/16; verify frame skeleton bytes.
+- **F1** CONSTANT + VERBATIM + FIXED subframes (no float LPC); byte-exact on silence /
+  simple signals.
+- **F2** Windows + autocorrelation + Levinson + quantization; **the float-parity gate** —
+  byte-exact LPC subframes on sine/noise.
+- **F3** Rice partition search + mid-side; full corpus byte-exact.
+- **F4** CD subcode split + endian-trial wrapper (or leave that to chd-rs); publish.
+
+## 10. Risk / effort
+
+**High.** The codec structure is well-defined and BSD-3, but **floating-point parity is the
+real risk** — windows and `lround` tie-breaking can diverge from the reference libm and are
+tedious to chase. Budget significant time for F2. ~5–7k LOC. Recommend porting **after**
+`lzma-sdk-rs` so the differential-test rig already exists. If float parity proves
+intractable on some platform, the fallback is embedding reference-computed window tables and
+a fixed `lround` policy, validated against the gold libm.

--- a/docs/codec-ports/lzma-sdk-rs.md
+++ b/docs/codec-ports/lzma-sdk-rs.md
@@ -1,0 +1,151 @@
+# Handoff: `lzma-sdk-rs` — bit-exact 7-zip LZMA encoder in Rust
+
+> Working name. `lzma-rs`, `xz2`, `lzma-sys` are taken and **wrap a different encoder**
+> (liblzma/xz) that produces different bytes. Pick a distinct name.
+
+## 1. Goal & success criterion
+
+A pure-Rust port of the **7-zip LZMA SDK 23.01 encoder** whose output is **byte-identical**
+to `LzmaEnc_MemEncode(...)` for the same input and properties. Ship a matching raw decoder
+too, for round-trip self-tests.
+
+**Done =** for every input in the test corpus, `lzma_sdk_rs::encode(input, props)` returns
+the exact bytes the C `LzmaEnc_MemEncode` returns (no LZMA file header, no end marker).
+
+## 2. Provenance & license
+
+- Upstream: 7-zip LZMA SDK **23.01**, vendored at `../mame/3rdparty/lzma/C/`.
+- License: **public domain** — `../mame/3rdparty/lzma/DOC/lzma-sdk.txt:30` ("LZMA SDK is
+  written and placed in the public domain by Igor Pavlov"). Publish the port **BSD-3-Clause**;
+  no attribution is legally required but credit Igor Pavlov as a courtesy.
+- This is the most legally frictionless of the three ports.
+
+## 3. Source files to port (single-threaded encode only)
+
+| C file | LOC | Role |
+| --- | --- | --- |
+| `LzmaEnc.c` / `.h` | 3144 / 83 | Encoder: range coder, optimal parser (`GetOptimum`), prob/state tables, props |
+| `LzFind.c` / `.h` | 1717 / 159 | Match finder: BT4 binary tree, hash chains, window/cyclic buffer |
+| `LzHash.h` | 34 | Hash constants (`kHash2/3Size`, CRC shifts) |
+| `7zTypes.h` | 523 | Types (`UInt32`, `SRes`, error codes) — map to Rust types, mostly discard |
+| `CpuArch.h/.c` | — | LE byte helpers (`SetUi32`) — reimplement in Rust, discard CPU detection |
+| `Alloc.c/.h` | — | Allocator shim — replace with Rust `Vec`/allocations |
+
+**Omit:** `LzFindMt.*` (multithreading — guard `#ifndef Z7_ST`), `Lzma2*`, `Xz*`, `7zDec`,
+`Bcj*`, `Ppmd*`, AES. For tests only: `LzmaDec.c/.h`.
+
+## 4. Exact settings CHD uses (`chdcodec.cpp:1310`)
+
+```c
+LzmaEncProps_Init(&props);
+props.level = 8;
+props.reduceSize = hunkbytes;     // caps the dictionary to the hunk size
+LzmaEncProps_Normalize(&props);
+```
+
+After `LzmaEncProps_Normalize` (`LzmaEnc.c:68`), level 8 yields:
+
+| Field | Value |
+| --- | --- |
+| `dictSize` | `min(1<<26, hunkbytes)` but `>= kReduceMin (4096)` (`LzmaEnc.c:81`) |
+| `lc`, `lp`, `pb` | `3`, `0`, `2` |
+| `algo` | `1` (optimal parser, **not** fast mode) |
+| `fb` (fast bytes) | `64` |
+| `btMode` | `1` (binary tree) |
+| `numHashBytes` | `4` (→ BT4) |
+| `mc` (match cycles / cutValue) | `48` |
+
+Encode call (`chdcodec.cpp:1272`): `LzmaEnc_MemEncode(enc, dest, &len, src, srclen,
+writeEndMark=0, ...)`. Output is the **raw LZMA stream with no 13-byte header and no EOS
+marker**. The 5 decoder props bytes are derived separately via `LzmaEnc_WriteProperties`
+(`decoder_props[0] = (pb*5+lp)*9+lc = 93 = 0x5D`, then LE `dictSize`) — chd-rs reconstructs
+these from the hunk size at decode time; the encoder output does not carry them.
+
+## 5. Suggested Rust module layout
+
+```
+lzma-sdk-rs/
+  src/
+    props.rs        // LzmaEncProps + Init/Normalize; level→params table
+    rangecoder.rs   // RangeEnc: shift-low, encode bit/direct/tree; flush ×5 (LE)
+    state.rs        // 12-state machine + next-state tables; prob model (11-bit, 2048)
+    price.rs        // CProbPrice[512] price tables; GET_PRICE_* macros
+    matchfinder/
+      mod.rs        // CMatchFinder: window, cyclic buffer, read-block
+      bt4.rs        // binary-tree-4 GetMatches; cutValue=48 search + tie-break
+      hash.rs       // 2/3/4-byte rolling CRC hash (LzHash.h constants)
+    optimum.rs      // GetOptimum DP parser (the heart); opt[] table
+    encoder.rs      // public encode(): create→set_props→mem_encode loop
+    decoder.rs      // raw LzmaDec port for round-trip tests (test-only)
+  tests/
+    differential.rs // vs C LzmaEnc_MemEncode gold vectors
+```
+
+## 6. Bit-exactness hazards (verified against the SDK)
+
+1. **Range-coder flush is exactly 5 iterations** of `RangeEnc_ShiftLow` (`LzmaEnc.c:717`),
+   little-endian. Off-by-one here corrupts the tail of every stream.
+2. **Optimal-parser tie-breaks use strict `<`**, not `<=` (`LzmaEnc.c:1361,1406,1465`). On
+   equal price the **first** candidate wins — replicate the comparison operators exactly.
+3. **Match finder init order**: `Init_HighHash` → `Init_LowHash` → `Init_4` (pos starts at
+   **1**) → `ReadBlock` (`LzFind.c:574`). Position must start at 1, hash tables zeroed in
+   that order.
+4. **BT4 search depth = cutValue (48)** and closest-distance tie-break: equal-length matches
+   must return the **smallest distance**. The tree traversal order is part of the contract.
+5. **Probability model is 11-bit** (`kNumBitModelTotalBits=11`, total 2048); price tables
+   `CProbPrice[512]` precomputed at init. Reproduce the rounding in `GET_PRICE_*` exactly.
+6. **State transition tables** (`kLiteral/Match/Rep/ShortRepNextStates`, `LzmaEnc.c:620`)
+   select which prob arrays are used — copy verbatim.
+7. **dictSize reduction** must apply `min(dictSize, reduceSize)` with the `kReduceMin=4096`
+   floor (`LzmaEnc.c:81`) — affects max match distance → match selection.
+8. **No SIMD / no `#ifdef MY_CPU_*`** influence on the single-threaded path; ensure all
+   `Z7_ST` multithread blocks are disabled.
+
+## 7. Differential testing
+
+Gold generator (dev-local, links the vendored C):
+```c
+LzmaEncProps props; LzmaEncProps_Init(&props);
+props.level = 8; props.reduceSize = srclen; LzmaEncProps_Normalize(&props);
+CLzmaEncHandle e = LzmaEnc_Create(&alloc);
+LzmaEnc_SetProps(e, &props);
+SizeT dlen = cap;
+LzmaEnc_MemEncode(e, dst, &dlen, src, srclen, /*writeEndMark=*/0, NULL, &alloc, &alloc);
+// emit dst[0..dlen] as the gold vector for `src`
+```
+Assert `encode(src, props_for(srclen)) == gold` byte-for-byte. Corpus: all-zeros,
+text/repetitive, an executable, random/incompressible, and dumped real CHD hunks at the
+hunk sizes CHD uses (4096, 19584, 65536, …). Also round-trip via the ported decoder.
+
+## 8. Public API (consumed by chd-rs and others)
+
+```rust
+pub struct LzmaProps { pub lc: u8, pub lp: u8, pub pb: u8, pub dict_size: u32,
+                       pub fb: u32, pub mc: u32, /* algo=1, bt4 fixed */ }
+impl LzmaProps {
+    /// chd-rs calls this: level-8 props with dict reduced to `hunk_bytes`.
+    pub fn chd_for_hunk(hunk_bytes: u32) -> Self;
+}
+/// Raw LZMA stream, no 13-byte header, no end marker — matches LzmaEnc_MemEncode.
+pub fn encode(input: &[u8], props: &LzmaProps) -> Vec<u8>;
+/// The 5 decoder property bytes for a given props (LzmaEnc_WriteProperties).
+pub fn decoder_props(props: &LzmaProps) -> [u8; 5];
+#[cfg(any(test, feature = "decode"))]
+pub fn decode_raw(input: &[u8], props: &[u8; 5], out_len: usize) -> Vec<u8>;
+```
+
+## 9. Milestones
+
+- **L0** Range coder + bit/tree/direct encoders; unit-test against hand-computed streams.
+- **L1** Literal-only encoding (force no matches); match against C with a tiny dict.
+- **L2** BT4 match finder + hash; verify match lists equal C's `GetMatches` on fixtures.
+- **L3** Optimal parser (`GetOptimum`); first end-to-end byte-exact streams.
+- **L4** Full corpus byte-exact at all CHD hunk sizes; ported decoder round-trips.
+- **L5** API polish, docs, publish.
+
+## 10. Risk / effort
+
+**Medium.** Integer-only (no float hazards), public-domain, self-contained. The optimal
+parser (`GetOptimum`, ~600 LOC of dense DP) is the hard part; everything else is mechanical.
+Estimate ~3–4k LOC Rust. Highest-confidence of the three ports — **do this one first** to
+establish the differential-test rig the others reuse.

--- a/docs/codec-ports/zlib-bitexact-integration.md
+++ b/docs/codec-ports/zlib-bitexact-integration.md
@@ -1,0 +1,133 @@
+# Integrating `zlib-bitexact-rs` into chd-rs (return handoff)
+
+> ✅ **The port is DONE.** `zlib-bitexact-rs` **0.131.0** is published to crates.io and is
+> byte-identical to stock **zlib 1.3.1** `deflate` at the exact CHD settings. This is the *return*
+> handoff — wire the crate into chd-rs and un-ignore the zlib parity test. The original outgoing
+> spec is [`zlib-bitexact.md`](zlib-bitexact.md).
+
+## What you're integrating
+
+- **Crate:** `zlib-bitexact-rs` v0.131.0 (crates.io) — pure-Rust, **zero runtime deps**,
+  `#![forbid(unsafe_code)]`. Encode-only, raw DEFLATE, one configuration.
+- **API (the entire surface):**
+  ```rust
+  /// Raw DEFLATE (no zlib header, no adler32 trailer), byte-identical to zlib 1.3.1
+  /// deflateInit2(9, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) + a single deflate(Z_FINISH).
+  pub fn deflate_raw(input: &[u8]) -> Vec<u8>;
+  ```
+- **Proof:** byte-for-byte vs the vendored zlib 1.3.1 C oracle across a broad corpus —
+  tiny/boundary sizes, long runs, repeated text, incompressible random (stored blocks), skewed /
+  geometric / Fibonacci distributions (the bit-length-overflow path), multi-block (>16383 symbols),
+  window-sliding (>64 KiB), and CHD hunk sizes (4096 / 2448-multiples / 19584). CI green.
+
+## Precondition — ✅ already verified
+
+chdman/MAME **0.288 bundles zlib 1.3.1** (`ZLIB_VERSION "1.3.1"` in
+`mame/3rdparty/zlib/zlib.h` and `libchdman-rs/deps/mame/3rdparty/zlib/zlib.h`), which is exactly
+what this crate targets. So the bytes should match. If a future chdman bumps its bundled zlib, the
+crate's minor version must be retargeted (the version encodes the upstream: `0.131.x` ⇒ zlib 1.3.1).
+
+## Integration steps
+
+### 1. Add the dependency — `chd-rs/chd-rs/Cargo.toml`
+
+Match the sibling pattern (optional, gated by `write`):
+
+```toml
+[dependencies]
+# published; byte-exact with stock zlib 1.3.1 (the version chdman 0.288 bundles)
+zlib-bitexact-rs = { version = "0.131", optional = true }
+# local-dev alternative against the sibling checkout:
+# zlib-bitexact-rs = { path = "../../zlib-bitexact-rs", optional = true }
+```
+
+Add it to the base `write` feature (zlib is the **HD default** *and* underlies every **CD** codec,
+so it belongs alongside lzma, not behind an optional sub-feature):
+
+```toml
+write = ["std", "dep:lzma-sdk-rs", "dep:zlib-bitexact-rs", "dep:sha1"]
+```
+
+### 2. Swap the encoder — `chd-rs/chd-rs/src/compression/zlib.rs`
+
+Replace the `flate2::Compress`-backed `ZlibEncoder` with `deflate_raw`. **Leave the decoder
+(`ZlibCodec`, flate2 inflate) untouched** — inflate is unambiguous, so flate2/zlib-rs stays for
+reads.
+
+```rust
+#[cfg(feature = "write")]
+pub struct ZlibEncoder; // no engine state needed
+
+#[cfg(feature = "write")]
+impl crate::compression::CodecEncodeImplementation for ZlibEncoder {
+    fn new(_: u32) -> Result<Self> {
+        Ok(ZlibEncoder)
+    }
+
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize> {
+        let compressed = zlib_bitexact_rs::deflate_raw(input);
+        // Codec "loses" if the raw DEFLATE stream doesn't fit the hunk-sized output buffer;
+        // the driver then stores the hunk uncompressed (NONE). Mirrors the old flate2 path.
+        if compressed.len() > output.len() {
+            return Err(Error::CompressionError);
+        }
+        output[..compressed.len()].copy_from_slice(&compressed);
+        Ok(compressed.len())
+    }
+}
+```
+
+Notes:
+- `deflate_raw` always consumes the whole input, so the old `total_in == input.len()` check is
+  implicit; the only failure mode is "doesn't fit", i.e. `compressed.len() > output.len()`.
+- The existing `#[cfg(all(test, feature = "write"))]` round-trip tests in this file still pass
+  (decode via flate2). They're a fast local sanity check that doesn't need chdman.
+
+### 3. Un-ignore the parity test — `chd-rs/chd-rs/src/chdman_compat.rs`
+
+Drop the `#[ignore = "…"]` on `zlib_bit_exact_vs_chdman` (~line 142):
+
+```rust
+#[test]
+fn zlib_bit_exact_vs_chdman() {
+    assert_codec_bit_exact("zlib", CodecType::ZLibV5, 4096, 512);
+}
+```
+
+### 4. Run it (needs a chdman 0.288 binary)
+
+```sh
+# chdman resolved via $CHDMAN, then C:\Tools\chdman\chdman.exe, then `chdman` on PATH
+cargo test -p chd --features "write chdman_compat_tests" zlib_bit_exact_vs_chdman
+```
+
+The harness has chdman build a single-codec raw CHD (`createraw -c zlib`), then for every hunk
+chdman compressed with zlib it decodes the raw data, re-encodes it with `ZlibEncoder`, and asserts
+the stored bytes are identical. (Use `--features "write-zstd chdman_compat_tests"` to run the whole
+compat suite, including the already-passing `huff`/`lzma`/`zstd` codecs.)
+
+### 5. CD codecs — `cdzl` / `cdlz` / `cdfl`
+
+All three CD codecs deflate via zlib: `cdzl` deflates the **sector + subcode** streams; `cdlz` and
+`cdfl` deflate the **subcode** sub-stream. Once their *encoders* route those deflate sub-streams
+through `deflate_raw` (reuse `ZlibEncoder`, or call `deflate_raw` directly), they become bit-exact
+too. `compression/cdrom.rs` today holds the CD *decoders*; the CD *encode* path is part of the
+writer WIP, so wire `deflate_raw` in there as those encoders land and add the analogous `cd*`
+compat tests.
+
+## Done =
+
+- `zlib_bit_exact_vs_chdman` passes against chdman 0.288 (no `#[ignore]`).
+- HD CHDs (`-c zlib`) and CD CHDs (`-c cdlz,cdzl,cdfl`) written by chd-rs are byte-identical to
+  chdman 0.288.
+- Mark zlib ✅ in [`README.md`](README.md), `PROGRESS.md`, and `PARITY_PLAN.md`.
+
+## Gotchas
+
+- **Encode-only by design.** Keep flate2/zlib-rs for decode; only the encoder swaps.
+- **Allocation per hunk.** `deflate_raw` returns a `Vec<u8>`. Fine for correctness; if the hot path
+  needs it later, add a buffer-reusing entry point to the crate (e.g. `deflate_raw_into(&mut Vec)`).
+- **"Lose" semantics.** If a hunk's deflate output ≥ the hunk size, the encoder must return `Err`
+  so the driver stores NONE — preserved by the `> output.len()` check above.
+- **Repo/links:** crate <https://crates.io/crates/zlib-bitexact-rs>,
+  source <https://github.com/danifunker/zlib-bitexact-rs>, docs <https://docs.rs/zlib-bitexact-rs>.

--- a/docs/codec-ports/zlib-bitexact.md
+++ b/docs/codec-ports/zlib-bitexact.md
@@ -1,0 +1,130 @@
+# Handoff: `zlib-bitexact-rs` — bit-exact stock-zlib 1.3.1 deflate in Rust
+
+> ✅ **BUILT & PUBLISHED (2026-06-20).** This outgoing spec is fulfilled: `zlib-bitexact-rs`
+> **0.131.0** is on crates.io, byte-exact vs stock zlib 1.3.1 `deflate` at the CHD config. The
+> module layout, hazards, and milestones below were the build plan. **To wire it into chd-rs, see
+> [`zlib-bitexact-integration.md`](zlib-bitexact-integration.md)** (the return handoff).
+
+> Working name (matches the `lib*-bitexact-rs` family). ⚠️ `zlib-rs`, `miniz_oxide`,
+> `flate2`, `libdeflater` all exist and are **NOT byte-identical** to stock zlib — that's
+> exactly why this is needed. `zlib-rs` 0.4.2 (chd-rs's current backend) is a from-scratch,
+> zlib-ng-quality deflate that produces ~2 bytes smaller output than stock zlib 1.3.1.
+
+## 0. Why this is the highest-priority codec port
+
+zlib is on the critical path for **both** default codec sets:
+- **HD default** = `[zlib]` — every hard-disk CHD.
+- **CD default** = `[cdlz, cdzl, cdfl]` — **all three** CD codecs use zlib: `cdzl` deflates the
+  sector + subcode streams; `cdlz` and `cdfl` deflate the **subcode** sub-stream.
+
+So without bit-exact zlib, neither HD nor CD CHDs can be byte-identical to chdman. lzma/flac/zstd
+are already done; **this is the remaining blocker for the primary use cases.**
+
+## 1. Goal & success criterion
+
+A pure-Rust port of **stock zlib 1.3.1's deflate** whose output is **byte-identical** to the C
+`deflate()` at the exact settings the CHD codec uses. Decode is not needed (chd-rs already
+inflates via `flate2`/`zlib-rs` — inflate is unambiguous).
+
+**Done =** for every input in the corpus, `zlib_bitexact::deflate_raw(input)` equals the bytes C
+zlib 1.3.1 produces with `deflateInit2(9, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY)` + a single
+`deflate(Z_FINISH)`.
+
+## 2. Provenance & license
+
+- Upstream: **zlib 1.3.1** (Jean-loup Gailly & Mark Adler), vendored at `../mame/3rdparty/zlib/`.
+- License: the **zlib license** (permissive, BSD-like: "use freely, subject to … don't
+  misrepresent the origin … mark altered versions"). Fully compatible — publish the port BSD-3
+  (or zlib), retaining the Gailly/Adler copyright.
+
+## 3. Source files to port (deflate/encode only)
+
+| C file | Role |
+| --- | --- |
+| `deflate.c` / `deflate.h` | The deflate engine: `deflate_slow` (lazy matching at level 9), `longest_match`, hash chains (`INSERT_STRING`/`UPDATE_HASH`), `fill_window`, the level config table |
+| `trees.c` / `trees.h` | Huffman trees: `build_tree`, `scan_tree`/`send_tree`, `compress_block`, `_tr_flush_block` (stored vs static vs dynamic block choice), the fixed trees |
+| `zutil.h` | Constants / small helpers |
+
+**Omit:** inflate (`inflate.c`, `infback.c`, `inftrees.c`), gzip framing, `adler32.c`/`crc32.c`
+(raw deflate has no checksum), `compress.c`/`uncompress.c`, dictionaries, and all flush modes
+except `Z_FINISH` (CHD compresses each hunk one-shot).
+
+## 4. Exact settings CHD uses (`chdcodec.cpp:910`)
+
+```c
+deflateInit2(&stream, Z_BEST_COMPRESSION /*9*/, Z_DEFLATED,
+             -MAX_WBITS /*-15: raw, no zlib header*/, 8 /*memLevel*/, Z_DEFAULT_STRATEGY);
+// then a single deflate(&stream, Z_FINISH) over the whole hunk.
+```
+
+Level-9 config (from zlib's `configuration_table[9]`): `good_match=32`, `max_lazy=258`,
+`nice_match=258`, `max_chain=4096`, function = `deflate_slow`. memLevel 8 → `hash_bits=15`,
+`hash_size=32768`, `lit_bufsize` per memLevel. Raw deflate (windowBits −15) → **no 2-byte zlib
+header and no adler32 trailer** — the output is a bare DEFLATE stream, exactly what the CHD map
+stores.
+
+## 5. Suggested Rust module layout
+
+```
+zlib-bitexact-rs/
+  src/
+    deflate.rs     // deflate_state, deflate_slow, fill_window, level-9 config
+    longest_match.rs // the match finder (hash chains, max_chain/nice/good/lazy thresholds)
+    trees.rs       // dynamic/static/stored block build + emit; _tr_flush_block
+    bitwriter.rs    // deflate's LSB-first bit packing (bi_buf/bi_valid) — NOT MSB-first!
+    lib.rs         // pub fn deflate_raw(input) -> Vec<u8>  (level 9, raw, memLevel 8)
+  cref/            // dev-only: vendored zlib 1.3.1 C + cc + FFI shim (the oracle)
+  tests/differential.rs
+```
+
+## 6. Bit-exactness hazards
+
+1. **LSB-first bit order.** deflate packs bits **least-significant-first** (`send_bits` →
+   `bi_buf`/`bi_valid`), the opposite of MAME's `bitstream_out` (MSB-first, used by huff/the map).
+   Don't reuse the huffman-encoder `BitWriter`; deflate needs its own.
+2. **Lazy matching (`deflate_slow`).** The decision to defer a match by one byte hinges on exact
+   `match_length`/`prev_length` comparisons and the `good_match`/`max_lazy` thresholds. Off-by-one
+   here diverges immediately.
+3. **`longest_match` tie-breaks.** Hash-chain traversal order, the `max_chain_length` cap, the
+   `nice_match` early-out, and the "prefer closer match of equal length" rule must match exactly.
+4. **Block-boundary decisions (`_tr_flush_block`).** When zlib closes a block and whether it emits
+   it **stored / static / dynamic** is a cost comparison (`static_len` vs `opt_len` vs stored).
+   Reproduce it bit-for-bit, including the `lit_bufsize`/`sym_end` full-buffer trigger.
+5. **Hash function.** `UPDATE_HASH` uses `hash_shift = (hash_bits+MIN_MATCH-1)/MIN_MATCH`; with
+   memLevel 8 → hash_bits 15. The exact hash determines chain contents → matches found.
+6. **Window/`fill_window`.** For a single-hunk one-shot the whole input fits the 32 KiB window;
+   still match zlib's window-fill and `strstart`/`lookahead` bookkeeping.
+
+## 7. Differential testing
+
+Gold = C zlib 1.3.1 (vendored under `cref/`), `deflateInit2(9, Z_DEFLATED, -15, 8,
+Z_DEFAULT_STRATEGY)` + `deflate(Z_FINISH)`. Corpus: all-zeros, runs, text, random, and **real CHD
+hunks** at CHD hunk sizes (4096, 2448-multiples for CD subcode, 19584). The killer test:
+chd-rs's `chdman_compat::zlib_bit_exact_vs_chdman` (already written, currently `#[ignore]`) — flip
+it on once this crate is wired and it must pass against chdman 0.288.
+
+## 8. Public API
+
+```rust
+/// Raw DEFLATE stream (no zlib header/trailer), byte-identical to zlib 1.3.1
+/// deflateInit2(9, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) + deflate(Z_FINISH).
+pub fn deflate_raw(input: &[u8]) -> Vec<u8>;
+```
+(That single entry point is all CHD needs. A `level`/`mem_level` parameter can come later.)
+
+## 9. Milestones
+
+- **D0** Bit writer (LSB-first) + stored blocks; byte-exact on incompressible input.
+- **D1** Static-Huffman blocks; byte-exact on small/simple input.
+- **D2** `longest_match` + `deflate_slow`; match the sequence of matches zlib finds.
+- **D3** Dynamic Huffman trees + `_tr_flush_block` cost choice; full corpus byte-exact.
+- **D4** Real CHD hunks byte-exact vs chdman; wire into chd-rs; un-ignore the zlib compat test.
+
+## 10. Risk / effort
+
+**Medium.** Deflate is intricate (lazy matching + tree cost decisions) but well-understood,
+deterministic, fully specified in `deflate.c`/`trees.c` (~3–4k lines C total, less to port since
+inflate/gzip/checksums are excluded), and permissively licensed. Comparable to `lzma-sdk-rs`.
+**Alternative (faster, not pure-Rust):** link C zlib **1.3.1** for the encoder only (e.g. a thin
+`libz-sys` pinned to 1.3.1) — gives instant bit-exactness but reintroduces a C toolchain for the
+zlib path. Recommended only if the port is deferred; the port keeps chd-rs fully pure-Rust.

--- a/docs/codec-ports/zstd-bitexact.md
+++ b/docs/codec-ports/zstd-bitexact.md
@@ -1,0 +1,143 @@
+# Handoff: `zstd-bitexact` — bit-exact libzstd encoder (level 22) in Rust
+
+> Working name. `zstd`/`zstd-safe`/`zstd-sys` (C bindings) and `ruzstd` (pure-Rust
+> **decoder**) are taken. Pick a name that signals "bit-exact encoder."
+
+## 1. Goal & success criterion
+
+A pure-Rust port of the **libzstd 1.5.5 encoder at level 22** whose per-hunk output is
+**byte-identical** to `ZSTD_compressStream2(..., ZSTD_e_end)`. This is the **largest** port
+(~4k LOC) but the per-hunk usage strips away most of zstd's complexity (no dictionary, LDM,
+multithreading, or cross-block streaming).
+
+**Done =** for every input in the corpus, `zstd_bitexact::compress_l22(input)` equals the
+bytes libzstd 1.5.5 produces for one independent `ZSTD_e_end` frame at `ZSTD_maxCLevel()`.
+
+## 2. Provenance & license
+
+- Upstream: libzstd **1.5.5** (Meta), vendored at `../mame/3rdparty/zstd/lib/`.
+- License: **BSD-3-Clause OR GPLv2** (dual) — `lib/compress/zstd_compress.c:1` header; full
+  text in `../mame/3rdparty/zstd/LICENSE`. **Select BSD-3-Clause**; do not pull from
+  `COPYING` (the GPLv2 copy). Publish the port BSD-3-Clause, retaining Meta's copyright.
+- ⚠️ libzstd output is **version-sensitive** — this port targets **1.5.5 exactly**. State
+  that prominently; a different libzstd version is a different gold standard.
+
+## 3. Source files involved at level 22
+
+Strategy at level 22 is **`btultra2`** (`clevels.h:50`). Compress path:
+
+| C file | LOC | Role |
+| --- | --- | --- |
+| `compress/zstd_compress.c` | 7032 | Orchestrator: frame/block headers, seq store, entropy dispatch |
+| `compress/zstd_opt.c` | 1472 | **btultra2 optimal parser** — match finding + cost-model DP |
+| `compress/zstd_compress_internal.h` | 1532 | `optState_t`, `ZSTD_optimal_t`, `seqStore_t` |
+| `compress/huf_compress.c` | 1435 | Huffman literals: canonical tree, weight table |
+| `compress/fse_compress.c` | 624 | FSE tables for litLength / matchLength / offset codes |
+| `compress/zstd_compress_sequences.c` | 442 | Sequence entropy mode selection + packing |
+| `compress/zstd_compress_literals.c` | 235 | Literal block: raw / RLE / compressed |
+| `common/hist.c` | 181 | Histogram counting |
+| `common/entropy_common.c`, `fse_decompress.c` | 340/311 | Normalization + (de)serialize tables |
+| `common/bitstream.h`, `bits.h`, `mem.h` | — | LE bit packing, ilog2, endian helpers |
+| `compress/clevels.h` | 134 | Level parameter tables |
+
+**Omit (not used per-hunk):** `zstd_ldm.c`, `zstdmt_compress.c`, `zstd_double_fast.c`,
+`zstd_fast.c`, `zstd_lazy.c` (lower-level strategies), dictionary code, row-hash match finder,
+external sequence producer, checksum (xxhash).
+
+## 4. Level-22 parameters (`clevels.h`)
+
+Two rows depending on input size (CHD hunks are small → second row):
+
+| srcSize | W | C | H | S | L (minMatch) | TL | strategy |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| > 256 KB | 27 | 27 | 25 | 9 | 3 | 999 | btultra2 |
+| **≤ 256 KB** | **18** | **19** | **19** | **13** | **3** | **999** | **btultra2** |
+
+CHD never sets `pledgedSrcSize` (no `ZSTD_CCtx_setPledgedSrcSize`), so:
+- frame header **omits content size** and **dict ID** and **checksum**;
+- window is clamped to the hunk; one block per hunk (hunks ≪ `ZSTD_BLOCKSIZE_MAX` 128 KB),
+  so **no block splitting**.
+
+## 5. Encode pipeline (per hunk)
+
+```
+ZSTD_initCStream(s, 22)
+ZSTD_compressStream2(s, out, in, ZSTD_e_end)
+  ├─ writeFrameHeader      → magic 0xFD2FB528 | FHD byte | window descriptor   (~6 bytes)
+  ├─ compress one block:
+  │    ├─ buildSeqStore    → ZSTD_compressBlock_btultra2 (zstd_opt.c): matches + optimal parse
+  │    └─ entropyCompressSeqStore:
+  │         ├─ literals    → huf_compress (or raw/RLE)
+  │         └─ sequences   → fse_compress (litLen/matchLen/offset) + bitstream
+  ├─ block header (3 bytes LE): lastBlock | blockType<<1 | blockSize<<3
+  └─ final empty block if needed
+```
+
+## 6. Bit-exactness hazards (honest)
+
+1. **Optimal parser cost model** (`zstd_opt.c:20`): `ZSTD_fracWeight` fixed-point fractional
+   bits + `ZSTD_highbit32`. The DP **tie-breaks** (equal-cost paths) resolve by insertion
+   order / first-match — replicate exactly. *Helpful fact:* per-hunk, the first block uses
+   **predefined statistics** (no entropy feedback), so costs are reproducible.
+2. **FSE/Huffman table construction** (`fse_compress.c:100`, `huf_compress.c`): histogram
+   **normalization** and symbol ordering must match on ties (equal frequencies). This is the
+   subtlest determinism point — port the normalization algorithm verbatim, including its
+   tie-handling.
+3. **Literals/sequences mode selection**: predefined vs RLE vs compressed vs repeat. Per-hunk
+   the tables are fresh so **repeat is unavailable on the first/only block** — simplifies to
+   predefined/compressed/RLE by cost, first-match on ties.
+4. **Frame header byte (FHD)**: with no content size / dict / checksum it's a fixed value;
+   reproduce the flag packing in `ZSTD_writeFrameHeader` (`zstd_compress.c:4473`).
+5. **Block header**: `MEM_writeLE24(lastBlock | type<<1 | size<<3)`.
+6. **No SIMD / version drift**: scalar path only; pin to 1.5.5 semantics. xxhash checksum is
+   **off** (don't emit it). Repcodes init `{1,4,8}` fresh per hunk.
+
+## 7. What per-hunk usage removes (scope relief)
+
+No dictionary, no long-distance matching, no multithreading, no cross-block streaming, no
+row-hash finder, no checksum, no content-size field. Each hunk is one isolated frame with
+predefined entropy stats — i.e. the **stateless, deterministic subset** of zstd. This is what
+makes a bit-exact port tractable at all.
+
+## 8. Differential testing
+
+Gold = libzstd 1.5.5:
+```c
+ZSTD_CStream* s = ZSTD_createCStream();
+ZSTD_initCStream(s, ZSTD_maxCLevel());                 // 22
+ZSTD_inBuffer in = {src, srclen, 0};
+ZSTD_outBuffer out = {dst, srclen, 0};
+ZSTD_compressStream2(s, &out, &in, ZSTD_e_end);        // out.pos = gold length
+```
+Assert `compress_l22(src) == dst[0..out.pos]`. Corpus: all-zeros (RLE), highly repetitive
+(matches), random (entropy worst case), real CHD hunk dumps at CHD hunk sizes. Build the port
+component-by-component (frame/block header → entropy tables on fixed seq sets → parser) and
+diff at each stage.
+
+## 9. Public API
+
+```rust
+/// One independent zstd frame at level 22, no dict/checksum/content-size —
+/// byte-identical to libzstd 1.5.5 ZSTD_compressStream2(..., ZSTD_e_end).
+pub fn compress_l22(input: &[u8]) -> Vec<u8>;
+```
+(Keep it minimal; CHD only needs level-22 single-shot. A `level: i32` param can come later if
+other consumers want it, but other levels are out of scope for bit-exact parity here.)
+
+## 10. Milestones
+
+- **Z0** Frame + block headers + raw/RLE blocks byte-exact (covers all-zeros / incompressible).
+- **Z1** FSE + Huffman table construction byte-exact on **fixed, hand-supplied** sequence/
+  literal sets (isolate entropy from the parser).
+- **Z2** btultra2 match finder + optimal parse producing the same sequences as C.
+- **Z3** Full pipeline byte-exact on the corpus at CHD hunk sizes.
+- **Z4** API + docs + publish.
+
+## 11. Risk / effort
+
+**High / largest (~3.5–4.5k LOC).** Feasible *because* per-hunk usage is the deterministic
+subset, but the optimal parser cost model and entropy-table tie-breaks are exacting. Port
+**last** of the three. If full bit-exactness on the parser proves too costly, a documented
+fallback is to keep `zstd` as a C-linked codec **only for the zstd path** while the rest of
+chd-rs stays pure Rust — but that reopens the "no C toolchain" exception this project exists
+to avoid, so treat it as a last resort, not a plan.

--- a/docs/encode-integration.md
+++ b/docs/encode-integration.md
@@ -1,0 +1,212 @@
+# chd-rs encode integration spec
+
+How the three bit-exact codec crates (`lzma-sdk-rs`, `libflac-rs`,
+`libzstd-bitexact-rs`) plus in-tree `zlib`/`huff` plug into chd-rs's existing codec
+layer to enable **writing** CHDs. This is the design that precedes implementation
+(PARITY_PLAN M0–M2). It mirrors the decode architecture exactly — every decoder has an
+inverse encoder constrained by the same `hunk_size` and property derivation.
+
+Scope: the **codec encode layer** only. The writer core that drives these (V5 header +
+compressed-map writer, SHA-1, the per-hunk codec-selection driver) is PARITY_PLAN M1 and is
+summarized in §6 for the contract the codecs must satisfy.
+
+## 1. Encode trait — mirror of `CodecImplementation`
+
+Decode side (`compression/mod.rs:43`):
+```rust
+pub trait CodecImplementation {
+    fn new(hunk_size: u32) -> Result<Self> where Self: Sized;
+    fn decompress(&mut self, input: &[u8], output: &mut [u8]) -> Result<DecompressResult>;
+}
+```
+
+Add a parallel trait (gated behind a new `write` feature):
+```rust
+pub trait CodecEncode {
+    fn new(hunk_size: u32) -> Result<Self> where Self: Sized;
+    /// Compress `input` (exactly hunk_size bytes) into `output`. Returns the number of
+    /// compressed bytes written. `output` is sized to hunk_size; a codec that cannot
+    /// beat that (would expand) returns Err(CompressionError) so the driver falls back
+    /// to a smaller codec or stores the hunk uncompressed. MUST be deterministic.
+    fn compress(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize>;
+}
+```
+
+`CompressResult` is unnecessary — encoders consume the whole hunk and report one length.
+Reuse the existing `Error::CompressionError` variant (already defined, currently unused).
+
+**Struct layout:** add a parallel encoder struct per codec under `compression/` (e.g.
+`ZlibEncoder`, `LzmaEncoder`, `HuffmanEncoder`, `RawFlacEncoder`, `CdEncoder<E, S>`), keeping
+decode and encode types separate (the new crates' encoders are distinct objects from the
+decoders chd-rs already uses). Mirror `CodecType::init` with:
+```rust
+impl CodecType {
+    #[cfg(feature = "write")]
+    pub fn init_encoder(&self, hunk_size: u32) -> Result<Box<dyn CodecEncode>> { /* match … */ }
+}
+```
+and a `CodecsEncode` enum mirroring `Codecs::{Single, Four}` (`chdfile.rs:434`).
+
+## 2. Per-codec mapping (decode internal → encode inverse)
+
+| CHD codec | FourCC | Encode source | Notes |
+| --- | --- | --- | --- |
+| `none` | 0 | in-tree | `output.copy_from_slice(input)`; only "wins" when nothing else fits (driver uses NONE map type, not this codec, but keep symmetric) |
+| `zlib` | `zlib` | `flate2` (in-tree) | raw deflate, **see §2.1** |
+| `lzma` | `lzma` | **`lzma-sdk-rs`** | **see §2.2** |
+| `zstd` | `zstd` | **`libzstd-bitexact-rs`** | `compress(input, 22)`; ⚠️ version drift (§2.3) |
+| `huff` | `huff` | in-tree | port MAME static-Huffman encoder; **see §2.4** |
+| `flac` | `flac` | **`libflac-rs`** | endian trial + `'L'/'B'`; **see §2.5** |
+| `cdzl` | `cdzl` | `CdEncoder<Zlib, Zlib>` | **see §2.6** |
+| `cdlz` | `cdlz` | `CdEncoder<Lzma, Zlib>` | sector=lzma, subcode=zlib |
+| `cdzs` | `cdzs` | `CdEncoder<Zstd, Zstd>` | ⚠️ inherits zstd drift |
+| `cdfl` | `cdfl` | `CdFlacEncoder` | sector=FLAC(BE), subcode=zlib; no header byte; **see §2.6** |
+| `avhuff` | `avhu` | — | **out of scope** (AV deferred) |
+
+### 2.1 `zlib` — flate2 raw deflate
+
+Decode uses `flate2::Decompress::new(false)` (raw, no zlib header). Encode:
+```rust
+let mut c = flate2::Compress::new(flate2::Compression::best(), false); // level 9, raw
+c.compress(input, output, flate2::FlushCompress::Finish)?;
+let n = c.total_out() as usize;
+```
+MAME uses `deflateInit2(Z_BEST_COMPRESSION, Z_DEFLATED, -MAX_WBITS, /*memLevel=*/8, Z_DEFAULT_STRATEGY)`.
+flate2 → `Compression::best()` = level 9, `zlib_header=false` = `-MAX_WBITS`, and zlib's default
+memLevel is 8 (flate2 doesn't override it). **Bit-exact hinges on the `zlib-rs` backend
+(already chd-rs's dep) producing byte-identical deflate to stock zlib 1.3.1.** This is the
+zlib validation task from PARITY_PLAN — add a differential test (deflate a corpus, compare to
+zlib 1.3.1). If `zlib-rs` diverges, pin/patch it; do not silently accept.
+
+### 2.2 `lzma` — lzma-sdk-rs
+
+Decode derives the dict size from hunk size (`get_lzma_dict_size(9, hunk_size)`, props
+lc=3/lp=0/pb=2). The crate's `LzmaProps::chd_for_hunk(hunk_bytes)` reproduces exactly that.
+Encode:
+```rust
+let props = lzma_sdk_rs::LzmaProps::chd_for_hunk(hunk_size);
+let out = lzma_sdk_rs::encode(input, &props);   // raw stream, no header, no end marker
+```
+`encode` is byte-exact with `LzmaEnc_MemEncode(..., writeEndMark=0)` — the exact bytes the V5
+map stores. Copy `out` into `output`, return its length (Err if `out.len() >= output.len()`).
+The 5 decoder-props bytes are **not** stored (chd-rs reconstructs them from hunk size on
+decode), so `decoder_props` is unused here.
+
+### 2.3 `zstd` — libzstd-bitexact-rs (IMPLEMENTED, gated `write-zstd`)
+
+`libzstd-bitexact-rs` **0.155** is byte-exact with zstd **1.5.5** (chdman's version). chdman's
+per-hunk path is level 22 with an **unknown pledged size**, so:
+```rust
+let mut out = Vec::new();
+libzstd_bitexact_rs::StreamEncoder::new(22)   // unknown pledged size => windowLog 27 + LDM
+    .finish(input, &mut out)?;                // == ZSTD_compressStream2(.., ZSTD_e_end)
+```
+Do **not** use `with_pledged_src_size` — pledging the hunk size downsizes `windowLog` and
+changes the output bytes. `compress(input, 22)` is byte-identical for a single `e_end`. For
+`cdzs`, the same encoder applies to each sub-stream. Implemented as `ZstdEncoder` in
+`compression/zstd.rs` behind the `write-zstd` feature (the zstd crate is large and `zstd`/`cdzs`
+aren't default codecs). ⚠️ A round-trip test proves validity only; to guard byte-identity,
+compare *compressed* bytes to a zstd-1.5.5 golden (decode is format-stable).
+
+### 2.4 `huff` — in-tree static-Huffman encoder
+
+Decode: `Huffman8BitDecoder::from_huffman_tree(reader)` then `decode_one` per byte
+(`huff.rs`). No standalone crate — implement the **encoder** in-tree alongside the decoder,
+porting MAME `huffman.cpp`'s `import_tree_rle`/`compute_tree_from_histogram`/encode path
+(BSD-3). The `huff_write` feature scaffolding in `huffman.rs` (the `parent`/`count`/`histogram`
+node fields) is the starting point. Output: serialize the tree (RLE bitstream) then Huffman-
+code each byte. This same encoder is also needed by the **V5 compressed-map writer** (the map
+uses a 16-symbol Huffman), so build it as a reusable `huffman` encode primitive.
+
+### 2.5 `flac` (raw) — libflac-rs with endian trial
+
+Decode: first byte `'L'`/`'B'` selects endianness, remainder is raw FLAC frames decoded to 2ch
+i16 PCM. Encode wrapper (chd-rs owns the endian trial, per libflac-rs's design note):
+```rust
+let block_size = blocksize(hunk_size);           // chd-rs's existing helper: /4, halve while >2048
+let enc = libflac_rs::Encoder::new(libflac_rs::EncoderConfig::chd(block_size));
+// interpret the hunk as i16 samples, two ways:
+let le_i32: Vec<i32> = samples_as_i32::<LittleEndian>(input);
+let be_i32: Vec<i32> = samples_as_i32::<BigEndian>(input);
+let le = enc.encode_frames(&le_i32);             // raw frames, no STREAMINFO
+let be = enc.encode_frames(&be_i32);
+// prepend marker, keep the smaller — exactly MAME's chd_flac_compressor
+let (marker, body) = if le.len() <= be.len() { (b'L', le) } else { (b'B', be) };
+```
+`EncoderConfig::chd(block_size)` bakes in level 8 / 2ch / 16-bit. **`encode_frames` takes
+`&[i32]` interleaved**, so convert the hunk's i16 PCM to i32. ⚠️ libflac-rs float parity is
+validated vs **glibc** libm — confirm the reference chdman is a glibc build (FLAC encode
+decisions are libm-dependent on both sides; PARITY_PLAN §11 secondary note).
+
+### 2.6 CD wrappers — `CdEncoder<Engine, Sub>` and `CdFlacEncoder`
+
+Each 2448-byte CD frame = **2048 sector data + 96 subcode** (`CD_MAX_SECTOR_DATA` +
+`CD_MAX_SUBCODE_DATA`; `CD_FRAME_SIZE=2448`). Decode (cdrom.rs) splits compressed input as
+`[ECC-flag bytes][sector complen 2|3 BE][sector stream][subcode stream]`, decompresses each
+sub-stream as one blob across all frames, de-interleaves to `[sector|subcode]×frames`, and for
+flagged frames writes the sync header + `generate_ecc()`. **Encode inverts this:**
+
+1. For each frame, split `[2048 sector][96 subcode]`.
+2. **ECC strip:** if a sector is a raw MODE1/MODE2 sector with a valid sync header and ECC
+   (detect with the existing `ecc.rs`: sync == `CD_SYNC_HEADER` and `verify_ecc()` true), set
+   its bit in the ECC-flag header and **omit** the ECC/sync from the data fed to the
+   compressor (MAME stores the sector without redundant ECC, regenerating on decode). Use
+   `clear_ecc()`/the known offsets to elide. Otherwise leave the sector intact, flag bit 0.
+3. Concatenate all (possibly ECC-stripped) sector data → compress with `Engine`
+   (`ZlibEncoder`/`LzmaEncoder`/`ZstdEncoder`); concatenate all subcode → compress with `Sub`.
+4. Emit header: `ceil(frames/8)` ECC-flag bytes, then the sector stream's compressed length as
+   **2 bytes** (hunk < 64 KiB) or **3 bytes** big-endian, then sector stream, then subcode
+   stream. (`CdFlacEncoder`: no ECC-flag/complen header byte layout differs — sector→FLAC(BE)
+   via §2.5 without the `'L'/'B'` trial since CD FLAC is always big-endian, subcode→zlib;
+   mirror `CdFlacCodec::decompress` exactly.)
+
+`ecc.rs`'s `ErrorCorrectedSector` trait already provides `generate_ecc`/`verify_ecc`/`clear_ecc`
+— the forward path needed here exists; no new ECC math.
+
+## 3. Dependency wiring
+
+The three crates are sibling repos outside the chd-rs workspace. In `chd-rs/chd-rs/Cargo.toml`:
+```toml
+[features]
+write = ["dep:lzma-sdk-rs", "dep:libflac-rs"]   # core write path (none/zlib/huff/lzma/flac)
+write-zstd = ["write", "dep:libzstd-bitexact-rs"] # gated until the crate targets zstd 1.5.5
+
+[dependencies]
+lzma-sdk-rs       = { path = "../../lzma-sdk-rs", optional = true }
+libflac-rs        = { path = "../../libflac-rs", optional = true }
+libzstd-bitexact-rs = { path = "../../libzstd-bitexact-rs", optional = true }
+```
+Path deps for local dev; switch to crates.io version deps once published. Keep `write` off by
+default so read-only consumers pull in nothing. All encode code is `#[cfg(feature = "write")]`.
+
+## 4. Sizing & invariants
+
+- `output` buffers handed to `compress` are sized to `hunk_size`; a codec that would meet or
+  exceed that returns `Err(CompressionError)` (the driver then tries the next slot / NONE).
+- FLAC requires `hunk_size % (channels * 2) == 0`; CD codecs require `hunk_size % 2448 == 0`
+  (already validated on the decode `new`; reuse the same checks).
+- lzma/flac encoders may allocate a `Vec` and copy into `output`; that's fine (matches the
+  decode side's buffering). Keep a reusable scratch `Vec` per encoder to avoid per-hunk allocs.
+
+## 5. Verification (per PARITY_PLAN §7)
+
+1. **Round-trip:** `encode` → existing chd-rs `decompress` → assert equals the original hunk.
+   Already have the decoders; this is the first gate for every codec.
+2. **Codec byte-exactness:** the three crates are self-verified vs their C oracle, so the
+   remaining risk is chd-rs's *wrappers* (endian trial, CD split/ECC, props derivation). Add a
+   thin differential: for a corpus of hunks, compare each chd-rs encoder's output to the
+   corresponding MAME codec output (via libchdman-rs / chdman), byte-for-byte. zlib is the
+   one in-tree codec whose bytes depend on `zlib-rs` — test it explicitly vs zlib 1.3.1.
+3. **End-to-end (M1+):** a full CHD written by chd-rs must be byte-identical to chdman's for
+   the same input + codec set, and pass `chdman verify`. That exercises codec selection order,
+   map encoding, and SHA-1 together (gated `chdman_compat_tests`, dev-local).
+
+## 6. Contract for the codec-selection driver (M1, summary)
+
+The writer core compresses each hunk by trying the configured codec slots and picking the
+output the same way MAME does — **smallest wins; tie broken by lowest slot index** — else
+self/parent-ref, else NONE. For bit-for-bit parity the driver must reproduce MAME's
+`chd.cpp` per-hunk decision order exactly (which codecs are attempted, in what order, and the
+tie rule), because the winning codec index is written into the V5 map. The codec layer above
+just needs to be **deterministic** and to **reject (Err) rather than expand**, so the driver
+can compare lengths. Map encoding, header, and SHA-1 ordering are specified in PARITY_PLAN M1.

--- a/docs/libchdman-differences.md
+++ b/docs/libchdman-differences.md
@@ -137,6 +137,24 @@ Same shape as libchdman-rs's `dvd` module; byte-identical to `chdman createdvd`.
 sectors + the empty `DVD ` metadata record. `extract_*` rejects non-DVD CHDs with
 `Error::UnsupportedFormat`.
 
+### Editing metadata on an existing CHD (`addmeta` / `delmeta`)
+
+libchdman-rs has `chd.write_metadata(...)` / `chd.delete_metadata(...)` on an owned writeable
+handle. chd-rs exposes them as **free functions over a `Read + Write + Seek` handle** (no owned
+mutable `Chd`):
+
+```rust
+use chd::metadata::{write_metadata, delete_metadata, METADATA_FLAG_CHECKSUM};
+let mut f = std::fs::OpenOptions::new().read(true).write(true).open(chd_path)?;
+write_metadata(&mut f, chd::CHD_CODEC_NONE /* any u32 tag */, 0, b"value\0", METADATA_FLAG_CHECKSUM)?;
+delete_metadata(&mut f, some_tag, 0)?;
+```
+
+Byte-identical to `chdman addmeta`/`delmeta`. Note: chdman only edits **uncompressed** CHDs (MAME
+refuses a writeable open of a compressed one); chd-rs's functions also handle compressed CHDs
+correctly (append + recompute the overall SHA-1). chdman's text form stores a trailing NUL — pass
+it in `data` if you're matching `--valuetext`.
+
 ---
 
 ## 3. Progress & cancellation (replaces `ChdCompressor`/`ChdDataHandler`/`CompressStep`)
@@ -178,7 +196,9 @@ appended after `Error::Unknown` so the existing libchdr-ABI discriminants are un
 | `ChdCompressor` / `ChdDataHandler` / `CompressStep` | synchronous create fns + `progress`/`cancel` |
 | `Chd::create` / `Chd::create_with_parent` | `hd::create_*` / `hd::create_raw_*` (parent/diff in a later phase) |
 | `copy::copy` / `CopyOptions` | `copy::copy` / `copy::CopyOptions` (same shape) |
-| `Chd::write_hunk` / `write_bytes` / `write_metadata` | runtime writes via a future `HdImage`; metadata writer in a later phase |
+| `Chd::write_metadata` / `delete_metadata` | `metadata::write_metadata` / `delete_metadata` (free fns over a `Read+Write+Seek` handle) |
+| `Chd::write_hunk` / `write_bytes` | runtime writes via a future `HdImage` |
+| `Chd::clone_all_metadata` | done inside `copy::copy` |
 | `Chd::info()` / `verify()` / `ChdInfo` | Phase G |
 | `make_tag(a,b,c,d)` (4-arg) | crate-internal `make_tag(&[u8;4])` |
 

--- a/docs/libchdman-differences.md
+++ b/docs/libchdman-differences.md
@@ -17,7 +17,7 @@ surface as free functions; do not graft libchdman-rs's owned, mutable `Chd` hand
 | | libchdman-rs | chd-rs |
 | --- | --- | --- |
 | Type | `Chd` — an **owned** handle over a path/`ChdIo`, with a `writeable` flag | `Chd<F: Read + Seek>` — a **generic, borrowed** reader |
-| Mutability | one handle **reads *and* writes** at runtime | **reads only**; creation is via free functions; runtime block writes via a future `HdImage` |
+| Mutability | one handle **reads *and* writes** at runtime | **reads only**; creation is via free functions; runtime per-sector block writes via [`hd::HdImage`](#runtime-block-device-hdimage) |
 | Custom I/O | the `ChdIo: Read + Write + Seek` trait | **any `Read + Seek`** — no trait needed |
 | Compression | async `ChdCompressor` + `ChdDataHandler` pull model | **synchronous** create functions with `progress`/`cancel` callbacks |
 
@@ -123,7 +123,8 @@ copy::copy(src_path, dst_path, opts, &mut |_p| {}, &|| false)?;
 
 Byte-identical to `chdman copy`: re-compresses the source's logical bytes into the new codec
 list/hunk size and clones every metadata record verbatim, preserving the unit size and `raw_sha1`.
-(Legacy CD/GD metadata re-do is not yet implemented — that lands with the `cd` module.)
+(Re-doing *legacy* CD/GD metadata — `CHCD`/`CHTR`/`CHGT` → `CHT2` — for legacy-source copies is not
+yet implemented; modern `CHT2`/`CHGD` sources copy verbatim and correctly.)
 
 ### DVD (`createdvd` / `extractdvd`)
 
@@ -136,6 +137,41 @@ dvd::extract_to_iso(chd_path, iso_path, &mut |_done| {})?;
 Same shape as libchdman-rs's `dvd` module; byte-identical to `chdman createdvd`. Flat 2048-byte
 sectors + the empty `DVD ` metadata record. `extract_*` rejects non-DVD CHDs with
 `Error::UnsupportedFormat`.
+
+### CD-ROM / GD-ROM (`createcd` / `extractcd`)
+
+```rust
+use chd::cd::{self, CdCreateOptions};
+// input dispatched by what you call: a CUE sheet, a Dreamcast .gdi, or a flat sector image.
+cd::create_from_cue(cue_path, out_path, CdCreateOptions::default(), &mut |_p| {}, &|| false)?;
+cd::create_from_gdi(gdi_path, out_path, CdCreateOptions::default(), &mut |_p| {}, &|| false)?;
+cd::create_from_iso(iso_path, out_path, CdCreateOptions::default(), &mut |_p| {}, &|| false)?;
+
+// extract back to cue+bin, to a .gdi + split track files, or a single MODE1 track to a raw .iso:
+cd::extract_to_cue(chd_path, cue_path, bin_path, &mut |_done| {})?;
+cd::extract_to_gdi(chd_path, gdi_path, &mut |_done| {})?;
+cd::extract_to_iso(chd_path, iso_path, &mut |_done| {})?;
+
+// read the track table, or stream a MODE1 track's cooked 2048-byte sectors (Read + Seek):
+let tracks: Vec<cd::TrackInfo> = cd::list_tracks(&mut chd)?;
+let mut cooked = cd::CdCookedReader::open(chd)?;
+```
+
+Byte-identical to `chdman createcd`/`extractcd`. `CdCreateOptions.codecs` defaults to
+`[cdlz, cdzl, cdfl, 0]`. The pure-Rust CUE/GDI/ISO TOC parser replaces MAME's `cdrom_file::parse_*`.
+(`extract_to_iso` / `CdCookedReader` have no chdman command and are round-trip-verified.)
+
+### Compressed child of a parent (`createraw -op`)
+
+```rust
+// libchdman-rs: Chd::create_with_parent(..)
+// chd-rs: hunks identical to the parent become COMPRESSION_PARENT refs; parent_sha1 is linked.
+hd::create_raw_from_path_with_parent(in_path, out_path, parent_path, opts, &mut |_p| {}, &|| false)?;
+```
+
+Byte-identical to `chdman createraw -op`. The child inherits the parent's hunk/unit/logical sizes.
+For the *uncompressed diff* form (runtime writes against a compressed parent) see
+[`hd::HdImage`](#runtime-block-device-hdimage).
 
 ### Editing metadata on an existing CHD (`addmeta` / `delmeta`)
 
@@ -188,28 +224,70 @@ appended after `Error::Unknown` so the existing libchdr-ABI discriminants are un
 
 ---
 
+## Runtime block device (`HdImage`)
+
+libchdman-rs's owned, writeable `Chd` lets a running machine read/write sectors at runtime. chd-rs
+puts that on a dedicated `hd::HdImage` (chd-rs's `Chd` stays read-only):
+
+```rust
+use chd::hd::HdImage;
+// in-place edits to an uncompressed HD CHD:
+let mut img = HdImage::open(path)?;
+// or an uncompressed *diff* over a compressed parent — writes land in the diff, unwritten
+// sectors fall through to the parent (exactly how MAME writes to a compressed image):
+let mut img = HdImage::open_with_diff(parent_path, diff_path)?; // or ::reopen_diff(..)
+
+let mut buf = vec![0u8; img.sector_size() as usize];
+img.read_sector(lba, &mut buf)?;
+img.write_sector(lba, &buf)?;
+```
+
+| libchdman-rs `HdImage` | chd-rs `hd::HdImage` |
+| --- | --- |
+| `open` / `open_with_diff` / `reopen_diff` | same names |
+| `read_sector` / `write_sector` / `sector_size` / `sector_count` / `geometry` | same |
+| `as_chd` / `as_chd_mut` | — (chd-rs's `Chd` is read-only; use `read_sector` or re-`open` for reads) |
+
+The diff is a standard uncompressed-with-parent CHD; `chdman extracthd -ip <parent>` reads it back.
+
+## Verifying a CHD (`verify`)
+
+```rust
+let r = chd.verify()?;                       // needs the `verify` feature (also pulled in by `write`)
+assert!(r.is_valid());                       // raw + overall (metadata-inclusive) SHA-1
+// r.raw_sha1_valid(), r.overall_sha1_valid(), r.computed_raw_sha1, r.expected_sha1, …
+```
+
+`Chd::verify()` recomputes both checksums and compares them to the header (uncompressed CHDs carry
+none → `Error::UnsupportedFormat`). `Chd::info() -> ChdInfo` mirrors `chdman info`.
+
+---
+
 ## 5. Not ported (and the chd-rs equivalent)
 
 | libchdman-rs | chd-rs equivalent |
 | --- | --- |
 | `ChdIo` trait | any `Read + Seek` (generic) |
 | `ChdCompressor` / `ChdDataHandler` / `CompressStep` | synchronous create fns + `progress`/`cancel` |
-| `Chd::create` / `Chd::create_with_parent` | `hd::create_*` / `hd::create_raw_*` (parent/diff in a later phase) |
+| `Chd::create` / `Chd::create_with_parent` | `hd::create_*` / `hd::create_raw_from_path_with_parent` |
 | `copy::copy` / `CopyOptions` | `copy::copy` / `copy::CopyOptions` (same shape) |
 | `Chd::write_metadata` / `delete_metadata` | `metadata::write_metadata` / `delete_metadata` (free fns over a `Read+Write+Seek` handle) |
-| `Chd::write_hunk` / `write_bytes` | runtime writes via a future `HdImage` |
+| `Chd::write_hunk` / `write_bytes` | [`hd::HdImage::write_sector`](#runtime-block-device-hdimage) |
 | `Chd::clone_all_metadata` | done inside `copy::copy` |
-| `Chd::info()` / `verify()` / `ChdInfo` | Phase G |
+| `Chd::info()` / `verify()` / `ChdInfo` | [`Chd::info()` / `Chd::verify()`](#verifying-a-chd-verify) / `ChdInfo` |
+| `HdImage` (+ `open`/`open_with_diff`/`read_sector`/…) | [`hd::HdImage`](#runtime-block-device-hdimage) |
+| `cd::create_from_*` / `extract_to_*` / `list_tracks` / `CdCookedReader` | same names in `chd::cd` (§2) |
 | `make_tag(a,b,c,d)` (4-arg) | crate-internal `make_tag(&[u8;4])` |
 
 `HunkIter`/`MetadataIter`/`ChdReader`/`HunkReader` and the metadata tag constants exist under
-different names — see [libchdman-parity.md](libchdman-parity.md) §3.7.
+different names — see [libchdman-parity.md](libchdman-parity.md) §3.7. The only libchdman-rs input
+not yet handled is **Nero `.nrg`** (a binary TOC with no fixture path to verify against).
 
 ---
 
 ## 6. FLAC byte-identity caveat
 
-The raw `flac` codec (and, later, `cdfl` / the DVD default) is backed by
+The `flac` and `cdfl` codecs (and the HD/DVD default sets that include `flac`) are backed by
 [`libflac-rs`](../../libflac-rs), whose float parity is validated against **glibc** libm. Output is
 byte-identical to a **glibc-built** chdman, but may differ by a few bytes from an **MSVC/Windows**
 chdman. It is always **round-trip-correct** (decodes back to the original PCM, and chdman extracts

--- a/docs/libchdman-differences.md
+++ b/docs/libchdman-differences.md
@@ -1,0 +1,186 @@
+# Porting from libchdman-rs to chd-rs
+
+chd-rs offers the same CHD **create/extract** functionality as
+[`libchdman-rs`](../../libchdman-rs) (a C++/MAME wrapper), but keeps chd-rs's own idioms on the
+read side. This doc is the authoritative "how do I translate my libchdman-rs code" guide: every
+intentional divergence, and the mechanical substitution for it. The full API map (which item maps
+to which) is in [libchdman-parity.md](libchdman-parity.md); this doc is the *why it differs / what
+to write instead*.
+
+The headline decision (locked): **keep chd-rs's generic, borrowed reader; add the create/extract
+surface as free functions; do not graft libchdman-rs's owned, mutable `Chd` handle.**
+
+---
+
+## 1. The `Chd` handle: borrowed reader vs owned read/write handle
+
+| | libchdman-rs | chd-rs |
+| --- | --- | --- |
+| Type | `Chd` — an **owned** handle over a path/`ChdIo`, with a `writeable` flag | `Chd<F: Read + Seek>` — a **generic, borrowed** reader |
+| Mutability | one handle **reads *and* writes** at runtime | **reads only**; creation is via free functions; runtime block writes via a future `HdImage` |
+| Custom I/O | the `ChdIo: Read + Write + Seek` trait | **any `Read + Seek`** — no trait needed |
+| Compression | async `ChdCompressor` + `ChdDataHandler` pull model | **synchronous** create functions with `progress`/`cancel` callbacks |
+
+### Opening
+
+```rust
+// libchdman-rs
+let chd = Chd::open(path, /*writeable=*/false, /*parent=*/None)?;
+
+// chd-rs — takes a Read+Seek, no `writeable` (reads only). Path helper:
+use std::io::BufReader; use std::fs::File;
+let chd = chd::Chd::open(BufReader::new(File::open(path)?), None)?;
+```
+
+There is **no `writeable` open**. Reading and creating are different operations on different types.
+`Chd::open_custom(io, ..)` collapses to plain `Chd::open(io, ..)` — any `Read + Seek` *is* "custom
+I/O", so `ChdIo` is unnecessary.
+
+### Header / hunk / metadata accessors (the 🟡 rows)
+
+These exist but live on sub-objects, not as methods on `Chd`:
+
+| libchdman-rs | chd-rs |
+| --- | --- |
+| `chd.version()/hunk_bytes()/hunk_count()/unit_bytes()/logical_bytes()` | `chd.header().{version,hunk_size,hunk_count,unit_bytes,logical_bytes}()` |
+| `chd.sha1()/raw_sha1()/parent_sha1()` | `chd.header().{sha1,raw_sha1,parent_sha1}()` |
+| `chd.hunk_info(n)` | `chd.map().get_entry(n)` → `MapEntry` (`hunk_type()` + `block_size()`) |
+| `chd.read_hunk(n, buf)` | `chd.hunk(n)?.read_hunk_in(&mut scratch, buf)` (needs a scratch buffer) |
+| `chd.read_bytes(off, buf)` | wrap in `read::ChdReader` (`Read + Seek`) and `seek` + `read_exact` |
+| `chd.read_metadata(tag, index)` | `chd.metadata_refs()` / `chd.metadata()` then filter by `metatag` (see `hd::read_geometry`) |
+
+---
+
+## 2. Creating CHDs
+
+libchdman-rs creates via `Chd::create(..)` / the format modules' `create_from_*` (which internally
+drive `ChdCompressor`). chd-rs has **free functions in the format modules** instead.
+
+### Hard disk — raw (`createraw`)
+
+```rust
+// chd-rs: byte-identical to `chdman createraw`
+use chd::hd::{self, HdCreateOptions};
+use chd::{CompressionProgress, CHD_CODEC_LZMA, CHD_CODEC_ZLIB};
+
+let opts = HdCreateOptions {
+    hunk_size: 4096,
+    unit_size: 512,
+    codecs: [CHD_CODEC_LZMA, CHD_CODEC_ZLIB, 0, 0], // per-hunk best-of, like chdman -c lzma,zlib
+    ..Default::default()
+};
+hd::create_raw_from_path(
+    in_path, out_path, opts,
+    &mut |p: CompressionProgress| eprintln!("{}/{} ({:.1}%)", p.bytes_done, p.bytes_total, p.ratio * 100.0),
+    &|| false, // cancel
+)?;
+```
+
+- **`codecs` is a `[u32; 4]` of `CHD_CODEC_*` FourCCs** (use `chd::parse_codec_spec("lzma,zlib")`
+  for chdman's `-c` syntax). The list must be contiguous from slot 0 (a `0` ends it); all-zero
+  means uncompressed. Per hunk, chd-rs reproduces MAME's `find_best_compressor` exactly.
+- The whole input is read into memory (a streaming writer is future work).
+- `progress` / `cancel` replace libchdman-rs's async pull model — see §3.
+
+### Hard disk — full `createhd` (with `GDDD`/`IDNT` geometry metadata)
+
+```rust
+use chd::hd::{self, HdCreateOptions, HdGeometry};
+let opts = HdCreateOptions {
+    codecs: [chd::CHD_CODEC_ZLIB, 0, 0, 0],
+    geometry: None,            // None → derived via compute_chs (like chdman)
+    ident: None,               // Some(blob) → also writes an IDNT record
+    ..Default::default()
+};
+hd::create_from_path(in_path, out_path, opts, &mut |_p| {}, &|| false)?;
+```
+
+`create_from_*` is byte-identical to `chdman createhd`: it writes the `GDDD` geometry record (and,
+if `opts.ident` is set, an `IDNT` record), and computes the metadata-inclusive overall SHA-1 for
+compressed CHDs (uncompressed CHDs leave the SHA-1 fields zero, as chdman does). Use
+`create_raw_*` (which writes **no** metadata) for the `createraw` equivalent — it rejects
+`geometry`/`ident` with `Error::UnsupportedFormat` so you can't accidentally lose them.
+
+### Extract (`extractraw` / `extracthd`)
+
+```rust
+hd::extract_to_path(chd_path, out_path, &mut |bytes_done| { /* progress */ })?;
+```
+
+Works for any CHD chd-rs can decode (any codec/version); the output is the exact logical image
+(the last hunk's zero-padding is truncated).
+
+### Copy / re-compress (`copy`)
+
+```rust
+use chd::copy::{self, CopyOptions};
+let opts = CopyOptions {
+    hunk_size: None,                       // None → keep the source's hunk size
+    codecs: [chd::CHD_CODEC_LZMA, 0, 0, 0],// [0;4] → uncompressed
+};
+copy::copy(src_path, dst_path, opts, &mut |_p| {}, &|| false)?;
+```
+
+Byte-identical to `chdman copy`: re-compresses the source's logical bytes into the new codec
+list/hunk size and clones every metadata record verbatim, preserving the unit size and `raw_sha1`.
+(Legacy CD/GD metadata re-do is not yet implemented — that lands with the `cd` module.)
+
+---
+
+## 3. Progress & cancellation (replaces `ChdCompressor`/`ChdDataHandler`/`CompressStep`)
+
+chd-rs's create functions are **synchronous** and take two callbacks:
+
+- `progress: &mut dyn FnMut(CompressionProgress)` — invoked per hunk. `CompressionProgress` matches
+  libchdman-rs field-for-field: `{ bytes_done: u64, bytes_total: u64, ratio: f64 }`.
+- `cancel: &dyn Fn() -> bool` — polled before each hunk. Returning `true` aborts with
+  `Error::Cancelled`. Because the output is assembled in memory and flushed only on success,
+  **a cancelled write leaves the output untouched** (and `create_raw_from_path` removes the partial
+  file).
+
+There is no `ChdCompressor`, `ChdDataHandler`, `ChdCompressor::compress_continue`, or `CompressStep`
+loop to drive — just pass the callbacks.
+
+```rust
+// libchdman-rs: drive the pull loop yourself
+// loop { match compressor.compress_continue()? { CompressStep::Continue(p) => .., Done(p) => break } }
+
+// chd-rs: hand the callbacks to the create function; it runs the loop internally.
+```
+
+---
+
+## 4. Errors
+
+chd-rs uses its own `chd::Error` (`Result<T> = Result<T, chd::Error>`), the same enum the read API
+returns. The create surface adds one variant, **`Error::Cancelled`** (no libchdr equivalent;
+appended after `Error::Unknown` so the existing libchdr-ABI discriminants are unchanged).
+
+---
+
+## 5. Not ported (and the chd-rs equivalent)
+
+| libchdman-rs | chd-rs equivalent |
+| --- | --- |
+| `ChdIo` trait | any `Read + Seek` (generic) |
+| `ChdCompressor` / `ChdDataHandler` / `CompressStep` | synchronous create fns + `progress`/`cancel` |
+| `Chd::create` / `Chd::create_with_parent` | `hd::create_*` / `hd::create_raw_*` (parent/diff in a later phase) |
+| `copy::copy` / `CopyOptions` | `copy::copy` / `copy::CopyOptions` (same shape) |
+| `Chd::write_hunk` / `write_bytes` / `write_metadata` | runtime writes via a future `HdImage`; metadata writer in a later phase |
+| `Chd::info()` / `verify()` / `ChdInfo` | Phase G |
+| `make_tag(a,b,c,d)` (4-arg) | crate-internal `make_tag(&[u8;4])` |
+
+`HunkIter`/`MetadataIter`/`ChdReader`/`HunkReader` and the metadata tag constants exist under
+different names — see [libchdman-parity.md](libchdman-parity.md) §3.7.
+
+---
+
+## 6. FLAC byte-identity caveat
+
+The raw `flac` codec (and, later, `cdfl` / the DVD default) is backed by
+[`libflac-rs`](../../libflac-rs), whose float parity is validated against **glibc** libm. Output is
+byte-identical to a **glibc-built** chdman, but may differ by a few bytes from an **MSVC/Windows**
+chdman. It is always **round-trip-correct** (decodes back to the original PCM, and chdman extracts
+a chd-rs-written flac CHD losslessly). Treat flac as round-trip-verified except against a confirmed
+glibc chdman. All other codecs (`none`/`zlib`/`huff`/`lzma`/`zstd`) are byte-identical to chdman
+0.288 unconditionally.

--- a/docs/libchdman-differences.md
+++ b/docs/libchdman-differences.md
@@ -125,6 +125,18 @@ Byte-identical to `chdman copy`: re-compresses the source's logical bytes into t
 list/hunk size and clones every metadata record verbatim, preserving the unit size and `raw_sha1`.
 (Legacy CD/GD metadata re-do is not yet implemented — that lands with the `cd` module.)
 
+### DVD (`createdvd` / `extractdvd`)
+
+```rust
+use chd::dvd::{self, DvdCreateOptions};
+dvd::create_from_iso(iso_path, out_path, DvdCreateOptions::default(), &mut |_p| {}, &|| false)?;
+dvd::extract_to_iso(chd_path, iso_path, &mut |_done| {})?;
+```
+
+Same shape as libchdman-rs's `dvd` module; byte-identical to `chdman createdvd`. Flat 2048-byte
+sectors + the empty `DVD ` metadata record. `extract_*` rejects non-DVD CHDs with
+`Error::UnsupportedFormat`.
+
 ---
 
 ## 3. Progress & cancellation (replaces `ChdCompressor`/`ChdDataHandler`/`CompressStep`)

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -29,10 +29,11 @@ and [docs/chdman-mapping.md](../../libchdman-rs/docs/chdman-mapping.md).
   `compute_overall_sha1`, wired into the compressed and uncompressed writers.
 
 - **`copy` module** (public): `copy::copy` + `CopyOptions`, byte-identical to `chdman copy`.
+- **`dvd` module** (public): `dvd::create_from_*`/`extract_to_*` + `DvdCreateOptions`, byte-identical
+  to `chdman createdvd`.
 
-**Left:** `createdvd`/`createcd` (the other metadata-writing create paths); metadata write/delete on
-**existing** CHDs; `cd`/`dvd`; `info`/`verify`; parent/diff + runtime writes; remaining docs.
-Everything below.
+**Left:** `createcd` (the CD create path); metadata write/delete on **existing** CHDs; `cd`;
+`info`/`verify`; parent/diff + runtime writes; remaining docs. Everything below.
 
 ---
 
@@ -128,8 +129,8 @@ wrapper) · ⬜ to build.
 
 | libchdman-rs | chd-rs target | status | notes |
 | --- | --- | --- | --- |
-| `DvdCreateOptions{logical_size,hunk_size,codecs}` (default 4096, `[lzma,zlib,huff,flac]`) | same | ⬜ | needs flac. |
-| `create_from_iso/create_from_reader`, `extract_to_iso/extract_to_writer` | new | ⬜ | empty `DVD ` metadata record (1-NUL-byte quirk). |
+| `DvdCreateOptions{logical_size,hunk_size,codecs}` (default 4096, `[lzma,zlib,huff,flac]`) | `dvd::DvdCreateOptions` | ✅ | done. |
+| `create_from_iso/create_from_reader`, `extract_to_iso/extract_to_writer` | `dvd::*` | ✅ | done & byte-identical; empty `DVD ` record (1-NUL-byte quirk). |
 
 ### 3.6 `copy` module
 
@@ -172,7 +173,8 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
   **existing** CHDs (splice the on-disk linked list: overwrite-in-place when the new payload fits,
   else unlink + append; update the previous entry's `next` / the header `meta_offset`) — verify
   `addmeta`/`delmeta` byte-identity.
-- **Phase D — `dvd` module.** Flat 2048 sectors + empty `DVD ` record. Verify `createdvd`.
+- **Phase D — `dvd` module. ✅ DONE.** Flat 2048 sectors + the empty `DVD ` record (1-NUL payload),
+  reusing the createhd metadata writer. `createdvd` verified byte-identical (`-c none/zlib/lzma`).
 - **Phase E — `cd` module.** Pure-Rust TOC parser, CD encoders (sector/subcode split + ECC via
   `ecc.rs`, subcode via `zlib`), CHT2 metadata, `list_tracks`, `extract_to_{cue,iso,gdi}`,
   `CdCookedReader`. Verify `createcd`/`extractcd`.

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -32,12 +32,12 @@ and [docs/chdman-mapping.md](../../libchdman-rs/docs/chdman-mapping.md).
 - **`dvd` module** (public): `dvd::create_from_*`/`extract_to_*` + `DvdCreateOptions`, byte-identical
   to `chdman createdvd`.
 
-**Done (cont.):** **`cd` createcd + extractcd** — `cd::create_from_cue`/`create_from_iso` (CUE/ISO
-TOC parser + CHT2) and `cd::extract_to_cue` + `list_tracks`/`TrackInfo`, all byte-identical to
-`chdman createcd`/`extractcd` (all four codecs encode; `cdfl` glibc-gated).
+**Done (cont.):** the **`cd` module** (essentially complete) — `create_from_cue`/`create_from_iso`/
+`create_from_gdi`, `extract_to_cue`/`extract_to_iso`/`extract_to_gdi`, `list_tracks`/`TrackInfo`,
+`CdCookedReader`; all byte-identical to `chdman` (all four codecs; `cdfl` glibc-gated).
 
-**Left:** the rest of `cd` (GDI/Nero parsing, `.gdi`/split-bin + `extract_to_iso`, `CdCookedReader`);
-`verify`; parent/diff + runtime writes; remaining docs. Everything below.
+**Left:** Nero (`.nrg`) input (deferred — unverifiable); `verify`; parent/diff + runtime writes;
+remaining docs. Everything below.
 
 ---
 
@@ -125,11 +125,11 @@ wrapper) · ⬜ to build.
 | --- | --- | --- | --- |
 | `CdCreateOptions{hunk_size,codecs}` (default 19584, `[cdlz,cdzl,cdfl,0]`) | `cd::CdCreateOptions` | ✅ | done; default matches and works (all of `cdlz`/`cdzl`/`cdfl` encode — `cdfl` byte-identical to a glibc chdman, libm-gated). |
 | `TrackType`/`SubcodeType`/`TrackInfo` | `cd::TrackType`/`cd::SubcodeType`/`cd::TrackInfo` | ✅ | done (+ `type_string`/`subtype_string`); `TrackInfo` returned by `list_tracks`. |
-| `create_from_cue/create_from_iso` | `cd::create_from_cue`/`create_from_iso` | ✅ | done & **byte-identical to `chdman createcd`** (`-c cdzl`/`cdlz`): pure-Rust CUE (`parse_cue`) + ISO (`parse_iso`) parser, 2448-frame assembly (port of `chd_cd_compressor::read_data`), CHT2 metadata. GDI/Nero/WAVE/GD-ROM not yet. |
-| `list_tracks(chd)` | `cd::list_tracks(&mut Chd)` | ✅ | done; reads `CHT2`/`CHTR` (port of `parse_metadata`). Takes `&mut Chd` (chd-rs reads metadata mutably). |
+| `create_from_cue/create_from_iso` | `cd::create_from_cue`/`create_from_iso`/`create_from_gdi` | ✅ | done & **byte-identical to `chdman createcd`**: pure-Rust CUE (`parse_cue`) + ISO (`parse_iso`) + **GDI** (`parse_gdi`, GD-ROM/`CHGD`) parsers, 2448-frame assembly (port of `chd_cd_compressor::read_data` incl. `padframes`), CHT2/CHGD metadata. Nero (`.nrg`)/WAVE not yet. |
+| `list_tracks(chd)` | `cd::list_tracks(&mut Chd)` | ✅ | done; reads `CHT2`/`CHTR`/`CHGD`/`CHGT` (port of `parse_metadata`). Takes `&mut Chd` (chd-rs reads metadata mutably). |
 | `extract_to_cue` | `cd::extract_to_cue` | ✅ | done & **byte-identical to `chdman extractcd`** (cue **and** bin), single + multi-track. Cue line endings match the host platform (CRLF on Windows, LF on Linux), like chdman. |
-| `extract_to_iso/extract_to_gdi` | new | ⬜ | `.gdi`/split-bin + single-track `.iso` extraction. |
-| `CdCookedReader` (+`open`/`open_track`/`Read+Seek`) | new | ⬜ | 2048-byte cooked stream over MODE1 tracks. |
+| `extract_to_iso/extract_to_gdi` | `cd::extract_to_iso`/`extract_to_gdi` | ✅ | `extract_to_gdi` **byte-identical to `chdman extractcd`** (`.gdi` index + split per-track files); `extract_to_iso` (single MODE1 → raw iso) round-trip-verified (chdman has no CD→iso command). |
+| `CdCookedReader` (+`open`/`open_track`/`Read+Seek`) | `cd::CdCookedReader` | ✅ | done; `Read+Seek` over a MODE1 track's cooked 2048-byte user data. Wraps chd-rs's owned `Chd`; MODE1/MODE1_RAW only. |
 
 ### 3.5 `dvd` module
 
@@ -182,12 +182,12 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
   reusing the createhd metadata writer. `createdvd` verified byte-identical (`-c none/zlib/lzma`).
 - **Phase E — `cd` module.** CD wrapper **encoders** ✅ DONE — `cdzl`/`cdlz`/`cdzs` (`CdEncoder<E,S>`)
   byte-identical; **`cdfl`** (`CdFlacEncoder`) byte-identical to a glibc chdman (libm-gated, like raw
-  `flac`). **`createcd` container** ✅ DONE — `cd::create_from_cue`/`create_from_iso` (pure-Rust
-  CUE+ISO TOC parser, 2448-frame assembly, CHT2 metadata) are **byte-identical to `chdman createcd`**
-  (single MODE1/2352, multi-track MODE1+AUDIO+pregap, flat ISO, all four codecs). **`extractcd`** ✅
-  DONE — `cd::extract_to_cue` + `list_tracks`/`TrackInfo`, **byte-identical to `chdman extractcd`**
-  (cue + bin) with a full create→extract round-trip. Remaining: GDI/Nero parsing,
-  `.gdi`/split-bin + `extract_to_iso`, `CdCookedReader`.
+  `flac`). **`cd` module essentially COMPLETE** — `create_from_cue`/`create_from_iso`/
+  `create_from_gdi`, `extract_to_cue`/`extract_to_iso`/`extract_to_gdi`, `list_tracks`/`TrackInfo`,
+  and `CdCookedReader`, all **byte-identical to `chdman`** (or round-trip-verified where chdman has
+  no equivalent command, e.g. CD→iso). Only **Nero (`.nrg`)** input is deferred — a binary TOC with
+  no way to generate a fixture (chdman can't write `.nrg`), so it can't be verified to the
+  byte-identity bar.
 - **Phase F — parent/diff + `HdImage`.** Uncompressed diff children vs a compressed parent
   (parent-hunk dedup lights up here — the driver hook exists), runtime `read_sector`/`write_sector`,
   `write_hunk`/`write_bytes` equivalents.

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -35,8 +35,8 @@ and [docs/chdman-mapping.md](../../libchdman-rs/docs/chdman-mapping.md).
 **Done (cont.):** **`cd` createcd** — `cd::create_from_cue`/`create_from_iso` + the CUE/ISO TOC
 parser + CHT2 metadata, byte-identical to `chdman createcd`.
 
-**Left:** `extractcd` + the rest of `cd` (GDI/Nero, `list_tracks`, `CdCookedReader`, `cdfl`);
-`verify`; parent/diff + runtime writes; remaining docs. Everything below.
+**Left:** `extractcd` + the rest of `cd` (GDI/Nero, `list_tracks`, `CdCookedReader`); `verify`;
+parent/diff + runtime writes; remaining docs. Everything below.
 
 ---
 
@@ -122,7 +122,7 @@ wrapper) · ⬜ to build.
 
 | libchdman-rs | chd-rs target | status | notes |
 | --- | --- | --- | --- |
-| `CdCreateOptions{hunk_size,codecs}` (default 19584, `[cdlz,cdzl,cdfl,0]`) | `cd::CdCreateOptions` | ✅ | done; default matches (note: `cdfl` has no encoder yet, so the default set currently errors — pass `[cdlz,cdzl,0,0]`). |
+| `CdCreateOptions{hunk_size,codecs}` (default 19584, `[cdlz,cdzl,cdfl,0]`) | `cd::CdCreateOptions` | ✅ | done; default matches and works (all of `cdlz`/`cdzl`/`cdfl` encode — `cdfl` byte-identical to a glibc chdman, libm-gated). |
 | `TrackType`/`SubcodeType`/`TrackInfo` | `cd::TrackType`/`cd::SubcodeType` | ✅/⬜ | enums done (+ `type_string`/`subtype_string`); `TrackInfo`/`list_tracks` (read CHT2) still ⬜. |
 | `create_from_cue/create_from_iso` | `cd::create_from_cue`/`create_from_iso` | ✅ | done & **byte-identical to `chdman createcd`** (`-c cdzl`/`cdlz`): pure-Rust CUE (`parse_cue`) + ISO (`parse_iso`) parser, 2448-frame assembly (port of `chd_cd_compressor::read_data`), CHT2 metadata. GDI/Nero/WAVE/GD-ROM not yet. |
 | `list_tracks(chd)` | new (read CHT2 metadata) | ⬜ | |
@@ -178,12 +178,12 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
   additionally handle compressed CHDs correctly.
 - **Phase D — `dvd` module. ✅ DONE.** Flat 2048 sectors + the empty `DVD ` record (1-NUL payload),
   reusing the createhd metadata writer. `createdvd` verified byte-identical (`-c none/zlib/lzma`).
-- **Phase E — `cd` module.** CD wrapper **encoders** ✅ DONE (`CdEncoder<E,S>`, cdzl/cdlz/cdzs
-  byte-identical; cdfl pending). **`createcd` container** ✅ DONE — `cd::create_from_cue`/
-  `create_from_iso` (pure-Rust CUE+ISO TOC parser, 2448-frame assembly, CHT2 metadata) are
-  **byte-identical to `chdman createcd`** (`-c cdzl`/`cdlz`; single MODE1/2352, multi-track
-  MODE1+AUDIO+pregap, flat ISO). Remaining: `extractcd` + `extract_to_{cue,iso,gdi}`, GDI/Nero
-  parsing, `list_tracks`, `CdCookedReader`, the `cdfl` encoder.
+- **Phase E — `cd` module.** CD wrapper **encoders** ✅ DONE — `cdzl`/`cdlz`/`cdzs` (`CdEncoder<E,S>`)
+  byte-identical; **`cdfl`** (`CdFlacEncoder`) byte-identical to a glibc chdman (libm-gated, like raw
+  `flac`). **`createcd` container** ✅ DONE — `cd::create_from_cue`/`create_from_iso` (pure-Rust
+  CUE+ISO TOC parser, 2448-frame assembly, CHT2 metadata) are **byte-identical to `chdman createcd`**
+  (single MODE1/2352, multi-track MODE1+AUDIO+pregap, flat ISO, all four codecs). Remaining:
+  `extractcd` + `extract_to_{cue,iso,gdi}`, GDI/Nero parsing, `list_tracks`, `CdCookedReader`.
 - **Phase F — parent/diff + `HdImage`.** Uncompressed diff children vs a compressed parent
   (parent-hunk dedup lights up here — the driver hook exists), runtime `read_sector`/`write_sector`,
   `write_hunk`/`write_bytes` equivalents.
@@ -213,8 +213,11 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
 - **Round-trip**: `create → chd-rs decode → equal logical bytes + raw_sha1`.
 - **API-shape tests**: a doc-test per new public function so the surface compiles as documented.
 - ⚠️ **flac is libm-dependent** — byte-identity for `flac`/`cdfl`/dvd-default needs the reference
-  chdman and `libflac-rs` to agree on libm (glibc). Confirm the reference build before asserting
-  byte-identity on flac paths; until then gate those as round-trip-only.
+  chdman and `libflac-rs` to agree on libm (glibc). **Confirmed:** against a **glibc-built chdman
+  0.288** (compiled from MAME source via `make TOOLS=1 OSD=sdl USE_QTDEBUG=0` + the `chdman` target),
+  both the raw `flac` and `cdfl` paths are **byte-identical** (the `dump_*_artifacts_for_glibc_check`
+  `#[ignore]`d tests emit the artifacts to compare). Against the default **MSVC/Windows** oracle the
+  FLAC paths are gated round-trip-only.
 
 ---
 

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -36,8 +36,11 @@ and [docs/chdman-mapping.md](../../libchdman-rs/docs/chdman-mapping.md).
 `create_from_gdi`, `extract_to_cue`/`extract_to_iso`/`extract_to_gdi`, `list_tracks`/`TrackInfo`,
 `CdCookedReader`; all byte-identical to `chdman` (all four codecs; `cdfl` glibc-gated).
 
-**Left:** Nero (`.nrg`) input (deferred — unverifiable); `verify`; parent/diff + runtime writes;
-remaining docs. Everything below.
+**Done (cont.):** **Phase F** — parent/diff (`hd::create_raw_from_path_with_parent`, byte-identical
+to `createraw -op`) + the `HdImage` runtime block device (uncompressed in-place / diff over a parent).
+
+**Left:** Nero (`.nrg`) input (deferred — unverifiable); `verify`; rchdman CLI; remaining docs.
+Everything below.
 
 ---
 
@@ -80,13 +83,13 @@ wrapper) · ⬜ to build.
 | `Chd::open(path, writeable, parent)` | `Chd::open(reader, parent)` | 🟡 | takes `Read+Seek`, not a path; **no `writeable`** (reads only). Path helper: `Chd::open(BufReader::new(File::open(p)?), None)`. |
 | `Chd::open_custom(io, …)` | `Chd::open(io, …)` | ✅ | any `Read+Seek` is "custom I/O"; `ChdIo` trait unneeded. |
 | `Chd::create(file, lb, hb, ub, comp)` | `hd::create_*` / `write::write_raw_compressed` | 🟢/⬜ | chd-rs creates via the **format modules**, not a generic `Chd::create`. |
-| `Chd::create_with_parent(…)` | parent/diff (§4 Phase F) | ⬜ | |
+| `Chd::create_with_parent(…)` | `hd::create_raw_from_path_with_parent` / `HdImage::open_with_diff` | ✅ | done (Phase F): compressed child (byte-identical to `createraw -op`) + uncompressed diff. |
 | `version/hunk_bytes/hunk_count/unit_bytes/unit_count/logical_bytes` | `chd.header().{hunk_count,hunk_size,unit_bytes,…}()` | 🟡 | accessor lives on `header()`. Optional: add passthroughs on `Chd`. |
 | `sha1/raw_sha1/parent_sha1` | `chd.header().{sha1,raw_sha1,parent_sha1}()` | 🟡 | same. |
 | `hunk_info(n) -> HunkInfo{compressor,compbytes}` | `chd.map().get_entry(n)` → `MapEntry` | 🟡 | map entry exposes `hunk_type()`+`block_size()`. Optional `HunkInfo` convenience. |
 | `read_hunk(n, buf)` | `chd.hunk(n)?.read_hunk_in(&mut tmp, buf)` | 🟡 | needs a scratch buffer; document. |
 | `read_bytes(off, buf)` | `read::ChdReader` (`Read+Seek`) → `read_exact` | 🟡 | |
-| `write_hunk/write_bytes` | `hd::HdImage` (Phase F) | ⬜ | runtime writes to uncompressed CHDs only. |
+| `write_hunk/write_bytes` | `hd::HdImage::write_sector` | ✅ | done (Phase F): per-sector runtime writes to uncompressed CHDs (in place or into a diff). |
 | `read_metadata(tag, index)` | `chd.metadata()` / `metadata_refs()` filter | 🟡 | optional `Chd::read_metadata(tag,index)` convenience. |
 | `write_metadata/delete_metadata` | `metadata::write_metadata`/`delete_metadata` | ✅ | done & byte-identical (free fns over `Read+Write+Seek`, not methods on `Chd`). chdman edits only uncompressed CHDs; chd-rs also handles compressed. |
 | `clone_all_metadata(src)` | `copy` module (clones all metadata) | ✅ | done inside `copy::copy`. |
@@ -117,7 +120,8 @@ wrapper) · ⬜ to build.
 | `format_gddd(g)` / `read_geometry(chd)` | `hd::format_gddd` / `hd::read_geometry` | ✅ | done; `read_geometry` parses chdman's `createhd` `GDDD`. (Writing GDDD into a new CHD = Phase B.) |
 | `create_from_path/create_from_reader` (createhd) | `hd::create_from_*` (createhd); `hd::create_raw_from_*` (createraw) | ✅ | both done & byte-identical (multi-codec, `progress`/`cancel`). `create_from_*` writes GDDD (+ optional IDNT) + the metadata-inclusive overall SHA-1. |
 | `extract_to_path/extract_to_writer` | `hd::extract_to_path` / `hd::extract_to_writer` | ✅ | done; streams logical bytes via the existing decoder (truncates last-hunk padding). |
-| `HdImage` (+`open`/`open_with_diff`/`reopen_diff`/`read_sector`/`write_sector`/`as_chd*`) | new (Phase F) | ⬜ | runtime block device; uncompressed writes + diff/parent. |
+| `HdImage` (+`open`/`open_with_diff`/`reopen_diff`/`read_sector`/`write_sector`) | `hd::HdImage` | ✅ | done; uncompressed in-place + diff/parent runtime writes. Holds the diff as a raw R/W file + in-memory map (chd-rs's `Chd` is read-only); chdman `extracthd -ip` reads our diff. |
+| `Chd::create_with_parent` (compressed child) | `hd::create_raw_from_path_with_parent` | ✅ | done & **byte-identical to `chdman createraw -op`** — `COMPRESSION_PARENT` refs via the sliding-window parent hash map + `parent_sha1` link. |
 
 ### 3.4 `cd` module (createcd/extractcd)
 
@@ -188,9 +192,11 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
   no equivalent command, e.g. CD→iso). Only **Nero (`.nrg`)** input is deferred — a binary TOC with
   no way to generate a fixture (chdman can't write `.nrg`), so it can't be verified to the
   byte-identity bar.
-- **Phase F — parent/diff + `HdImage`.** Uncompressed diff children vs a compressed parent
-  (parent-hunk dedup lights up here — the driver hook exists), runtime `read_sector`/`write_sector`,
-  `write_hunk`/`write_bytes` equivalents.
+- **Phase F — parent/diff + `HdImage`. ✅ DONE.** Compressed child vs a compressed parent
+  (`hd::create_raw_from_path_with_parent`, `COMPRESSION_PARENT` refs via the sliding-window parent
+  hash map, **byte-identical to `chdman createraw -op`**) + the `HdImage` runtime block device
+  (uncompressed in-place or a diff over a compressed parent; `read_sector`/`write_sector`; verified
+  round-trip and chdman-readable).
 - **Phase G — `Chd::info`/`verify`, `ChdInfo`, rchdman, docs.** Lift verify from rchdman; add
   `ChdInfo`; extend rchdman with `create*`/`copy`/`addmeta`/`delmeta`; port libchdman-rs's
   `format-modules.md` + `chdman-mapping.md`; README rewrite.

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -32,8 +32,11 @@ and [docs/chdman-mapping.md](../../libchdman-rs/docs/chdman-mapping.md).
 - **`dvd` module** (public): `dvd::create_from_*`/`extract_to_*` + `DvdCreateOptions`, byte-identical
   to `chdman createdvd`.
 
-**Left:** `createcd` (the CD create path); metadata write/delete on **existing** CHDs; `cd`;
-`info`/`verify`; parent/diff + runtime writes; remaining docs. Everything below.
+**Done (cont.):** **`cd` createcd** — `cd::create_from_cue`/`create_from_iso` + the CUE/ISO TOC
+parser + CHT2 metadata, byte-identical to `chdman createcd`.
+
+**Left:** `extractcd` + the rest of `cd` (GDI/Nero, `list_tracks`, `CdCookedReader`, `cdfl`);
+`verify`; parent/diff + runtime writes; remaining docs. Everything below.
 
 ---
 
@@ -119,9 +122,9 @@ wrapper) · ⬜ to build.
 
 | libchdman-rs | chd-rs target | status | notes |
 | --- | --- | --- | --- |
-| `CdCreateOptions{hunk_size,codecs}` (default 19584, `[cdlz,cdzl,cdfl,0]`) | same | ⬜ | |
-| `TrackType`/`SubcodeType`/`TrackInfo` | same (chd-rs has `cdrom`/`metadata::KnownMetadata`) | 🟡/⬜ | reconcile with chd-rs's CD constants. |
-| `create_from_cue/create_from_iso` | new | ⬜ | **pure-Rust** CUE/GDI/Nero TOC parser; CD encoders wrap `none/zlib/lzma/zstd/flac` over the 2048+96 sector/subcode split with ECC (reuse `ecc.rs` `generate_ecc`). |
+| `CdCreateOptions{hunk_size,codecs}` (default 19584, `[cdlz,cdzl,cdfl,0]`) | `cd::CdCreateOptions` | ✅ | done; default matches (note: `cdfl` has no encoder yet, so the default set currently errors — pass `[cdlz,cdzl,0,0]`). |
+| `TrackType`/`SubcodeType`/`TrackInfo` | `cd::TrackType`/`cd::SubcodeType` | ✅/⬜ | enums done (+ `type_string`/`subtype_string`); `TrackInfo`/`list_tracks` (read CHT2) still ⬜. |
+| `create_from_cue/create_from_iso` | `cd::create_from_cue`/`create_from_iso` | ✅ | done & **byte-identical to `chdman createcd`** (`-c cdzl`/`cdlz`): pure-Rust CUE (`parse_cue`) + ISO (`parse_iso`) parser, 2448-frame assembly (port of `chd_cd_compressor::read_data`), CHT2 metadata. GDI/Nero/WAVE/GD-ROM not yet. |
 | `list_tracks(chd)` | new (read CHT2 metadata) | ⬜ | |
 | `extract_to_cue/extract_to_iso/extract_to_gdi` | new | ⬜ | |
 | `CdCookedReader` (+`open`/`open_track`/`Read+Seek`) | new | ⬜ | 2048-byte cooked stream over MODE1 tracks. |
@@ -175,9 +178,12 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
   additionally handle compressed CHDs correctly.
 - **Phase D — `dvd` module. ✅ DONE.** Flat 2048 sectors + the empty `DVD ` record (1-NUL payload),
   reusing the createhd metadata writer. `createdvd` verified byte-identical (`-c none/zlib/lzma`).
-- **Phase E — `cd` module.** CD wrapper **encoders** ✅ DONE (`CdEncoder<E,S>`, cdzl/cdlz byte-
-  identical; cdfl pending). Remaining: pure-Rust TOC parser, CHT2 metadata, the createcd/extractcd
-  container, `list_tracks`, `extract_to_{cue,iso,gdi}`, `CdCookedReader`. Verify `createcd`/`extractcd`.
+- **Phase E — `cd` module.** CD wrapper **encoders** ✅ DONE (`CdEncoder<E,S>`, cdzl/cdlz/cdzs
+  byte-identical; cdfl pending). **`createcd` container** ✅ DONE — `cd::create_from_cue`/
+  `create_from_iso` (pure-Rust CUE+ISO TOC parser, 2448-frame assembly, CHT2 metadata) are
+  **byte-identical to `chdman createcd`** (`-c cdzl`/`cdlz`; single MODE1/2352, multi-track
+  MODE1+AUDIO+pregap, flat ISO). Remaining: `extractcd` + `extract_to_{cue,iso,gdi}`, GDI/Nero
+  parsing, `list_tracks`, `CdCookedReader`, the `cdfl` encoder.
 - **Phase F — parent/diff + `HdImage`.** Uncompressed diff children vs a compressed parent
   (parent-hunk dedup lights up here — the driver hook exists), runtime `read_sector`/`write_sector`,
   `write_hunk`/`write_bytes` equivalents.

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -1,0 +1,217 @@
+# libchdman-rs API parity & completion handoff
+
+**Purpose.** Bring chd-rs to **full functional parity** with `../libchdman-rs`'s public API, while
+**keeping chd-rs's existing (read-side) API** where it makes sense and **documenting every
+divergence**. This doc is the spec for that task *and* the roadmap for the rest of the write-support
+work. Strategy lives in [PARITY_PLAN.md](../PARITY_PLAN.md); the live checklist is
+[PROGRESS.md](../PROGRESS.md); the codec encode design is in [encode-integration.md](encode-integration.md).
+
+Read this with the libchdman-rs surface in [docs/format-modules.md](../../libchdman-rs/docs/format-modules.md)
+and [docs/chdman-mapping.md](../../libchdman-rs/docs/chdman-mapping.md).
+
+---
+
+## 1. Where we are (done) vs. what's left
+
+**Done & byte-identical to chdman 0.288:**
+- Codec encoders: `none`/`zlib`/`huff`/`lzma`/`zstd` byte-identical; **`flac`** wired
+  (`RawFlacEncoder`) and **round-trip-verified** (byte-identity libm-gated — see §6).
+- V5 writer core (`mod write`): `write_raw_uncompressed`, `write_raw_compressed`, and the
+  **multi-codec `write_raw`** (per-hunk `find_best_compressor`) — header, `compress_v5_map`, SHA-1,
+  per-hunk codec/none driver, **self-hunk dedup**. Full `chdman createraw` parity (no-parent),
+  single- and multi-codec.
+- **`codec` module** (public): `CHD_CODEC_*`, `parse_codec_spec`/`codec_name`/`codec_exists`.
+- **`CompressionProgress`** (crate root) + the `progress`/`cancel` callback convention.
+- **`hd` module** (public): `HdGeometry`, `HdCreateOptions`, `compute_chs`, `format_gddd`,
+  `read_geometry`, `create_raw_from_reader`/`_path` (createraw), `extract_to_writer`/`_path`, and
+  **`create_from_reader`/`_path` (full `createhd`** — GDDD + optional IDNT).
+- **Metadata writer for new files** (`write.rs`, crate-internal): `build_metadata_blob` +
+  `compute_overall_sha1`, wired into the compressed and uncompressed writers.
+
+- **`copy` module** (public): `copy::copy` + `CopyOptions`, byte-identical to `chdman copy`.
+
+**Left:** `createdvd`/`createcd` (the other metadata-writing create paths); metadata write/delete on
+**existing** CHDs; `cd`/`dvd`; `info`/`verify`; parent/diff + runtime writes; remaining docs.
+Everything below.
+
+---
+
+## 2. The core difference — and the reconciliation policy
+
+This is the divergence to document front and center (decision **D3**, confirmed):
+
+| | libchdman-rs | chd-rs |
+| --- | --- | --- |
+| `Chd` shape | **owned handle** over a path/`ChdIo`, with a `writeable` flag; `read_hunk`/`write_hunk`/`read_bytes`/`write_bytes`/`read_metadata`/… are **methods on it** | **generic, borrowed reader** `Chd<F: Read + Seek>` — read-only; accessors via `header()`/`map()`/`metadata()`; hunk reads via `hunk().read_hunk_in()` + `read::` adapters |
+| Mutability | one handle reads *and* writes at runtime | reads only; creation is via free functions; runtime block writes via a future `HdImage` |
+| Custom I/O | `ChdIo: Read + Write + Seek` trait | any `Read + Seek` — generic, no trait needed |
+| Compression | async `ChdCompressor` + `ChdDataHandler` pull model | synchronous create functions with `progress`/`cancel` callbacks |
+
+**Policy:** *keep chd-rs's idioms; add the parity surface as free functions/modules; document the
+gaps.*
+1. **Keep** `Chd<F: Read + Seek>` and its read API as-is (it's nicer — zero-copy, generic, no FFI).
+2. **Add** the create/extract/copy functionality as libchdman-rs-**named free functions** in new
+   `hd`/`cd`/`dvd`/`copy` modules (this is where chd-rs has nothing today).
+3. **Add** the small value types/constants libchdman-rs exposes (`CHD_CODEC_*`, `parse_codec_spec`,
+   `CompressionProgress`, `ChdInfo`, options structs) — names matched exactly.
+4. **Adapt, don't clone, the `Chd` handle.** Do *not* graft libchdman-rs's owned mutable `Chd`
+   onto chd-rs. Where libchdman-rs uses `chd.read_hunk(n, buf)`, chd-rs users write
+   `chd.hunk(n)?.read_hunk_in(&mut tmp, buf)`. Provide thin convenience methods only where they
+   clearly help (e.g. `Chd::info()`), and document the mapping for everything else.
+5. **Every divergence goes in `docs/libchdman-differences.md`** (see §5) so a libchdman-rs user can
+   port mechanically.
+
+---
+
+## 3. Full API map (libchdman-rs → chd-rs)
+
+`status`: ✅ exists · 🟡 exists but different shape (document it) · 🟢 done in `write` (needs public
+wrapper) · ⬜ to build.
+
+### 3.1 Top-level (`lib.rs`)
+
+| libchdman-rs | chd-rs target | status | notes / difference |
+| --- | --- | --- | --- |
+| `Chd::open(path, writeable, parent)` | `Chd::open(reader, parent)` | 🟡 | takes `Read+Seek`, not a path; **no `writeable`** (reads only). Path helper: `Chd::open(BufReader::new(File::open(p)?), None)`. |
+| `Chd::open_custom(io, …)` | `Chd::open(io, …)` | ✅ | any `Read+Seek` is "custom I/O"; `ChdIo` trait unneeded. |
+| `Chd::create(file, lb, hb, ub, comp)` | `hd::create_*` / `write::write_raw_compressed` | 🟢/⬜ | chd-rs creates via the **format modules**, not a generic `Chd::create`. |
+| `Chd::create_with_parent(…)` | parent/diff (§4 Phase F) | ⬜ | |
+| `version/hunk_bytes/hunk_count/unit_bytes/unit_count/logical_bytes` | `chd.header().{hunk_count,hunk_size,unit_bytes,…}()` | 🟡 | accessor lives on `header()`. Optional: add passthroughs on `Chd`. |
+| `sha1/raw_sha1/parent_sha1` | `chd.header().{sha1,raw_sha1,parent_sha1}()` | 🟡 | same. |
+| `hunk_info(n) -> HunkInfo{compressor,compbytes}` | `chd.map().get_entry(n)` → `MapEntry` | 🟡 | map entry exposes `hunk_type()`+`block_size()`. Optional `HunkInfo` convenience. |
+| `read_hunk(n, buf)` | `chd.hunk(n)?.read_hunk_in(&mut tmp, buf)` | 🟡 | needs a scratch buffer; document. |
+| `read_bytes(off, buf)` | `read::ChdReader` (`Read+Seek`) → `read_exact` | 🟡 | |
+| `write_hunk/write_bytes` | `hd::HdImage` (Phase F) | ⬜ | runtime writes to uncompressed CHDs only. |
+| `read_metadata(tag, index)` | `chd.metadata()` / `metadata_refs()` filter | 🟡 | optional `Chd::read_metadata(tag,index)` convenience. |
+| `write_metadata/delete_metadata` | metadata writer (Phase C) | ⬜ | |
+| `clone_all_metadata(src)` | `copy` module (Phase C) | ⬜ | |
+| `info() -> ChdInfo` | new `ChdInfo` + `Chd::info()` | ⬜ | aggregate header + track count + `is_hd/cd/gd/dvd/av`. |
+| `verify()` | new `Chd::verify()` | ⬜ | rchdman already has the logic — lift into the lib. |
+| `make_tag(a,b,c,d)` | `make_tag(&[u8;4])` (private) | 🟡 | expose (note signature difference) or add a 4-arg form. |
+| `CompressionProgress` | `crate::CompressionProgress` | ✅ | `{bytes_done,bytes_total,ratio}` matched exactly (crate root, `write` feature). |
+| `ChdInfo`, `HunkInfo`, `CompressStep` | new value types | ⬜ | `ChdInfo`/`info()` + `verify()` land in Phase G. |
+| `ChdIo`, `ChdDataHandler`, `ChdCompressor` | — | 🟡 (document) | not ported: chd-rs is generic + synchronous. Document the equivalent patterns. |
+
+### 3.2 `codec` module
+
+| libchdman-rs | chd-rs target | status | notes |
+| --- | --- | --- | --- |
+| `CHD_CODEC_NONE/ZLIB/ZSTD/LZMA/HUFF/FLAC/CD_*/AVHUFF` | `pub mod codec` consts | ✅ | done (`src/codec.rs`), re-exported at crate root. |
+| `codec_exists(u32)` | `codec::codec_exists` | ✅ | done. |
+| `codec_name(u32) -> Option<&str>` | `codec::codec_name` | ✅ | done. |
+| `parse_codec_spec(&str) -> Result<[u32;4]>` | `codec::parse_codec_spec` | ✅ | done; `"none"` or 1..=4 mnemonics. |
+
+### 3.3 `hd` module (createhd/extracthd/createraw/extractraw)
+
+| libchdman-rs | chd-rs target | status | notes |
+| --- | --- | --- | --- |
+| `HdCreateOptions{logical_size,hunk_size,unit_size,codecs,geometry,ident}` | `hd::HdCreateOptions` | ✅ | done; `Default` = hunk 4096 / unit 512 / `[zlib,0,0,0]`. `geometry`/`ident` are Phase B (rejected by `create_raw_*`). |
+| `HdGeometry{cylinders,heads,sectors,sector_bytes}` + `logical_bytes()` | `hd::HdGeometry` | ✅ | done. |
+| `compute_chs(lb, ss) -> HdGeometry` | `hd::compute_chs` | ✅ | done; port of `guess_chs` (`chdman.cpp:1115`), verified vs chdman geometry. |
+| `format_gddd(g)` / `read_geometry(chd)` | `hd::format_gddd` / `hd::read_geometry` | ✅ | done; `read_geometry` parses chdman's `createhd` `GDDD`. (Writing GDDD into a new CHD = Phase B.) |
+| `create_from_path/create_from_reader` (createhd) | `hd::create_from_*` (createhd); `hd::create_raw_from_*` (createraw) | ✅ | both done & byte-identical (multi-codec, `progress`/`cancel`). `create_from_*` writes GDDD (+ optional IDNT) + the metadata-inclusive overall SHA-1. |
+| `extract_to_path/extract_to_writer` | `hd::extract_to_path` / `hd::extract_to_writer` | ✅ | done; streams logical bytes via the existing decoder (truncates last-hunk padding). |
+| `HdImage` (+`open`/`open_with_diff`/`reopen_diff`/`read_sector`/`write_sector`/`as_chd*`) | new (Phase F) | ⬜ | runtime block device; uncompressed writes + diff/parent. |
+
+### 3.4 `cd` module (createcd/extractcd)
+
+| libchdman-rs | chd-rs target | status | notes |
+| --- | --- | --- | --- |
+| `CdCreateOptions{hunk_size,codecs}` (default 19584, `[cdlz,cdzl,cdfl,0]`) | same | ⬜ | |
+| `TrackType`/`SubcodeType`/`TrackInfo` | same (chd-rs has `cdrom`/`metadata::KnownMetadata`) | 🟡/⬜ | reconcile with chd-rs's CD constants. |
+| `create_from_cue/create_from_iso` | new | ⬜ | **pure-Rust** CUE/GDI/Nero TOC parser; CD encoders wrap `none/zlib/lzma/zstd/flac` over the 2048+96 sector/subcode split with ECC (reuse `ecc.rs` `generate_ecc`). |
+| `list_tracks(chd)` | new (read CHT2 metadata) | ⬜ | |
+| `extract_to_cue/extract_to_iso/extract_to_gdi` | new | ⬜ | |
+| `CdCookedReader` (+`open`/`open_track`/`Read+Seek`) | new | ⬜ | 2048-byte cooked stream over MODE1 tracks. |
+
+### 3.5 `dvd` module
+
+| libchdman-rs | chd-rs target | status | notes |
+| --- | --- | --- | --- |
+| `DvdCreateOptions{logical_size,hunk_size,codecs}` (default 4096, `[lzma,zlib,huff,flac]`) | same | ⬜ | needs flac. |
+| `create_from_iso/create_from_reader`, `extract_to_iso/extract_to_writer` | new | ⬜ | empty `DVD ` metadata record (1-NUL-byte quirk). |
+
+### 3.6 `copy` module
+
+| libchdman-rs | chd-rs target | status | notes |
+| --- | --- | --- | --- |
+| `CopyOptions{hunk_size:Option<u32>,codecs}` | `copy::CopyOptions` | ✅ | done. |
+| `copy(src, dst, opts, progress, cancel)` | `copy::copy` | ✅ | done & byte-identical: reads via `read::ChdReader`, recompresses via `write_raw`, clones all metadata, preserves `raw_sha1`/`unit_bytes`. (Legacy CD/GD metadata re-do = Phase E.) |
+
+### 3.7 `enhancements` (libchdman-rs's pure-Rust helpers — chd-rs mostly already has these)
+
+| libchdman-rs | chd-rs | status | notes |
+| --- | --- | --- | --- |
+| `Version` | `header::Version` | ✅ | |
+| `HunkIter` / `MetadataIter` / `MetadataEntry` | `Chd::hunks()` / `metadata()` (+ `iter::`) | 🟡 | different names; document. |
+| `ChdReader` / `HunkReader` | `read::ChdReader` / `read::HunkBufReader` | 🟡 | |
+| `metadata::tags::*` / `make_tag` / `is_cdrom`/`is_gdrom` | `metadata::KnownMetadata` | 🟡 | re-expose the tag constants if useful. |
+| `cdrom::{CD_*}` | `cdrom.rs` constants | 🟡 | |
+
+---
+
+## 4. Remaining work — phased to completion
+
+Each phase: lands a slice of the API map, gets `chdman_compat` byte-identity tests, and updates docs.
+Ordered by dependency; maps onto PARITY_PLAN M3–M8.
+
+- **Phase A — public write surface + `codec` module + flac. ✅ DONE.** Shipped: the `codec` module;
+  the `flac` encoder (`RawFlacEncoder`, round-trip-verified — libm-gated byte-identity); the
+  **multi-codec `write_raw`**; `CompressionProgress` + the `progress: &mut dyn
+  FnMut(CompressionProgress)` / `cancel: &dyn Fn() -> bool` convention; and the public `hd`
+  createraw create (`create_raw_from_*`) + `extract_to_*` + geometry helpers (`compute_chs`,
+  `format_gddd`, `read_geometry`). `cdfl` and the createhd GDDD-write move to E and B.
+- **Phase B — `hd` createhd. ✅ DONE.** Shipped the metadata **writer** for new files
+  (`build_metadata_blob`) + the metadata-inclusive overall SHA-1 (`compute_overall_sha1`), wired
+  into both writers, and `hd::create_from_*` writing GDDD (+ optional IDNT). Verified byte-identical
+  to `chdman createhd` (`-c none`/`zlib`/`lzma`, GDDD+IDNT). The new-file metadata writer is the
+  foundation for Phase C's write/delete-on-existing + `copy`.
+- **Phase C — metadata write/delete + `copy`.** `copy` ✅ DONE (`copy::copy`, byte-identical:
+  recompress + clone metadata via the new-file writer). The new-file metadata **writer**
+  (`build_metadata_blob`) landed in Phase B. Remaining: `write_metadata`/`delete_metadata` on
+  **existing** CHDs (splice the on-disk linked list: overwrite-in-place when the new payload fits,
+  else unlink + append; update the previous entry's `next` / the header `meta_offset`) — verify
+  `addmeta`/`delmeta` byte-identity.
+- **Phase D — `dvd` module.** Flat 2048 sectors + empty `DVD ` record. Verify `createdvd`.
+- **Phase E — `cd` module.** Pure-Rust TOC parser, CD encoders (sector/subcode split + ECC via
+  `ecc.rs`, subcode via `zlib`), CHT2 metadata, `list_tracks`, `extract_to_{cue,iso,gdi}`,
+  `CdCookedReader`. Verify `createcd`/`extractcd`.
+- **Phase F — parent/diff + `HdImage`.** Uncompressed diff children vs a compressed parent
+  (parent-hunk dedup lights up here — the driver hook exists), runtime `read_sector`/`write_sector`,
+  `write_hunk`/`write_bytes` equivalents.
+- **Phase G — `Chd::info`/`verify`, `ChdInfo`, rchdman, docs.** Lift verify from rchdman; add
+  `ChdInfo`; extend rchdman with `create*`/`copy`/`addmeta`/`delmeta`; port libchdman-rs's
+  `format-modules.md` + `chdman-mapping.md`; README rewrite.
+
+---
+
+## 5. Documentation deliverables (update as you go)
+
+1. **`docs/libchdman-differences.md` (new)** — the authoritative "porting from libchdman-rs" guide:
+   every 🟡 row above, the `Chd<F>` vs owned-handle model, no `writeable` open, the read-accessor
+   patterns, no `ChdIo`/`ChdCompressor`, and the create-function callback convention. Goal: a
+   libchdman-rs user can mechanically translate their code.
+2. **Port `chdman-mapping.md` + `format-modules.md`** from libchdman-rs into `chd-rs/docs/`, adjusted
+   for chd-rs's function names/shapes.
+3. **README** — add a write section + a "coming from libchdman-rs?" pointer.
+4. **PROGRESS.md** — tick the API-map rows as they land; keep the session log current.
+
+---
+
+## 6. Verification (per phase)
+
+- **chdman byte-identity** (the bar): each new `create*` produces a CHD byte-identical to the
+  matching `chdman` command (extend `chdman_compat.rs`; gated `chdman_compat_tests`).
+- **Round-trip**: `create → chd-rs decode → equal logical bytes + raw_sha1`.
+- **API-shape tests**: a doc-test per new public function so the surface compiles as documented.
+- ⚠️ **flac is libm-dependent** — byte-identity for `flac`/`cdfl`/dvd-default needs the reference
+  chdman and `libflac-rs` to agree on libm (glibc). Confirm the reference build before asserting
+  byte-identity on flac paths; until then gate those as round-trip-only.
+
+---
+
+## 7. Definition of done
+
+Functional parity with every libchdman-rs public API (per §3), each create path byte-identical to
+chdman 0.288 (or round-trip-correct where flac/libm blocks byte-identity), the differences doc
+complete, and `chd-rs`'s existing read API unchanged.

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -37,10 +37,11 @@ and [docs/chdman-mapping.md](../../libchdman-rs/docs/chdman-mapping.md).
 `CdCookedReader`; all byte-identical to `chdman` (all four codecs; `cdfl` glibc-gated).
 
 **Done (cont.):** **Phase F** — parent/diff (`hd::create_raw_from_path_with_parent`, byte-identical
-to `createraw -op`) + the `HdImage` runtime block device (uncompressed in-place / diff over a parent).
+to `createraw -op`) + the `HdImage` runtime block device. **Phase G** — `Chd::verify()`, the
+chdman-style `rchdman` CLI, and the write docs (README + chdman-mapping).
 
-**Left:** Nero (`.nrg`) input (deferred — unverifiable); `verify`; rchdman CLI; remaining docs.
-Everything below.
+**All phases A–G are complete.** Deferred (documented): Nero (`.nrg`) input (unverifiable without a
+fixture chdman can't produce) and `copy` re-doing legacy CD metadata for legacy-source copies.
 
 ---
 
@@ -94,7 +95,7 @@ wrapper) · ⬜ to build.
 | `write_metadata/delete_metadata` | `metadata::write_metadata`/`delete_metadata` | ✅ | done & byte-identical (free fns over `Read+Write+Seek`, not methods on `Chd`). chdman edits only uncompressed CHDs; chd-rs also handles compressed. |
 | `clone_all_metadata(src)` | `copy` module (clones all metadata) | ✅ | done inside `copy::copy`. |
 | `info() -> ChdInfo` | `ChdInfo` + `Chd::info()` | ✅ | done; header + metadata tags + track count + `is_hd/cd/gd/dvd/av` (read-side). |
-| `verify()` | new `Chd::verify()` | ⬜ | deferred — needs a SHA-1 dep in the read-only build. |
+| `verify()` | `Chd::verify() -> VerifyResult` | ✅ | done; `verify` feature (pulls only `sha1`; `write` enables it). Recomputes raw + overall SHA-1, compares to header. |
 | `make_tag(a,b,c,d)` | `make_tag(&[u8;4])` (private) | 🟡 | expose (note signature difference) or add a 4-arg form. |
 | `CompressionProgress` | `crate::CompressionProgress` | ✅ | `{bytes_done,bytes_total,ratio}` matched exactly (crate root, `write` feature). |
 | `ChdInfo` | `crate::ChdInfo` | ✅ | done (crate root). |
@@ -197,9 +198,9 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
   hash map, **byte-identical to `chdman createraw -op`**) + the `HdImage` runtime block device
   (uncompressed in-place or a diff over a compressed parent; `read_sector`/`write_sector`; verified
   round-trip and chdman-readable).
-- **Phase G — `Chd::info`/`verify`, `ChdInfo`, rchdman, docs.** Lift verify from rchdman; add
-  `ChdInfo`; extend rchdman with `create*`/`copy`/`addmeta`/`delmeta`; port libchdman-rs's
-  `format-modules.md` + `chdman-mapping.md`; README rewrite.
+- **Phase G — `Chd::info`/`verify`, rchdman, docs. ✅ DONE.** `Chd::info`/`ChdInfo` +
+  `Chd::verify()`/`VerifyResult` (the `verify` feature); rchdman extended to a chdman-style CLI
+  (create/extract/copy/addmeta/delmeta/verify); README "Writing CHDs" + `docs/chdman-mapping.md`.
 
 ---
 

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -86,11 +86,12 @@ wrapper) · ⬜ to build.
 | `read_metadata(tag, index)` | `chd.metadata()` / `metadata_refs()` filter | 🟡 | optional `Chd::read_metadata(tag,index)` convenience. |
 | `write_metadata/delete_metadata` | `metadata::write_metadata`/`delete_metadata` | ✅ | done & byte-identical (free fns over `Read+Write+Seek`, not methods on `Chd`). chdman edits only uncompressed CHDs; chd-rs also handles compressed. |
 | `clone_all_metadata(src)` | `copy` module (clones all metadata) | ✅ | done inside `copy::copy`. |
-| `info() -> ChdInfo` | new `ChdInfo` + `Chd::info()` | ⬜ | aggregate header + track count + `is_hd/cd/gd/dvd/av`. |
-| `verify()` | new `Chd::verify()` | ⬜ | rchdman already has the logic — lift into the lib. |
+| `info() -> ChdInfo` | `ChdInfo` + `Chd::info()` | ✅ | done; header + metadata tags + track count + `is_hd/cd/gd/dvd/av` (read-side). |
+| `verify()` | new `Chd::verify()` | ⬜ | deferred — needs a SHA-1 dep in the read-only build. |
 | `make_tag(a,b,c,d)` | `make_tag(&[u8;4])` (private) | 🟡 | expose (note signature difference) or add a 4-arg form. |
 | `CompressionProgress` | `crate::CompressionProgress` | ✅ | `{bytes_done,bytes_total,ratio}` matched exactly (crate root, `write` feature). |
-| `ChdInfo`, `HunkInfo`, `CompressStep` | new value types | ⬜ | `ChdInfo`/`info()` + `verify()` land in Phase G. |
+| `ChdInfo` | `crate::ChdInfo` | ✅ | done (crate root). |
+| `HunkInfo`, `CompressStep` | new value types | ⬜ | minor; `verify()` lands in Phase G. |
 | `ChdIo`, `ChdDataHandler`, `ChdCompressor` | — | 🟡 (document) | not ported: chd-rs is generic + synchronous. Document the equivalent patterns. |
 
 ### 3.2 `codec` module

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -32,11 +32,12 @@ and [docs/chdman-mapping.md](../../libchdman-rs/docs/chdman-mapping.md).
 - **`dvd` module** (public): `dvd::create_from_*`/`extract_to_*` + `DvdCreateOptions`, byte-identical
   to `chdman createdvd`.
 
-**Done (cont.):** **`cd` createcd** — `cd::create_from_cue`/`create_from_iso` + the CUE/ISO TOC
-parser + CHT2 metadata, byte-identical to `chdman createcd`.
+**Done (cont.):** **`cd` createcd + extractcd** — `cd::create_from_cue`/`create_from_iso` (CUE/ISO
+TOC parser + CHT2) and `cd::extract_to_cue` + `list_tracks`/`TrackInfo`, all byte-identical to
+`chdman createcd`/`extractcd` (all four codecs encode; `cdfl` glibc-gated).
 
-**Left:** `extractcd` + the rest of `cd` (GDI/Nero, `list_tracks`, `CdCookedReader`); `verify`;
-parent/diff + runtime writes; remaining docs. Everything below.
+**Left:** the rest of `cd` (GDI/Nero parsing, `.gdi`/split-bin + `extract_to_iso`, `CdCookedReader`);
+`verify`; parent/diff + runtime writes; remaining docs. Everything below.
 
 ---
 
@@ -123,10 +124,11 @@ wrapper) · ⬜ to build.
 | libchdman-rs | chd-rs target | status | notes |
 | --- | --- | --- | --- |
 | `CdCreateOptions{hunk_size,codecs}` (default 19584, `[cdlz,cdzl,cdfl,0]`) | `cd::CdCreateOptions` | ✅ | done; default matches and works (all of `cdlz`/`cdzl`/`cdfl` encode — `cdfl` byte-identical to a glibc chdman, libm-gated). |
-| `TrackType`/`SubcodeType`/`TrackInfo` | `cd::TrackType`/`cd::SubcodeType` | ✅/⬜ | enums done (+ `type_string`/`subtype_string`); `TrackInfo`/`list_tracks` (read CHT2) still ⬜. |
+| `TrackType`/`SubcodeType`/`TrackInfo` | `cd::TrackType`/`cd::SubcodeType`/`cd::TrackInfo` | ✅ | done (+ `type_string`/`subtype_string`); `TrackInfo` returned by `list_tracks`. |
 | `create_from_cue/create_from_iso` | `cd::create_from_cue`/`create_from_iso` | ✅ | done & **byte-identical to `chdman createcd`** (`-c cdzl`/`cdlz`): pure-Rust CUE (`parse_cue`) + ISO (`parse_iso`) parser, 2448-frame assembly (port of `chd_cd_compressor::read_data`), CHT2 metadata. GDI/Nero/WAVE/GD-ROM not yet. |
-| `list_tracks(chd)` | new (read CHT2 metadata) | ⬜ | |
-| `extract_to_cue/extract_to_iso/extract_to_gdi` | new | ⬜ | |
+| `list_tracks(chd)` | `cd::list_tracks(&mut Chd)` | ✅ | done; reads `CHT2`/`CHTR` (port of `parse_metadata`). Takes `&mut Chd` (chd-rs reads metadata mutably). |
+| `extract_to_cue` | `cd::extract_to_cue` | ✅ | done & **byte-identical to `chdman extractcd`** (cue **and** bin), single + multi-track. Cue line endings match the host platform (CRLF on Windows, LF on Linux), like chdman. |
+| `extract_to_iso/extract_to_gdi` | new | ⬜ | `.gdi`/split-bin + single-track `.iso` extraction. |
 | `CdCookedReader` (+`open`/`open_track`/`Read+Seek`) | new | ⬜ | 2048-byte cooked stream over MODE1 tracks. |
 
 ### 3.5 `dvd` module
@@ -182,8 +184,10 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
   byte-identical; **`cdfl`** (`CdFlacEncoder`) byte-identical to a glibc chdman (libm-gated, like raw
   `flac`). **`createcd` container** ✅ DONE — `cd::create_from_cue`/`create_from_iso` (pure-Rust
   CUE+ISO TOC parser, 2448-frame assembly, CHT2 metadata) are **byte-identical to `chdman createcd`**
-  (single MODE1/2352, multi-track MODE1+AUDIO+pregap, flat ISO, all four codecs). Remaining:
-  `extractcd` + `extract_to_{cue,iso,gdi}`, GDI/Nero parsing, `list_tracks`, `CdCookedReader`.
+  (single MODE1/2352, multi-track MODE1+AUDIO+pregap, flat ISO, all four codecs). **`extractcd`** ✅
+  DONE — `cd::extract_to_cue` + `list_tracks`/`TrackInfo`, **byte-identical to `chdman extractcd`**
+  (cue + bin) with a full create→extract round-trip. Remaining: GDI/Nero parsing,
+  `.gdi`/split-bin + `extract_to_iso`, `CdCookedReader`.
 - **Phase F — parent/diff + `HdImage`.** Uncompressed diff children vs a compressed parent
   (parent-hunk dedup lights up here — the driver hook exists), runtime `read_sector`/`write_sector`,
   `write_hunk`/`write_bytes` equivalents.

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -84,8 +84,8 @@ wrapper) · ⬜ to build.
 | `read_bytes(off, buf)` | `read::ChdReader` (`Read+Seek`) → `read_exact` | 🟡 | |
 | `write_hunk/write_bytes` | `hd::HdImage` (Phase F) | ⬜ | runtime writes to uncompressed CHDs only. |
 | `read_metadata(tag, index)` | `chd.metadata()` / `metadata_refs()` filter | 🟡 | optional `Chd::read_metadata(tag,index)` convenience. |
-| `write_metadata/delete_metadata` | metadata writer (Phase C) | ⬜ | |
-| `clone_all_metadata(src)` | `copy` module (Phase C) | ⬜ | |
+| `write_metadata/delete_metadata` | `metadata::write_metadata`/`delete_metadata` | ✅ | done & byte-identical (free fns over `Read+Write+Seek`, not methods on `Chd`). chdman edits only uncompressed CHDs; chd-rs also handles compressed. |
+| `clone_all_metadata(src)` | `copy` module (clones all metadata) | ✅ | done inside `copy::copy`. |
 | `info() -> ChdInfo` | new `ChdInfo` + `Chd::info()` | ⬜ | aggregate header + track count + `is_hd/cd/gd/dvd/av`. |
 | `verify()` | new `Chd::verify()` | ⬜ | rchdman already has the logic — lift into the lib. |
 | `make_tag(a,b,c,d)` | `make_tag(&[u8;4])` (private) | 🟡 | expose (note signature difference) or add a 4-arg form. |
@@ -167,12 +167,11 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
   into both writers, and `hd::create_from_*` writing GDDD (+ optional IDNT). Verified byte-identical
   to `chdman createhd` (`-c none`/`zlib`/`lzma`, GDDD+IDNT). The new-file metadata writer is the
   foundation for Phase C's write/delete-on-existing + `copy`.
-- **Phase C — metadata write/delete + `copy`.** `copy` ✅ DONE (`copy::copy`, byte-identical:
-  recompress + clone metadata via the new-file writer). The new-file metadata **writer**
-  (`build_metadata_blob`) landed in Phase B. Remaining: `write_metadata`/`delete_metadata` on
-  **existing** CHDs (splice the on-disk linked list: overwrite-in-place when the new payload fits,
-  else unlink + append; update the previous entry's `next` / the header `meta_offset`) — verify
-  `addmeta`/`delmeta` byte-identity.
+- **Phase C — metadata write/delete + `copy`. ✅ DONE.** `copy::copy` (recompress + clone metadata)
+  and `metadata::write_metadata`/`delete_metadata` (in-place edit of an existing CHD's linked list:
+  overwrite-in-place-or-append + relink + overall-SHA-1 update) are both byte-identical to chdman
+  (`copy`/`addmeta`/`delmeta`). Note: chdman only edits *uncompressed* CHDs; chd-rs's free functions
+  additionally handle compressed CHDs correctly.
 - **Phase D — `dvd` module. ✅ DONE.** Flat 2048 sectors + the empty `DVD ` record (1-NUL payload),
   reusing the createhd metadata writer. `createdvd` verified byte-identical (`-c none/zlib/lzma`).
 - **Phase E — `cd` module.** Pure-Rust TOC parser, CD encoders (sector/subcode split + ECC via

--- a/docs/libchdman-parity.md
+++ b/docs/libchdman-parity.md
@@ -175,9 +175,9 @@ Ordered by dependency; maps onto PARITY_PLAN M3–M8.
   additionally handle compressed CHDs correctly.
 - **Phase D — `dvd` module. ✅ DONE.** Flat 2048 sectors + the empty `DVD ` record (1-NUL payload),
   reusing the createhd metadata writer. `createdvd` verified byte-identical (`-c none/zlib/lzma`).
-- **Phase E — `cd` module.** Pure-Rust TOC parser, CD encoders (sector/subcode split + ECC via
-  `ecc.rs`, subcode via `zlib`), CHT2 metadata, `list_tracks`, `extract_to_{cue,iso,gdi}`,
-  `CdCookedReader`. Verify `createcd`/`extractcd`.
+- **Phase E — `cd` module.** CD wrapper **encoders** ✅ DONE (`CdEncoder<E,S>`, cdzl/cdlz byte-
+  identical; cdfl pending). Remaining: pure-Rust TOC parser, CHT2 metadata, the createcd/extractcd
+  container, `list_tracks`, `extract_to_{cue,iso,gdi}`, `CdCookedReader`. Verify `createcd`/`extractcd`.
 - **Phase F — parent/diff + `HdImage`.** Uncompressed diff children vs a compressed parent
   (parent-hunk dedup lights up here — the driver hook exists), runtime `read_sector`/`write_sector`,
   `write_hunk`/`write_bytes` equivalents.

--- a/rchdman/Cargo.toml
+++ b/rchdman/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-chd = { path = "../chd-rs", features = ["unstable_lending_iterators", "max_perf"]}
+chd = { path = "../chd-rs", features = ["unstable_lending_iterators", "max_perf", "write-zstd"]}
 clap = { version = "3", features = ["derive"] }
 anyhow = "1"
 thousands = "0.2.0"

--- a/rchdman/src/main.rs
+++ b/rchdman/src/main.rs
@@ -6,13 +6,40 @@ use chd::metadata::Metadata;
 use chd::Chd;
 use clap::{Parser, Subcommand};
 use num_traits::cast::FromPrimitive;
-use sha1::{Digest, Sha1};
 use std::ffi::OsStr;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 use thousands::Separable;
+
+/// Parse a chdman-style `-c` compression spec (e.g. `"lzma,zlib"` or `"none"`).
+fn parse_comp(spec: &str) -> anyhow::Result<[u32; 4]> {
+    chd::parse_codec_spec(spec).map_err(|_| anyhow!("invalid compression spec: {spec}"))
+}
+
+/// Refuse to clobber an existing output unless `--force`.
+fn check_overwrite(out: &Path, force: bool) -> anyhow::Result<()> {
+    if !force && out.exists() {
+        return Err(anyhow!(
+            "Output file already exists (use --force to overwrite): {}",
+            out.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Per-hunk progress line for the create/copy commands.
+fn print_progress(p: chd::CompressionProgress) {
+    if p.bytes_total > 0 {
+        print!(
+            "\rCompressing, {:5.1}% complete... (ratio={:.1}%)",
+            100.0 * p.bytes_done as f64 / p.bytes_total as f64,
+            100.0 * p.ratio
+        );
+        let _ = std::io::stdout().flush();
+    }
+}
 
 fn validate_file_exists(s: &OsStr) -> Result<PathBuf, std::io::Error> {
     let path = PathBuf::from(s);
@@ -110,6 +137,122 @@ enum Commands {
         /// parent file name for input CHD
         #[clap(short = 'p', long, parse(try_from_os_str = validate_file_exists))]
         inputparent: Option<PathBuf>,
+    },
+    /// Create a raw CHD from the input file
+    Createraw {
+        #[clap(short, long, parse(try_from_os_str = validate_file_exists))]
+        input: PathBuf,
+        #[clap(short, long)]
+        output: PathBuf,
+        /// parent CHD for the output (creates a compressed child/diff)
+        #[clap(long = "outputparent", short = 'p')]
+        outputparent: Option<PathBuf>,
+        #[clap(long = "hunksize", default_value = "4096")]
+        hunksize: u32,
+        #[clap(long = "unitsize", default_value = "512")]
+        unitsize: u32,
+        #[clap(short = 'c', long, default_value = "zlib")]
+        compression: String,
+        #[clap(short, long)]
+        force: bool,
+    },
+    /// Create a hard-disk CHD from the input file
+    Createhd {
+        #[clap(short, long, parse(try_from_os_str = validate_file_exists))]
+        input: PathBuf,
+        #[clap(short, long)]
+        output: PathBuf,
+        #[clap(long = "hunksize", default_value = "4096")]
+        hunksize: u32,
+        #[clap(long = "unitsize", default_value = "512")]
+        unitsize: u32,
+        #[clap(short = 'c', long, default_value = "lzma,zlib,huff,flac")]
+        compression: String,
+        #[clap(short, long)]
+        force: bool,
+    },
+    /// Create a CD CHD from a CUE / GDI / ISO input
+    Createcd {
+        #[clap(short, long, parse(try_from_os_str = validate_file_exists))]
+        input: PathBuf,
+        #[clap(short, long)]
+        output: PathBuf,
+        #[clap(short = 'c', long, default_value = "cdlz,cdzl,cdfl")]
+        compression: String,
+        #[clap(short, long)]
+        force: bool,
+    },
+    /// Create a DVD CHD from the input ISO
+    Createdvd {
+        #[clap(short, long, parse(try_from_os_str = validate_file_exists))]
+        input: PathBuf,
+        #[clap(short, long)]
+        output: PathBuf,
+        #[clap(short = 'c', long, default_value = "lzma,zlib,huff,flac")]
+        compression: String,
+        #[clap(short, long)]
+        force: bool,
+    },
+    /// Copy a CHD, optionally recompressing / re-hunking
+    Copy {
+        #[clap(short, long, parse(try_from_os_str = validate_file_exists))]
+        input: PathBuf,
+        #[clap(short, long)]
+        output: PathBuf,
+        #[clap(long = "hunksize")]
+        hunksize: Option<u32>,
+        #[clap(short = 'c', long, default_value = "zlib")]
+        compression: String,
+        #[clap(short, long)]
+        force: bool,
+    },
+    /// Add a metadata item to a CHD
+    Addmeta {
+        #[clap(short, long, parse(try_from_os_str = validate_file_exists))]
+        input: PathBuf,
+        #[clap(short, long, parse(try_from_str = try_fourcc_to_u32))]
+        tag: u32,
+        #[clap(short = 'x', long, default_value = "0")]
+        index: u32,
+        /// text value (a trailing NUL is appended, as chdman does)
+        #[clap(long = "valuetext", short = 'v')]
+        valuetext: Option<String>,
+        /// file whose raw contents become the value
+        #[clap(long = "valuefile", short = 'b')]
+        valuefile: Option<PathBuf>,
+        /// do not flag the entry as checksummed
+        #[clap(long = "nochecksum", short = 'n')]
+        nochecksum: bool,
+    },
+    /// Delete a metadata item from a CHD
+    Delmeta {
+        #[clap(short, long, parse(try_from_os_str = validate_file_exists))]
+        input: PathBuf,
+        #[clap(short, long, parse(try_from_str = try_fourcc_to_u32))]
+        tag: u32,
+        #[clap(short = 'x', long, default_value = "0")]
+        index: u32,
+    },
+    /// Extract a CD CHD to a CUE/GDI + binary track file(s)
+    Extractcd {
+        #[clap(short, long, parse(try_from_os_str = validate_file_exists))]
+        input: PathBuf,
+        #[clap(short, long)]
+        output: PathBuf,
+        /// output bin filename (default: the output name with a .bin extension)
+        #[clap(long = "outputbin", short = 'b')]
+        outputbin: Option<PathBuf>,
+        #[clap(short, long)]
+        force: bool,
+    },
+    /// Extract a DVD CHD to an ISO
+    Extractdvd {
+        #[clap(short, long, parse(try_from_os_str = validate_file_exists))]
+        input: PathBuf,
+        #[clap(short, long)]
+        output: PathBuf,
+        #[clap(short, long)]
+        force: bool,
     },
 }
 
@@ -515,39 +658,207 @@ fn verify(input: impl AsRef<Path>, inputparent: Option<impl AsRef<Path>>) -> any
 
     let mut chd = Chd::open(f, p)?;
 
-    let header = chd.header();
-    if !header.is_compressed() {
+    if !chd.header().is_compressed() {
         return Err(anyhow!("No verification to be done; CHD is uncompressed"));
     }
 
-    let raw_sha1 = match header {
-        Header::V3Header(h) => h.sha1,
-        Header::V4Header(h) => h.raw_sha1,
-        Header::V5Header(h) => h.raw_sha1,
-        _ => return Err(anyhow!("No verification to be done; CHD has no checksum")),
-    };
+    // Full verification: raw (data) SHA-1 over the logical bytes + the metadata-inclusive overall.
+    let r = chd.verify()?;
 
-    let mut hasher = Sha1::new();
-    let mut out_buf = chd.get_hunksized_buffer();
-    let mut hunk_iter = chd.hunks();
-    let mut comp_buffer = Vec::new();
-    while let Some(mut hunk) = hunk_iter.next() {
-        hunk.read_hunk_in(&mut comp_buffer, &mut out_buf)?;
-        hasher.update(&out_buf);
-    }
-    let raw_result = hasher.finalize();
-
-    if raw_result[..] == raw_sha1[..] {
+    if r.raw_sha1_valid() {
         println!("Raw SHA1 verification successful!");
     } else {
         eprintln!(
-            "Error: Raw SHA1 in header = {}\n              actual SHA1 = {}\n",
-            hex::encode(raw_sha1),
-            hex::encode(raw_result)
+            "Error: Raw SHA1 in header = {}\n              actual SHA1 = {}",
+            hex::encode(r.expected_raw_sha1),
+            hex::encode(r.computed_raw_sha1)
         );
     }
+    if r.overall_sha1_valid() {
+        println!("Overall SHA1 verification successful!");
+    } else {
+        eprintln!(
+            "Error: Overall SHA1 in header = {}\n                  actual SHA1 = {}",
+            hex::encode(r.expected_sha1),
+            hex::encode(r.computed_sha1)
+        );
+    }
+    Ok(())
+}
 
-    // todo: full verification
+fn createraw(
+    input: &Path,
+    output: &Path,
+    outputparent: Option<&PathBuf>,
+    hunksize: u32,
+    unitsize: u32,
+    compression: &str,
+    force: bool,
+) -> anyhow::Result<()> {
+    println!("\nchd-rs - rchdman createraw");
+    check_overwrite(output, force)?;
+    let opts = chd::hd::HdCreateOptions {
+        hunk_size: hunksize,
+        unit_size: unitsize,
+        codecs: parse_comp(compression)?,
+        ..Default::default()
+    };
+    if let Some(parent) = outputparent {
+        chd::hd::create_raw_from_path_with_parent(
+            input,
+            output,
+            parent,
+            opts,
+            &mut print_progress,
+            &|| false,
+        )?;
+    } else {
+        chd::hd::create_raw_from_path(input, output, opts, &mut print_progress, &|| false)?;
+    }
+    println!("\nCompression complete");
+    Ok(())
+}
+
+fn createhd(
+    input: &Path,
+    output: &Path,
+    hunksize: u32,
+    unitsize: u32,
+    compression: &str,
+    force: bool,
+) -> anyhow::Result<()> {
+    println!("\nchd-rs - rchdman createhd");
+    check_overwrite(output, force)?;
+    let opts = chd::hd::HdCreateOptions {
+        hunk_size: hunksize,
+        unit_size: unitsize,
+        codecs: parse_comp(compression)?,
+        ..Default::default()
+    };
+    chd::hd::create_from_path(input, output, opts, &mut print_progress, &|| false)?;
+    println!("\nCompression complete");
+    Ok(())
+}
+
+fn createcd(input: &Path, output: &Path, compression: &str, force: bool) -> anyhow::Result<()> {
+    println!("\nchd-rs - rchdman createcd");
+    check_overwrite(output, force)?;
+    let opts = chd::cd::CdCreateOptions {
+        codecs: parse_comp(compression)?,
+        ..Default::default()
+    };
+    let ext = input
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "cue" => chd::cd::create_from_cue(input, output, opts, &mut print_progress, &|| false)?,
+        "gdi" => chd::cd::create_from_gdi(input, output, opts, &mut print_progress, &|| false)?,
+        _ => chd::cd::create_from_iso(input, output, opts, &mut print_progress, &|| false)?,
+    }
+    println!("\nCompression complete");
+    Ok(())
+}
+
+fn createdvd(input: &Path, output: &Path, compression: &str, force: bool) -> anyhow::Result<()> {
+    println!("\nchd-rs - rchdman createdvd");
+    check_overwrite(output, force)?;
+    let opts = chd::dvd::DvdCreateOptions {
+        codecs: parse_comp(compression)?,
+        ..Default::default()
+    };
+    chd::dvd::create_from_iso(input, output, opts, &mut print_progress, &|| false)?;
+    println!("\nCompression complete");
+    Ok(())
+}
+
+fn copy(
+    input: &Path,
+    output: &Path,
+    hunksize: Option<u32>,
+    compression: &str,
+    force: bool,
+) -> anyhow::Result<()> {
+    println!("\nchd-rs - rchdman copy");
+    check_overwrite(output, force)?;
+    let opts = chd::copy::CopyOptions {
+        hunk_size: hunksize,
+        codecs: parse_comp(compression)?,
+    };
+    chd::copy::copy(input, output, opts, &mut print_progress, &|| false)?;
+    println!("\nCompression complete");
+    Ok(())
+}
+
+fn addmeta(
+    input: &Path,
+    tag: u32,
+    index: u32,
+    valuetext: Option<&String>,
+    valuefile: Option<&PathBuf>,
+    nochecksum: bool,
+) -> anyhow::Result<()> {
+    println!("\nchd-rs - rchdman addmeta");
+    let data = if let Some(text) = valuetext {
+        let mut b = text.clone().into_bytes();
+        b.push(0); // chdman stores the C string's NUL terminator
+        b
+    } else if let Some(file) = valuefile {
+        std::fs::read(file)?
+    } else {
+        return Err(anyhow!("either --valuetext or --valuefile is required"));
+    };
+    let flags = if nochecksum {
+        0
+    } else {
+        chd::metadata::METADATA_FLAG_CHECKSUM
+    };
+    let mut file = OpenOptions::new().read(true).write(true).open(input)?;
+    chd::metadata::write_metadata(&mut file, tag, index, &data, flags)?;
+    println!("Metadata added");
+    Ok(())
+}
+
+fn delmeta(input: &Path, tag: u32, index: u32) -> anyhow::Result<()> {
+    println!("\nchd-rs - rchdman delmeta");
+    let mut file = OpenOptions::new().read(true).write(true).open(input)?;
+    chd::metadata::delete_metadata(&mut file, tag, index)?;
+    println!("Metadata deleted");
+    Ok(())
+}
+
+fn extractcd(
+    input: &Path,
+    output: &Path,
+    outputbin: Option<&PathBuf>,
+    force: bool,
+) -> anyhow::Result<()> {
+    println!("\nchd-rs - rchdman extractcd");
+    check_overwrite(output, force)?;
+    let is_gdi = output
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("gdi"))
+        .unwrap_or(false);
+    if is_gdi {
+        chd::cd::extract_to_gdi(input, output, &mut |_| {})?;
+    } else {
+        let bin = outputbin
+            .cloned()
+            .unwrap_or_else(|| output.with_extension("bin"));
+        check_overwrite(&bin, force)?;
+        chd::cd::extract_to_cue(input, output, &bin, &mut |_| {})?;
+    }
+    println!("Extraction complete");
+    Ok(())
+}
+
+fn extractdvd(input: &Path, output: &Path, force: bool) -> anyhow::Result<()> {
+    println!("\nchd-rs - rchdman extractdvd");
+    check_overwrite(output, force)?;
+    chd::dvd::extract_to_iso(input, output, &mut |_| {})?;
+    println!("Extraction complete");
     Ok(())
 }
 
@@ -645,6 +956,77 @@ fn main() -> anyhow::Result<()> {
             force,
             output,
         } => extractraw(input, inputparent.as_deref(), output, *force)?,
+        Commands::Createraw {
+            input,
+            output,
+            outputparent,
+            hunksize,
+            unitsize,
+            compression,
+            force,
+        } => createraw(
+            input,
+            output,
+            outputparent.as_ref(),
+            *hunksize,
+            *unitsize,
+            compression,
+            *force,
+        )?,
+        Commands::Createhd {
+            input,
+            output,
+            hunksize,
+            unitsize,
+            compression,
+            force,
+        } => createhd(input, output, *hunksize, *unitsize, compression, *force)?,
+        Commands::Createcd {
+            input,
+            output,
+            compression,
+            force,
+        } => createcd(input, output, compression, *force)?,
+        Commands::Createdvd {
+            input,
+            output,
+            compression,
+            force,
+        } => createdvd(input, output, compression, *force)?,
+        Commands::Copy {
+            input,
+            output,
+            hunksize,
+            compression,
+            force,
+        } => copy(input, output, *hunksize, compression, *force)?,
+        Commands::Addmeta {
+            input,
+            tag,
+            index,
+            valuetext,
+            valuefile,
+            nochecksum,
+        } => addmeta(
+            input,
+            *tag,
+            *index,
+            valuetext.as_ref(),
+            valuefile.as_ref(),
+            *nochecksum,
+        )?,
+        Commands::Delmeta { input, tag, index } => delmeta(input, *tag, *index)?,
+        Commands::Extractcd {
+            input,
+            output,
+            outputbin,
+            force,
+        } => extractcd(input, output, outputbin.as_ref(), *force)?,
+        Commands::Extractdvd {
+            input,
+            output,
+            force,
+        } => extractdvd(input, output, *force)?,
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds pure-Rust **write / create support** to chd-rs, with output **byte-for-byte identical to chdman 0.288**, while keeping the existing read API unchanged. This brings chd-rs to functional parity with `libchdman-rs` (the MAME C++ wrapper) **without any C/C++ toolchain** — every codec encoder is a bit-exact pure-Rust port.

32 commits, 39 files. All encode code is behind feature flags, so the **default read-only build pulls in nothing extra**.

## What's included

**Create / extract — all byte-identical to chdman:**
- `createraw` / `extractraw` — `hd::create_raw_from_*` / `hd::extract_to_*`
- `createhd` — `hd::create_from_*` (GDDD geometry + optional IDNT)
- `createcd` / `extractcd` — `cd::create_from_{cue,gdi,iso}` / `extract_to_{cue,gdi,iso}`; pure-Rust CUE/GDI/ISO TOC parsers, `list_tracks`, `CdCookedReader`
- `createdvd` / `extractdvd` — `dvd::create_from_iso` / `extract_to_iso`
- `copy` — `copy::copy`
- `addmeta` / `delmeta` — `metadata::write_metadata` / `delete_metadata`

**Codecs (bit-exact pure-Rust encoders):** zlib, lzma, zstd, huff, flac + the CD wrappers cdlz/cdzl/cdzs/cdfl. All byte-identical to chdman 0.288 except the FLAC paths, which are libm-gated — byte-identical to a **glibc** chdman, round-trip-correct otherwise (verified against a glibc chdman 0.288 built specifically for this).

**Parent / diff + runtime device:**
- `hd::create_raw_from_path_with_parent` — compressed child (`COMPRESSION_PARENT` refs), byte-identical to `createraw -op`
- `hd::HdImage` — runtime block device: per-sector `read_sector` / `write_sector` on an uncompressed CHD, in place or as an uncompressed diff over a compressed parent (chdman `extracthd -ip` reads our diff back)

**Read-side additions:** `Chd::info()` + `ChdInfo`; `Chd::verify()` + `VerifyResult` (raw + overall SHA-1).

**`rchdman` CLI:** grew from read-only into a chdman-style front-end — createraw/hd/cd/dvd, copy, addmeta/delmeta, extractcd/extractdvd, and full verify.

## Verification

The bar throughout is **byte-for-byte identity vs chdman 0.288**, checked by an in-crate `chdman_compat` test suite that shells out to a real chdman binary and compares the output bytes per hunk / whole file. 67 lib + compat tests green; CI (build + test on ubuntu/windows/macos + a fmt gate) passing.

## API stability & features

- **Read API is unchanged** — existing read code needs no edits.
- One source-breaking change: `chd::Error` gained a `Cancelled` variant, appended **last** so the `#[repr(C)]` discriminants and the libchdr C ABI are unchanged (only an exhaustive `match` without a `_` arm needs updating).
- Feature flags: `write` (create/extract/copy/metadata/HdImage, also enables `verify`), `write-zstd` (+ zstd/cdzs), `verify` (`Chd::verify`, pulls only the small `sha1` crate).
- The sibling bit-exact codec crates are now crates.io version deps (all published), so a fresh checkout / external consumer resolves them automatically.

See the README **Migrating** + **Writing CHDs** sections, plus `docs/chdman-mapping.md`, `docs/libchdman-differences.md`, and `docs/libchdman-parity.md`.

## Deferred (documented, non-blocking)

- **Nero `.nrg`** input — a binary TOC with no fixture path to verify against (chdman can't *write* `.nrg`).
- **`copy` re-doing legacy CD metadata** (CHCD/CHTR → CHT2) for legacy-source CDs — modern sources already copy correctly.